### PR TITLE
More robust medgen concept test

### DIFF
--- a/tests/test_medgen_fetcher.py
+++ b/tests/test_medgen_fetcher.py
@@ -32,24 +32,17 @@ class TestMedGenFetcher(unittest.TestCase):
         concept = fetch.concept_by_uid(324960)
         assert concept.OMIM[0] == '600376'
 
-        # names is a list of dictionaries. We can't predict what order they come in. 
-        # we'll just cherry-pick one we know well already.
+        # names is a list of dictionaries. We can't predict what order they come in or 
+        # even if the list of names will stay the same. 
         # 
         # the goal here is to use the tests to monitor when/how these
         # schemas change.
-        for name in concept.names:
-            if name['name'] == 'Hemorrhagic Telangiectasia, Hereditary':
-                name0 = name
+        
+        FIELDS = ['name', 'SDUI', 'CODE', 'SAB', 'TTY', 'PT', 'type']
 
-        assert name0['name'] == 'Hemorrhagic Telangiectasia, Hereditary'
-        assert name0['SDUI'] == 'D013683'
-        assert name0['SCUI'] == 'M0021123'
-        assert name0['CODE'] == 'D013693'
-        assert name0['SAB'] == 'MSH'
-        assert name0['TTY'] == 'PM'
-        assert name0['PT'] == None
-        assert name0['type'] == 'syn'
-        assert len(name0) == 8
+        name0 = concept.names[0]
+        for field in FIELDS:
+            assert field in name0.keys()
 
         # synonyms is constructed by Metapub from .names; it's a list of strings.
         assert len(concept.synonyms) > 1
@@ -57,12 +50,13 @@ class TestMedGenFetcher(unittest.TestCase):
             assert type(item) == str
 
         # title should always be a simple string.
-        assert concept.title == 'Hereditary hemorrhagic telangiectasia'
+        assert str(concept.title) == concept.title
 
         # Definitions is in the shape of the XML.  But usually there's only 1 definition. 
         assert len(concept.definitions) > 0
         assert type(concept.definition) == str
         
+        # semantic_id should be a short string like "T047".  semantic_type is like "Disease or Syndrome".
         assert concept.semantic_id == 'T047'
         assert concept.semantic_type == 'Disease or Syndrome'
 
@@ -74,6 +68,6 @@ class TestMedGenFetcher(unittest.TestCase):
         assert concept.chromosome == '' or concept.chromosome is None or concept.chromosome
 
         # Two properties, one actual memory location on the object.
-        assert concept.medgen_uid == '52657'
-        assert concept.uid == '52657'
+        assert concept.medgen_uid is not None
+        assert concept.uid is not None
 


### PR DESCRIPTION
The contents of the Medgen DB are too volatile for us to test against their content.  This test simplifies down to testing for the existence of expected fields.