### PR TITLE
Fix CrossRefWork crash when author field is None

### DIFF
--- a/metapub/crossref.py
+++ b/metapub/crossref.py
@@ -105,58 +105,87 @@ class CrossRefWork(object):
         if self.issued:
             return datetime.date(self.issued['date-parts'][0])
 
+    @staticmethod
+    def _format_author_first_last(auth):
+        """Format an author dict as 'Firstname Lastname', handling missing fields."""
+        given = auth.get('given', '')
+        family = auth.get('family', '')
+        name = auth.get('name', '')
+        if given and family:
+            return given + ' ' + family
+        if family:
+            return family
+        return name
+
+    @staticmethod
+    def _format_author_last_fm(auth):
+        """Format an author dict as 'Lastname F', handling missing fields."""
+        given = auth.get('given', '')
+        family = auth.get('family', '')
+        name = auth.get('name', '')
+        if family and given:
+            return family + ' ' + given[0].upper()
+        if family:
+            return family
+        return name
+
     @property
     def author1(self):
+        if not self.author:
+            return ''
         for auth in self.author:
-            if auth['sequence'] == 'first':
-                return auth['given'] + ' ' + auth['family']
+            if auth.get('sequence') == 'first':
+                return self._format_author_first_last(auth)
         return ''
 
     @property
     def author1_last_fm(self):
+        if not self.author:
+            return ''
         for auth in self.author:
-            if auth['sequence'] == 'first':
-                return auth['family'] + ' ' + auth['given'][0].upper()
+            if auth.get('sequence') == 'first':
+                return self._format_author_last_fm(auth)
         return ''
 
     @property
     def authors_str_lastfirst(self):
         """Returns this work's authors as a semicolon-separated string -- LASTNAME FIRSTInitial."""
+        if not self.author:
+            return ''
         out = self.author1_last_fm
-        # assume already sorted by crossref with first author first in the list.
         if len(self.author) > 1:
             for auth in self.author[1:]:
-                out += ';' + auth['family'] + ' ' + auth['given'][0].upper()
+                out += ';' + self._format_author_last_fm(auth)
         return out
 
     @property
     def author_list(self):
         """Returns this work's authors as a flat list (Firstname Lastname), retaining order given by Crossref."""
-        out = []
-        for auth in self.author:
-            out.append(auth['given'] + ' ' + auth['family'])
-        return out
+        if not self.author:
+            return []
+        return [self._format_author_first_last(auth) for auth in self.author]
 
     @property
     def author_list_last_fm(self):
         """Returns this work's authors as a flat list (Lastname FirstInitial), retaining order given by Crossref."""
-        out = []
-        for auth in self.author:
-            out.append(auth['family'] + ' ' + auth['given'][0].upper())
-        return out
+        if not self.author:
+            return []
+        return [self._format_author_last_fm(auth) for auth in self.author]
 
     def to_citation(self):
         """Describes this work as a dictionary suitable for citation lookups in PubMed."""
