### PR TITLE
Broken embargo handling

### DIFF
--- a/bin/embargo_data_checker.py
+++ b/bin/embargo_data_checker.py
@@ -1,0 +1,51 @@
+import requests
+from metapub import FindIt
+from metapub import PubMedFetcher
+from datetime import datetime
+import csv
+
+
+def fetch_pmids(year_from, year_to, count):
+    fetcher = PubMedFetcher()
+    pmids = []
+
+    for year in range(year_from, year_to + 1):
+        query = f'{year}[dp]'
+        result = fetcher.pmids_for_query(query, retmax=count)
+        pmids.extend(result)
+        if len(pmids) >= count:
+            break
+    return pmids
+
+
+# Example usage:
+pmids = fetch_pmids(2022, 2024, count=150)
+
+
+with open('embargo_check_results.csv', 'w', newline='') as csvfile:
+    fieldnames = ['PMID', 'is_embargoed', 'Findit_reason']
+    writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+    writer.writeheader()
+
+    for pmid in pmids:
+        print(f"{pmid}")
+
+        src = FindIt(pmid, use_nih=True)
+        print(f"Embargo date:", src.pma.history.get('pmc-release', None))
+
+        is_embargoed = False
+
+        if src.url:
+            findit_reason = src.url
+            is_embargoed = False
+        else:
+            findit_reason = src.reason
+            if findit_reason.startswith("PAYWALL") and "embargo" in src.reason:
+                is_embargoed = True
+
+        print(f"FindIt result for PMID {pmid}: {findit_reason}")
+
+        # Write to CSV
+        writer.writerow({'PMID': pmid, 'is_embargoed': is_embargoed, 'Findit_reason': findit_reason})
+        print("---------")
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='metapub',
-    version='0.5.7',
+    version='0.5.8',
     description='Pubmed / NCBI / eutils interaction library, handling the metadata of pubmed papers.',
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Fixes issue where papers were improperly labeled as "embargoed" in FindIt instead of checking the embargo date against current date.

Previously, NIH article data would remove the embargo date when the article was out of embargo.  So the logic in FindIt would simply check IF the article had an embargo date, and if so, it would mark it with something like the following message:

"PAYWALL: article in embargo until XXXX-XX-XX"

This fix checks against the date and serves the PMC file correctly if it exists.   

(If article is indeed still in embargo, the FindIt.reason will be the above "PAYWALL..." message.)