### PR TITLE
Fixes XML parsing for titles with HTML

### DIFF
--- a/metapub/base.py
+++ b/metapub/base.py
@@ -1,4 +1,5 @@
 from lxml import etree
+from lxml.html.clean import Cleaner
 
 from .exceptions import MetaPubError, BaseXMLError
 
@@ -79,9 +80,16 @@ class MetaPubObject(object):
         '''Returns content of named XML element, or None if not found.'''
         elem = self.content.find(tag)
         if elem is not None:
+            if len(elem.getchildren()):
+                return self.__clean_html(elem)
             return elem.text
         return None
 
+    def __clean_html(self, elem):
+        '''Removes HTML elements like i, b, and a'''
+        cleaner = Cleaner(remove_tags = ['a', 'i', 'b', 'em'])
+        return cleaner.clean_html(etree.tostring(elem).decode("utf-8"))\
+            .replace("<div>", "").replace("</div>", "").strip() # This part seems hacky to me
 
 # singleton class used by the fetchers.
 class Borg(object):

--- a/tests/test_pubmed_fetcher.py
+++ b/tests/test_pubmed_fetcher.py
@@ -37,12 +37,18 @@ class TestPubmedFetcher(unittest.TestCase):
         article = fetch.article_by_pmid(pmid)
         assert str(article.pmid) == pmid
 
+    def test_article_by_pmid_with_html(self):
+        pmid = '30109010'
+        title = b'Discovery of a tetrazolyl \xce\xb2-carboline with in vitro and in vivo osteoprotective activity under estrogen-deficient conditions.'.decode('utf-8')
+        article = fetch.article_by_pmid(pmid)
+        assert str(article.pmid) == pmid
+        assert article.title == title
     # Doesn't work...
     #def test_article_by_pmid_with_bookID(self):
     #    bookID = 'NBK2040'
     #    fetch = PubMedFetcher()
     #    article = fetch.article_by_pmid(bookID)
-    #    assert article.pubmed_type == 'book'        
+    #    assert article.pubmed_type == 'book'
 
     def test_related_pmids(self):
         """ * pubmed    (all related links)

--- a/tests/test_pubmed_fetcher.py
+++ b/tests/test_pubmed_fetcher.py
@@ -1,6 +1,6 @@
 import unittest, os
 
-from metapub import PubMedFetcher 
+from metapub import PubMedFetcher
 from metapub.pubmedfetcher import parse_related_pmids_result
 from metapub.pubmedcentral import *
 
@@ -53,7 +53,8 @@ class TestPubmedFetcher(unittest.TestCase):
         """
 
         expected_keys = ['pubmed', 'citedin', 'five', 'reviews', 'combined']
-        xmlstr = open('tests/data/sample_related_pmids_result.xml').read()
+        with open('tests/data/sample_related_pmids_result.xml') as f:
+            xmlstr = f.read()
         resd = parse_related_pmids_result(xmlstr)
         for key in resd.keys():
             assert key in expected_keys


### PR DESCRIPTION
Addresses #16 and adds a test case.

Note that the solution at lines 90-92 in `base.py` isn't elegant, but can be modified. I chose to `remove_tags` common style or links tags that might be seen in HTML from article titles.