### PR TITLE
Release 0.7.3

### DIFF
--- a/metapub/__init__.py
+++ b/metapub/__init__.py
@@ -13,5 +13,5 @@ from .findit import FindIt
 from .dx_doi import DxDOI
 from .urlreverse import UrlReverse
 
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class PostDevelopCommand(develop):
 
 setup(
     name="metapub",
-    version="0.7.2",
+    version="0.7.3",
     description="Pubmed / NCBI / eutils interaction library, handling the metadata of pubmed papers.",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
## Summary

- Fix `DxDOI._query_api` silently returning `None` for HTTP 202 responses (broke Brill DOI resolution)
- Fix `the_brill_bridge` rejecting HTTP 202 as a valid article page status
- Fix `the_scielo_chula` to handle SciELO's new URL format: construct PDF URL from redirect destination (`/j/{journal}/a/{hash}/?lang=en&format=pdf`) when HTML no longer contains `citation_pdf_url` meta tags or `format=pdf` links
- Fix `test_pmc.py` using `verify=False, cachedir=None` to avoid stale EuropePMC cache
- Fix wrong mock targets in `test_scielo.py` and `test_projectmuse.py` (`requests.get` → `unified_uri_get`)
- Document findit test philosophy in `CLAUDE.md`: failing dance tests signal broken publisher formats, not test bugs to paper over

## Related issues

Open bugs filed for remaining failures: #114 (Brill XML), #115 (DovePress HTML), #116 (ProjectMuse bot protection)

## Test plan

- [x] `pytest tests/findit/test_scielo.py` — all pass
- [x] `pytest tests/findit/test_pmc.py` — passes
- [x] `pytest tests/findit/test_projectmuse.py` — legitimate failures remain (bot protection, tracked in #116)
- [x] Manual verification: DxDOI resolves Brill 202 DOIs correctly
- [x] Manual verification: SciELO returns `format=pdf` URLs for PMID 23657305 and 32294727

🤖 Generated with [Claude Code](https://claude.com/claude-code)