### PR TITLE
Release 0.7.4

### DIFF
--- a/metapub/__init__.py
+++ b/metapub/__init__.py
@@ -13,5 +13,5 @@ from .findit import FindIt
 from .dx_doi import DxDOI
 from .urlreverse import UrlReverse
 
-__version__ = '0.7.3'
+__version__ = '0.7.4'
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class PostDevelopCommand(develop):
 
 setup(
     name="metapub",
-    version="0.7.3",
+    version="0.7.4",
     description="Pubmed / NCBI / eutils interaction library, handling the metadata of pubmed papers.",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
## Changes since 0.7.3

- **DovePress** (#115): Added `brotli` dependency — DovePress/Cloudflare switched to Brotli encoding, causing garbled HTML and broken PDF link detection
- **Brill** (#114): Derive PDF URL directly from DOI-resolved article URL (`/view/journals/` → `/downloadpdf/journals/`), bypassing AWS WAF bot protection; `verify=False` now returns a usable URL
- **ProjectMuse** (#116): Extract article ID from muse.jhu.edu `/verify` redirect and construct PDF URL directly, bypassing human-verification bot protection; `verify=False` now returns a usable URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)