### PR TITLE
Fix #115: add brotli dependency to decompress DovePress responses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         "lxml",
         "lxml_html_clean",
         "requests",
+        "brotli",
         "habanero",
         "tabulate",
         "cssselect",


### PR DESCRIPTION
## Root cause

DovePress (via Cloudflare) switched to Brotli content encoding (`Content-Encoding: br`). The `requests` library doesn't decompress Brotli without the `brotli` package installed — it silently returns the raw compressed bytes. The HTML parser was therefore seeing garbled binary, finding no PDF links, and raising `NoPDFLink`.

## Fix

Add `brotli` to `install_requires` in `setup.py`. Once installed, `requests` automatically decompresses Brotli responses and `the_dovepress_peacock` works without any code changes.

## Verification

All 5 previously-failing DovePress tests now pass, including the XML fixture tests which correctly find the expected `article/download/{id}` URLs.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)