-        return {'journal': self.container_title[0],
+        author1 = self.author1
+        aulast = author1.split()[-1] if author1 else ''
+        return {'journal': self.container_title[0] if self.container_title else '',
                 'year': self.pubyear,
-                'title': self.title[0],
+                'title': self.title[0] if self.title else '',
                 'authors': self.author_list_last_fm,
                 'doi': self.doi,
                 'volume': self.volume,
                 'issue': self.issue,
                 'pages': self.page,
                 'first_page': self.first_page,
-                'aulast': self.author1.split()[-1:][0],    #just the last name of first author.
+                'aulast': aulast,
                 }
 
     def to_dict(self):

--- a/tests/test_crossref_work.py
+++ b/tests/test_crossref_work.py
@@ -1,0 +1,103 @@
+import unittest
+
+from metapub.crossref import CrossRefWork
+
+
+class TestCrossRefWorkNoneAuthor(unittest.TestCase):
+    """Test that CrossRefWork handles None/missing author data gracefully."""
+
+    def setUp(self):
+        self.work = CrossRefWork(
+            DOI='10.1234/test',
+            title=['Test Title'],
+            author=None,
+            container_title=['Test Journal'],
+            issued={'date-parts': [[2024]]},
+        )
+
+    def test_author_list_returns_empty_list(self):
+        self.assertEqual(self.work.author_list, [])
+
+    def test_author_list_last_fm_returns_empty_list(self):
+        self.assertEqual(self.work.author_list_last_fm, [])
+
+    def test_author1_returns_empty_string(self):
+        self.assertEqual(self.work.author1, '')
+
+    def test_author1_last_fm_returns_empty_string(self):
+        self.assertEqual(self.work.author1_last_fm, '')
+
+    def test_authors_str_lastfirst_returns_empty_string(self):
+        self.assertEqual(self.work.authors_str_lastfirst, '')
+
+    def test_to_citation_returns_dict(self):
+        cit = self.work.to_citation()
+        self.assertIsInstance(cit, dict)
+        self.assertEqual(cit['aulast'], '')
+        self.assertEqual(cit['authors'], [])
+
+    def test_citation_property(self):
+        # Should not crash
+        result = self.work.citation
+        self.assertIsInstance(result, str)
+
+
+class TestCrossRefWorkIncompleteAuthor(unittest.TestCase):
+    """Test that CrossRefWork handles author dicts missing 'given' key."""
+
+    def setUp(self):
+        self.work = CrossRefWork(
+            DOI='10.1234/test2',
+            title=['Test Title 2'],
+            author=[
+                {'sequence': 'first', 'family': 'Smith'},
+                {'sequence': 'additional', 'name': 'Some Consortium'},
+            ],
+            container_title=['Test Journal'],
+            issued={'date-parts': [[2024]]},
+        )
+
+    def test_author_list(self):
+        self.assertEqual(self.work.author_list, ['Smith', 'Some Consortium'])
+
+    def test_author_list_last_fm(self):
+        self.assertEqual(self.work.author_list_last_fm, ['Smith', 'Some Consortium'])
+
+    def test_author1(self):
+        self.assertEqual(self.work.author1, 'Smith')
+
+    def test_author1_last_fm(self):
+        self.assertEqual(self.work.author1_last_fm, 'Smith')
+
+    def test_authors_str_lastfirst(self):
+        self.assertEqual(self.work.authors_str_lastfirst, 'Smith;Some Consortium')
+
+
+class TestCrossRefWorkNormalAuthor(unittest.TestCase):
+    """Verify normal author data still works correctly."""
+
+    def setUp(self):
+        self.work = CrossRefWork(
+            DOI='10.1234/test3',
+            title=['Test Title 3'],
+            author=[
+                {'sequence': 'first', 'given': 'John', 'family': 'Doe'},
+                {'sequence': 'additional', 'given': 'Jane', 'family': 'Smith'},
+            ],
+            container_title=['Test Journal'],
+            issued={'date-parts': [[2024]]},
+        )
+
+    def test_author_list(self):
+        self.assertEqual(self.work.author_list, ['John Doe', 'Jane Smith'])
+
+    def test_author_list_last_fm(self):
+        self.assertEqual(self.work.author_list_last_fm, ['Doe J', 'Smith J'])
+
+    def test_author1(self):
+        self.assertEqual(self.work.author1, 'John Doe')
+
+    def test_to_citation(self):
+        cit = self.work.to_citation()
+        self.assertEqual(cit['aulast'], 'Doe')
+        self.assertEqual(cit['authors'], ['Doe J', 'Smith J'])


### PR DESCRIPTION
## Summary
- Handle `None` author data in all CrossRefWork author properties (`author_list`, `author_list_last_fm`, `author1`, `author1_last_fm`, `authors_str_lastfirst`, `to_citation`)
- Handle incomplete author dicts missing `'given'` key (e.g. consortia with only `'name'`)
- Also guard against `None` in `container_title` and `title` in `to_citation()`

Fixes #104

## Test plan
- [x] 16 new unit tests covering None author, incomplete author dicts, and normal author data
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)