### PR TITLE
Fix: Improve MeSH heading parsing to capture all qualifiers

### DIFF
--- a/metapub/pubmedarticle.py
+++ b/metapub/pubmedarticle.py
@@ -432,15 +432,21 @@ class PubMedArticle(MetaPubObject):
         outd = {}
         for mesh in meshtags:
             descript = mesh.find('DescriptorName')  # should always be present
-            qual = mesh.find('QualifierName')       # may not be present
-
             dui = descript.get('UI')
+
+            qualifiers_list = []
+            for qual in mesh.findall('QualifierName'):
+                qualifiers_list.append({
+                    'qualifier_name': qual.text,
+                    'qualifier_ui': qual.get('UI'),
+                    'qualifier_major_topic': True if qual.get('MajorTopicYN') == 'Y' else False,
+                })
+
             outd[dui] = {
-                    'descriptor_name': descript.text,
-                    'major_topic': True if descript.get('MajorTopicYN') == 'Y' else False,
-                    'qualifier_name': None if qual is None else qual.text,
-                    'qualifier_ui': None if qual is None else qual.get('UI'),
-                }
+                'descriptor_name': descript.text,
+                'descriptor_major_topic': True if descript.get('MajorTopicYN') == 'Y' else False,
+                'qualifiers': qualifiers_list,
+            }
         return outd
 
     def _get_chemicals(self):


### PR DESCRIPTION
This commit addresses an issue where the MeSH heading parsing logic in `PubMedArticle._get_mesh_headings` was not capturing all `QualifierName` information when multiple qualifiers were present for a single `DescriptorName`. Additionally, the `MajorTopicYN` status for each qualifier was not being distinctly captured.

The `_get_mesh_headings` method has been updated to:
- Iterate through all `QualifierName` elements within each `MeshHeading`.
- Store each qualifier as a dictionary containing its `qualifier_name`, `qualifier_ui`, and `qualifier_major_topic` status.
- The `major_topic` attribute for the descriptor has been renamed to `descriptor_major_topic` for clarity.
- The `mesh` attribute now stores a list of these qualifier dictionaries under the `qualifiers` key for each descriptor.

A new test case (`test_mesh_heading_parsing_detailed`) has been added to `tests/test_pubmed_article.py` using PMID 34558640. This test verifies the corrected parsing logic and ensures that all qualifier details, including their `MajorTopicYN` status, are accurately represented in the `PubMedArticle.mesh` attribute.

All tests in `tests/test_pubmed_article.py` pass with these changes.