### PR TITLE
Add 30s timeout to requests missing timeouts

### DIFF
--- a/metapub/pubmedcentral.py
+++ b/metapub/pubmedcentral.py
@@ -28,7 +28,7 @@ __doc__="""An assortment of functions providing access to various web APIs.
 
 def _pmc_id_conversion_api(input_id):
     try:
-        xml = requests.get(PMC_ID_CONVERSION_URI % input_id).content
+        xml = requests.get(PMC_ID_CONVERSION_URI % input_id, timeout=30).content
         root = etree.fromstring(xml)
     except Exception as e:
         # Handle PMC ID conversion API errors

--- a/metapub/pubmedfetcher.py
+++ b/metapub/pubmedfetcher.py
@@ -488,7 +488,7 @@ class PubMedFetcher(Borg):
         req = base_uri.format(**inp_dict)
         log.debug('pmids_for_citation: querying with %s', req)
 
-        content = requests.get(req).text
+        content = requests.get(req, timeout=30).text
         pmids = []
         for item in content.split('\n'):
             if item.strip():


### PR DESCRIPTION
## Summary
- Add `timeout=30` to `requests.get()` in `pmids_for_citation()` (pubmedfetcher.py)
- Add `timeout=30` to `requests.get()` in PMC ID conversion API (pubmedcentral.py)
- These were the only two places in the codebase making HTTP requests without timeouts, which could hang indefinitely when NCBI is unresponsive

The main `NCBIClient` already had a 30-second timeout — this brings the remaining call sites in line.

Fixes #95

## Test plan
- [x] Verified these are the only `requests.get()` calls without timeouts in the codebase
- [ ] Manual test with large batch processing to confirm no hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)