### PR TITLE
Fixes abstract parsing with HTML

### DIFF
--- a/metapub/base.py
+++ b/metapub/base.py
@@ -81,11 +81,11 @@ class MetaPubObject(object):
         elem = self.content.find(tag)
         if elem is not None:
             if len(elem.getchildren()):
-                return self.__clean_html(elem)
+                return self._clean_html(elem)
             return elem.text
         return None
 
-    def __clean_html(self, elem):
+    def _clean_html(self, elem):
         '''Removes HTML elements like i, b, and a'''
         cleaner = Cleaner(remove_tags = ['a', 'i', 'b', 'em'])
         return cleaner.clean_html(etree.tostring(elem).decode("utf-8"))\

--- a/metapub/pubmedarticle.py
+++ b/metapub/pubmedarticle.py
@@ -290,7 +290,10 @@ class PubMedArticle(MetaPubObject):
             return self._get(self._root+'/Article/Abstract/AbstractText')
 
         if len(abstracts) == 1:
-            return abstracts[0].text
+            elem = abstracts[0]
+            if len(elem.getchildren()):
+                return self._clean_html(elem)
+            return elem.text
 
         # this is a type of PMA with several AbstractText listings (like a Book)
         abd = OrderedDict()


### PR DESCRIPTION
Addresses #22.

Had to move `MetaPubObject.__clean_html() -> `MetaPubObject._clean_html` to use if from then `PubMedArticle` subclass.

Result of `pmf.article_by_pmid(28661438)` goes from 
```The dramatic rise in the use of smartphones, tablets, and laptop computers over the past decade has raised concerns about potentially deleterious health effects of increased "screen time" (ST) and associated short-wavelength (blue) light exposure. We determined baseline associations and effects of 6 months\' supplementation with the macular carotenoids (MC) lutein, zeaxanthin, and mesozeaxanthin on the blue-absorbing macular pigment (MP) and measures of sleep quality, visual performance, and physical indicators of excessive ST. Forty-eight healthy young adults with at least 6 h of daily near-field ST exposure participated in this placebo-controlled trial. Visual performance measures included contrast sensitivity, critical flicker fusion, disability glare, and photostress recovery. Physical indicators of excessive screen time and sleep quality were assessed via questionnaire. MP optical density (MPOD) was assessed via heterochromatic flicker photometry. At baseline, MPOD was correlated significantly with all visual performance measures (```  

TO
 
```The dramatic rise in the use of smartphones, tablets, and laptop computers over the past decade has raised concerns about potentially deleterious health effects of increased "screen time" (ST) and associated short-wavelength (blue) light exposure. We determined baseline associations and effects of 6 months\' supplementation with the macular carotenoids (MC) lutein, zeaxanthin, and mesozeaxanthin on the blue-absorbing macular pigment (MP) and measures of sleep quality, visual performance, and physical indicators of excessive ST. Forty-eight healthy young adults with at least 6 h of daily near-field ST exposure participated in this placebo-controlled trial. Visual performance measures included contrast sensitivity, critical flicker fusion, disability glare, and photostress recovery. Physical indicators of excessive screen time and sleep quality were assessed via questionnaire. MP optical density (MPOD) was assessed via heterochromatic flicker photometry. At baseline, MPOD was correlated significantly with all visual performance measures (p &lt; 0.05 for all). MC supplementation (24 mg daily) yielded significant improvement in MPOD, overall sleep quality, headache frequency, eye strain, eye fatigue, and all visual performance measures, versus placebo (p &lt; 0.05 for all). Increased MPOD significantly improves visual performance and, in turn, improves several undesirable physical outcomes associated with excessive ST. The improvement in sleep quality was not directly related to increases in MPOD, and may be due to systemic reduction in oxidative stress and inflammation.```

*Could use a proper test case.*