### PR TITLE
Scope coloredlogs to metapub logger, bump to 0.7.1

### DIFF
--- a/metapub/__init__.py
+++ b/metapub/__init__.py
@@ -13,5 +13,5 @@ from .findit import FindIt
 from .dx_doi import DxDOI
 from .urlreverse import UrlReverse
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 

--- a/metapub/config.py
+++ b/metapub/config.py
@@ -3,9 +3,8 @@ import coloredlogs
 import logging
 import tempfile
 
-coloredlogs.install()
-
 log = logging.getLogger('metapub.config')
+coloredlogs.install(logger=logging.getLogger('metapub'))
 
 PKGNAME = 'metapub'
 

--- a/metapub/convert.py
+++ b/metapub/convert.py
@@ -4,7 +4,6 @@ Defines command-line tools `convert pmid2doi` and `convert doi2pmid`.
 """
 
 import logging
-import coloredlogs
 from urllib.error import HTTPError
 
 from .pubmedfetcher import PubMedFetcher
@@ -18,8 +17,6 @@ except ImportError:
     docopt = None
 
 log = logging.getLogger('metapub.convert')
-
-coloredlogs.install()
 
 cr_fetch = None   #CrossRefFetcher()
 pm_fetch = None   #PubMedFetcher()

--- a/metapub/findit/findit.py
+++ b/metapub/findit/findit.py
@@ -2,7 +2,6 @@ __author__ = 'nthmost'
 
 import time
 import logging
-import coloredlogs
 
 import requests
 
@@ -20,8 +19,6 @@ from .logic import find_article_from_pma
 from .dances import the_sciencedirect_disco, the_doi_2step, the_wolterskluwer_volta
 
 log = logging.getLogger('metapub.findit')
-
-coloredlogs.install()
 
 """ findit/findit.py
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class PostDevelopCommand(develop):
 
 setup(
     name="metapub",
-    version="0.7.0",
+    version="0.7.1",
     description="Pubmed / NCBI / eutils interaction library, handling the metadata of pubmed papers.",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
## Summary
- Scoped `coloredlogs.install()` to the `metapub` logger instead of the root logger, so importing metapub no longer hijacks application-wide logging
- Removed redundant `coloredlogs.install()` calls from `convert.py` and `findit/findit.py`
- Bumped version to 0.7.1

Fixes #103

## Test plan
- [ ] `import metapub` should no longer alter root logger behavior
- [ ] metapub's own loggers still get colored output

🤖 Generated with [Claude Code](https://claude.com/claude-code)