### PR TITLE
Add local PostgreSQL backend for PubMed article lookups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides coding guidelines for Claude when working on the metapub proj
 1. **Never use Opus** - Always use Sonnet or Haiku models for this project.
 
 ## Import Guidelines
-2. **Avoid in-function imports** - Place imports at the module level unless ABSOLUTELY necessary to avoid circular import problems. In-function imports should be a last resort and well-documented when used.
+2. **All imports at module level** - Every import belongs at the top of the file. No `import` statements inside functions, methods, or closures. The only exception is a genuine circular import that cannot be resolved by restructuring — in that case, document why with a comment at the import site. Standard library modules (`os`, `re`, `logging`, etc.) have no circular-import risk and must always be at module level.
 
 ## Exception Handling
 3. **Avoid huge try-except blocks** - Keep exception handling focused and specific to the operations that might fail.

--- a/metapub/citation_resolver.py
+++ b/metapub/citation_resolver.py
@@ -1,0 +1,333 @@
+"""
+citation_resolver — resolve messy citation text to PubMed IDs.
+
+Takes freeform citation strings like "Bienvenu et al 1993" or
+"Cukier HN et al. (2016)" and resolves them to PMIDs by searching
+the local pubmed.article table first, then CrossRef as a backup.
+
+Designed for bulk resolution of LOVD-style citation text, which is
+notoriously messy: mixed formats, tooltip HTML fragments, multiple
+citations per field, full author lists, missing years, etc.
+
+Usage::
+
+    from metapub.citation_resolver import CitationResolver
+
+    resolver = CitationResolver(db_url="postgresql://medgen:medgen@loki.local/medgen")
+
+    # Single citation
+    pmid = resolver.resolve("Bienvenu et al 1993", gene="CFTR")
+    # → 7691353
+
+    # Batch
+    results = resolver.resolve_batch([
+        {"text": "Cukier HN et al. (2016)", "gene": "ABCA7"},
+        {"text": "Abou-Sleiman PM, 2003", "gene": "PINK1"},
+    ])
+    # → [{"text": ..., "pmid": 12345, "method": "local_db", "confidence": 0.95}, ...]
+"""
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+
+def parse_citation_text(raw: str) -> list[dict]:
+    """
+    Parse messy LOVD citation text into structured citation(s).
+
+    Handles:
+      - "Author et al. (YEAR)" → {"author": "Author", "year": 2016}
+      - "Author1, YEAR;Author2, YEAR" → multiple citations
+      - "Author1 A1, Author2 B2, ... (YEAR)" → first author + year
+      - Strips LOVD tooltip HTML fragments
+
+    Returns a list of {"author": str, "year": int|None} dicts.
+    """
+    if not raw or raw.strip() in ("-", ""):
+        return []
+
+    # Strip LOVD tooltip HTML fragments
+    # Pattern: "Author et al 1993 ', this);">Author et al 1993"
+    # Keep only the first occurrence (before the tooltip repeat)
+    text = re.split(r"',\s*this\);", raw)[0].strip()
+    text = re.sub(r"<[^>]+>", " ", text)       # remove any HTML tags
+    text = re.sub(r"\\+'", "", text)            # remove escaped quotes
+    text = text.strip().strip("'\"").strip()
+
+    if not text or text in ("-", ""):
+        return []
+
+    # Split multiple citations separated by semicolons
+    # "Abou-Sleiman PM, 2003;Lockhart PJ, 2004" → two citations
+    parts = re.split(r"\s*;\s*", text)
+
+    results = []
+    for part in parts:
+        part = part.strip()
+        if not part or part in ("-", "dbSNP", "ClinVar", "link"):
+            continue
+
+        citation = _parse_single_citation(part)
+        if citation:
+            results.append(citation)
+
+    return results
+
+
+# Patterns for extracting author + year from a single citation string
+_RE_AUTHOR_ET_AL_YEAR = re.compile(
+    r"^([A-Z][A-Za-zÀ-ÿ\-'\s]+?)\s+(?:et|at)\s+al\.?\s*\(?(\d{4})\)?",
+    re.IGNORECASE,
+)
+_RE_AUTHOR_COMMA_YEAR = re.compile(
+    r"^([A-Z][A-Za-zÀ-ÿ\-']+(?:\s+[A-Z]{1,2})?)\s*,\s*(\d{4})",
+)
+_RE_FULL_AUTHORS_YEAR = re.compile(
+    r"^([A-Z][A-Za-zÀ-ÿ\-']+)\s+\w{1,3}[\d]?\s*,.*?\(?(\d{4})\)?$",
+)
+_RE_YEAR_ONLY = re.compile(r"\((\d{4})\)$")
+_RE_BARE_PMID = re.compile(r"^(\d{7,8})\s")
+
+
+def _parse_single_citation(text: str) -> dict | None:
+    """Parse a single citation string into {"author": str, "year": int|None}."""
+
+    # "26176978 et al. (2015)" — starts with a PMID-like number (garbage)
+    m = _RE_BARE_PMID.match(text)
+    if m:
+        return None
+
+    # "Author et al. (YEAR)" or "Author et al YEAR"
+    m = _RE_AUTHOR_ET_AL_YEAR.match(text)
+    if m:
+        author = m.group(1).strip().rstrip(",")
+        # Take the last substantial word as surname
+        # "Polin Haghvirdizadeh et al" → "Haghvirdizadeh"
+        # "Cukier HN et al" → "Cukier" (HN is initials)
+        words = author.split()
+        surname = words[0]  # default to first word
+        for w in reversed(words):
+            if len(w) > 2 and not re.match(r"^[A-Z]{1,3}\d?$", w):
+                surname = w
+                break
+        return {"author": surname, "year": int(m.group(2))}
+
+    # "Author, YEAR" (simple format)
+    m = _RE_AUTHOR_COMMA_YEAR.match(text)
+    if m:
+        author = m.group(1).strip()
+        author = author.split()[0] if " " in author else author
+        return {"author": author, "year": int(m.group(2))}
+
+    # "Firstname Lastname, Firstname Lastname, ... (YEAR)" (full author list)
+    m = _RE_FULL_AUTHORS_YEAR.match(text)
+    if m:
+        author = m.group(1).strip()
+        return {"author": author, "year": int(m.group(2))}
+
+    # Last resort: find any 4-digit year and grab the first substantial word
+    m = _RE_YEAR_ONLY.search(text)
+    if not m:
+        # Also try year without parens at end
+        m = re.search(r"\b(\d{4})\s*$", text)
+    if m:
+        year = int(m.group(1))
+        surname = _extract_surname(text)
+        if surname:
+            return {"author": surname, "year": year}
+
+    # No year found — try to get at least an author
+    surname = _extract_surname(text)
+    if surname:
+        return {"author": surname, "year": None}
+
+    return None
+
+
+def _extract_surname(text: str) -> str | None:
+    """Extract the most likely surname from the beginning of a citation string.
+
+    Skips single-letter initials ("A Del Grande" → "Del Grande" → "Grande").
+    Takes the first word longer than 2 chars that isn't all-caps initials.
+    """
+    words = re.findall(r"[A-ZÀ-ÿ][A-Za-zÀ-ÿ\-']+", text)
+    for w in words:
+        # Skip initials (A, AB, JC1) and very short words
+        if len(w) <= 2 or re.match(r"^[A-Z]{1,3}\d?$", w):
+            continue
+        return w
+    return None
+
+
+class CitationResolver:
+    """
+    Resolve citation text to PMIDs using local DB + CrossRef.
+
+    Resolution order:
+      1. Local pubmed.article (author + year + optional gene)
+      2. CrossRef bibliographic search (if local misses)
+    """
+
+    def __init__(self, db_url: str = None):
+        self._db_url = db_url
+        self._conn = None
+
+    def _get_conn(self):
+        if self._conn is not None and not self._conn.closed:
+            return self._conn
+        if not self._db_url:
+            return None
+        try:
+            import psycopg2
+            self._conn = psycopg2.connect(self._db_url)
+            self._conn.set_session(readonly=True, autocommit=True)
+            return self._conn
+        except Exception as e:
+            log.warning("CitationResolver: DB connect failed: %s", e)
+            return None
+
+    def resolve(self, text: str, gene: str = None) -> dict | None:
+        """
+        Resolve a single citation string to a PMID.
+
+        Returns {"pmid": int, "method": str, "confidence": float} or None.
+        """
+        citations = parse_citation_text(text)
+        if not citations:
+            return None
+
+        # Try each parsed citation
+        for cite in citations:
+            result = self._resolve_one(cite, gene)
+            if result:
+                return result
+
+        return None
+
+    def _resolve_one(self, cite: dict, gene: str = None) -> dict | None:
+        """Try to resolve a single parsed citation."""
+        author = cite.get("author")
+        year = cite.get("year")
+
+        if not author:
+            return None
+
+        # Try local DB first
+        result = self._search_local(author, year, gene)
+        if result:
+            return result
+
+        # Try CrossRef
+        result = self._search_crossref(author, year, gene)
+        if result:
+            return result
+
+        return None
+
+    def _search_local(self, author: str, year: int = None,
+                      gene: str = None) -> dict | None:
+        """Search pubmed.article by author + year, optionally filtered by gene in title/abstract."""
+        conn = self._get_conn()
+        if conn is None:
+            return None
+
+        # Build query — use first_author column for speed, fall back to authors
+        conditions = ["first_author ILIKE %s"]
+        params = [f"{author}%"]
+
+        if year:
+            conditions.append("year = %s")
+            params.append(year)
+
+        # If we have a gene name, require it in title or abstract
+        if gene:
+            conditions.append("(title ILIKE %s OR abstract ILIKE %s)")
+            params.extend([f"%{gene}%", f"%{gene}%"])
+
+        sql = f"""
+            SELECT pmid, title, first_author, year
+            FROM pubmed.article
+            WHERE {' AND '.join(conditions)}
+            ORDER BY year DESC
+            LIMIT 10
+        """
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+        except Exception as e:
+            log.warning("CitationResolver local search error: %s", e)
+            self._conn = None
+            return None
+
+        if not rows:
+            # Try without gene filter
+            if gene:
+                return self._search_local(author, year, gene=None)
+            return None
+
+        if len(rows) == 1:
+            pmid, title, first_author, yr = rows[0]
+            return {"pmid": int(pmid), "method": "local_db", "confidence": 0.95,
+                    "title": title, "matched_author": first_author}
+
+        # Multiple results — if we had a gene filter and got exactly one, that's high confidence
+        # Otherwise, return the first with lower confidence
+        pmid, title, first_author, yr = rows[0]
+        confidence = 0.7 if len(rows) <= 3 else 0.5
+        return {"pmid": int(pmid), "method": "local_db", "confidence": confidence,
+                "title": title, "matched_author": first_author,
+                "note": f"{len(rows)} candidates"}
+
+    def _search_crossref(self, author: str, year: int = None,
+                         gene: str = None) -> dict | None:
+        """Search CrossRef by author + year, resolve to PMID."""
+        try:
+            from .crossref import CrossRefFetcher
+            from .pubmedfetcher import PubMedFetcher
+        except ImportError:
+            return None
+
+        query = f"{author} {year}" if year else author
+        if gene:
+            query = f"{query} {gene}"
+
+        try:
+            cr = CrossRefFetcher()
+            work = cr.article_by_title(query)
+            if work and work.doi:
+                # Resolve DOI → PMID
+                try:
+                    fetch = PubMedFetcher()
+                    pma = fetch.article_by_doi(work.doi)
+                    if pma and pma.pmid:
+                        return {"pmid": int(pma.pmid), "method": "crossref",
+                                "confidence": 0.8, "doi": work.doi,
+                                "title": work.title[0] if work.title else None}
+                except Exception:
+                    pass
+        except Exception as e:
+            log.debug("CrossRef search failed for '%s': %s", query, e)
+
+        return None
+
+    def resolve_batch(self, items: list[dict]) -> list[dict]:
+        """
+        Resolve a batch of citations.
+
+        Each item should have {"text": str, "gene": str (optional)}.
+        Returns list with added "pmid", "method", "confidence" fields.
+        """
+        results = []
+        for item in items:
+            text = item.get("text", "")
+            gene = item.get("gene")
+            result = self.resolve(text, gene=gene)
+            out = dict(item)
+            if result:
+                out.update(result)
+            results.append(out)
+        return results

--- a/metapub/citation_resolver.py
+++ b/metapub/citation_resolver.py
@@ -206,23 +206,42 @@ class CitationResolver:
 
         return None
 
-    def _resolve_one(self, cite: dict, gene: str = None) -> dict | None:
-        """Try to resolve a single parsed citation."""
+    def _resolve_one(self, cite: dict, gene: str = None,
+                     use_crossref: bool = False) -> dict | None:
+        """Try to resolve a single parsed citation.
+
+        If use_crossref is True, queries CrossRef in addition to local DB.
+        When both find a result, agreement boosts confidence; disagreement
+        flags ambiguity.
+        """
         author = cite.get("author")
         year = cite.get("year")
 
         if not author:
             return None
 
-        # Try local DB first
-        result = self._search_local(author, year, gene)
-        if result:
-            return result
+        local = self._search_local(author, year, gene)
 
-        # Try CrossRef
-        result = self._search_crossref(author, year, gene)
-        if result:
-            return result
+        if not use_crossref:
+            return local
+
+        cr = self._search_crossref(author, year, gene)
+
+        if local and cr:
+            if local["pmid"] == cr["pmid"]:
+                # Both agree — high confidence
+                local["confidence"] = min(local["confidence"] + 0.1, 1.0)
+                local["method"] = "local_db+crossref"
+                local["crossref_doi"] = cr.get("doi")
+                return local
+            else:
+                # Disagreement — trust local but note it
+                local["note"] = f"CrossRef disagrees (PMID {cr['pmid']})"
+                return local
+        elif local:
+            return local
+        elif cr:
+            return cr
 
         return None
 
@@ -233,9 +252,9 @@ class CitationResolver:
         if conn is None:
             return None
 
-        # Build query — use first_author column for speed, fall back to authors
-        conditions = ["first_author ILIKE %s"]
-        params = [f"{author}%"]
+        # Build query — use lower(first_author) with text_pattern_ops index
+        conditions = ["lower(first_author) LIKE %s"]
+        params = [f"{author.lower()}%"]
 
         if year:
             conditions.append("year = %s")

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -46,6 +46,22 @@ try:
 except ImportError:
     HAS_PSYCOPG2 = False
 
+def _ensure_article_set_wrapper(xml: str) -> str:
+    """Wrap bare <PubmedArticle> XML in <PubmedArticleSet> if the wrapper is missing.
+
+    PubMedArticle.parse_xml searches for a 'PubmedArticle' child of the root
+    element.  If the DB stores bare <PubmedArticle> XML (no <PubmedArticleSet>
+    parent), that search returns None and every attribute ends up None.
+    eutils always returns the full set wrapper, so this only matters for
+    pre-existing DB rows written by other tools (e.g. medgen-stacks).
+    """
+    if isinstance(xml, bytes):
+        xml = xml.decode('utf-8')
+    if '<PubmedArticleSet>' not in xml and '<PubmedArticle>' in xml:
+        return f'<PubmedArticleSet>{xml}</PubmedArticleSet>'
+    return xml
+
+
 _SELECT_ONE  = "SELECT xml FROM pubmed.article WHERE pmid = %s"
 _SELECT_MANY = "SELECT pmid, xml FROM pubmed.article WHERE pmid = ANY(%s)"
 _UPSERT_XML  = """
@@ -155,7 +171,7 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
         if xml:
             log.debug("localfetcher: hit for PMID %s", pmid)
             try:
-                return PubMedArticle(xml)
+                return PubMedArticle(_ensure_article_set_wrapper(xml))
             except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
@@ -180,7 +196,7 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
             xml = local_xml.get(int(pmid))
             if xml:
                 try:
-                    results[pmid] = PubMedArticle(xml)
+                    results[pmid] = PubMedArticle(_ensure_article_set_wrapper(xml))
                     continue
                 except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                     log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -1,0 +1,153 @@
+"""
+metapub.localfetcher — PostgreSQL-backed PubMed article fetcher.
+
+Looks up articles from a local medgen-stacks `pubmed.article` table first,
+falling back to NCBI eutils for any PMID not found locally.  Returns the
+same `PubMedArticle` objects as the standard fetcher — fully transparent to
+callers.
+
+The local table stores raw NLM XML (identical to efetch output), so
+PubMedArticle is instantiated exactly as it is in the normal path.
+
+Usage::
+
+    from metapub import PubMedFetcher
+
+    # Local-first with NCBI fallback
+    fetch = PubMedFetcher(db_url="postgresql://medgen:medgen@loki.local/medgen")
+    article = fetch.article_by_pmid("27022295")
+
+    # Bulk lookup (new — not available in eutils-only mode)
+    articles = fetch.articles_by_pmids(["27022295", "18319072", "32404922"])
+    # returns {pmid_str: PubMedArticle, ...}
+
+Configuration via environment variables (read automatically)::
+
+    METAPUB_DB_URL   postgresql://user:pass@host/dbname
+
+Requires psycopg2::
+
+    pip install psycopg2-binary
+"""
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    HAS_PSYCOPG2 = True
+except ImportError:
+    HAS_PSYCOPG2 = False
+
+_SELECT_ONE  = "SELECT xml FROM pubmed.article WHERE pmid = %s"
+_SELECT_MANY = "SELECT pmid, xml FROM pubmed.article WHERE pmid = ANY(%s)"
+
+
+class LocalPubMedBackend:
+    """PostgreSQL connection to the medgen-stacks pubmed schema."""
+
+    def __init__(self, db_url: str):
+        if not HAS_PSYCOPG2:
+            raise ImportError(
+                "psycopg2 is required for the local backend. "
+                "Install it with: pip install psycopg2-binary"
+            )
+        self._db_url = db_url
+        self._conn = None
+
+    def _connection(self):
+        """Return an open connection, reconnecting if needed."""
+        if self._conn is None or self._conn.closed:
+            self._conn = psycopg2.connect(self._db_url)
+            self._conn.set_session(readonly=True, autocommit=True)
+        return self._conn
+
+    def fetch_xml(self, pmid: int | str) -> str | None:
+        """Return raw NLM XML for a single PMID, or None if not in the local DB."""
+        try:
+            with self._connection().cursor() as cur:
+                cur.execute(_SELECT_ONE, (int(pmid),))
+                row = cur.fetchone()
+                return row[0] if row else None
+        except Exception as e:
+            log.warning("localfetcher: DB error for PMID %s: %s", pmid, e)
+            self._conn = None   # force reconnect next time
+            return None
+
+    def fetch_xml_many(self, pmids: list[int | str]) -> dict[int, str]:
+        """
+        Return {pmid: xml} for all PMIDs found in the local DB.
+        Missing PMIDs are simply absent from the returned dict.
+        """
+        int_pmids = [int(p) for p in pmids]
+        if not int_pmids:
+            return {}
+        try:
+            with self._connection().cursor() as cur:
+                cur.execute(_SELECT_MANY, (int_pmids,))
+                return {row[0]: row[1] for row in cur.fetchall()}
+        except Exception as e:
+            log.warning("localfetcher: DB error for batch of %d PMIDs: %s", len(pmids), e)
+            self._conn = None
+            return {}
+
+
+def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher):
+    """
+    Return (article_by_pmid, articles_by_pmids) methods that use the local
+    backend first and fall back to eutils for misses.
+
+    `eutils_fetcher` is a bound method: the existing PubMedFetcher instance's
+    `_eutils_article_by_pmid`.
+    """
+    from .pubmedarticle import PubMedArticle
+
+    def article_by_pmid(pmid):
+        xml = backend.fetch_xml(pmid)
+        if xml:
+            log.debug("localfetcher: hit for PMID %s", pmid)
+            try:
+                return PubMedArticle(xml)
+            except Exception as e:
+                log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
+        log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
+        return eutils_fetcher(pmid)
+
+    def articles_by_pmids(pmids: list) -> dict:
+        """
+        Bulk fetch articles for a list of PMIDs.
+        Returns {str(pmid): PubMedArticle} for all PMIDs that resolve.
+        PMIDs not found in the local DB are fetched from NCBI individually.
+        """
+        pmids = [str(p) for p in pmids]
+        local_xml = backend.fetch_xml_many(pmids)
+
+        results: dict[str, PubMedArticle] = {}
+        ncbi_needed = []
+
+        for pmid in pmids:
+            xml = local_xml.get(int(pmid))
+            if xml:
+                try:
+                    results[pmid] = PubMedArticle(xml)
+                    continue
+                except Exception as e:
+                    log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)
+            ncbi_needed.append(pmid)
+
+        if ncbi_needed:
+            log.debug("localfetcher: fetching %d PMIDs from NCBI", len(ncbi_needed))
+            for pmid in ncbi_needed:
+                try:
+                    art = eutils_fetcher(pmid)
+                    if art:
+                        results[pmid] = art
+                except Exception as e:
+                    log.warning("localfetcher: NCBI error for PMID %s: %s", pmid, e)
+
+        return results
+
+    return article_by_pmid, articles_by_pmids

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -44,6 +44,11 @@ except ImportError:
 
 _SELECT_ONE  = "SELECT xml FROM pubmed.article WHERE pmid = %s"
 _SELECT_MANY = "SELECT pmid, xml FROM pubmed.article WHERE pmid = ANY(%s)"
+_UPSERT_XML  = """
+INSERT INTO pubmed.article (pmid, xml)
+VALUES (%s, %s)
+ON CONFLICT (pmid) DO UPDATE SET xml = EXCLUDED.xml, updated_at = NOW()
+"""
 
 
 class LocalPubMedBackend:
@@ -56,14 +61,22 @@ class LocalPubMedBackend:
                 "Install it with: pip install psycopg2-binary"
             )
         self._db_url = db_url
-        self._conn = None
+        self._ro_conn = None   # read-only connection (reads)
+        self._rw_conn = None   # read-write connection (write-through stores)
 
     def _connection(self):
-        """Return an open connection, reconnecting if needed."""
-        if self._conn is None or self._conn.closed:
-            self._conn = psycopg2.connect(self._db_url)
-            self._conn.set_session(readonly=True, autocommit=True)
-        return self._conn
+        """Return a read-only connection, reconnecting if needed."""
+        if self._ro_conn is None or self._ro_conn.closed:
+            self._ro_conn = psycopg2.connect(self._db_url)
+            self._ro_conn.set_session(readonly=True, autocommit=True)
+        return self._ro_conn
+
+    def _rw_connection(self):
+        """Return a read-write connection for write-through stores."""
+        if self._rw_conn is None or self._rw_conn.closed:
+            self._rw_conn = psycopg2.connect(self._db_url)
+            self._rw_conn.autocommit = True
+        return self._rw_conn
 
     def fetch_xml(self, pmid: int | str) -> str | None:
         """Return raw NLM XML for a single PMID, or None if not in the local DB."""
@@ -74,7 +87,7 @@ class LocalPubMedBackend:
                 return row[0] if row else None
         except Exception as e:
             log.warning("localfetcher: DB error for PMID %s: %s", pmid, e)
-            self._conn = None   # force reconnect next time
+            self._ro_conn = None   # force reconnect next time
             return None
 
     def fetch_xml_many(self, pmids: list[int | str]) -> dict[int, str]:
@@ -91,17 +104,35 @@ class LocalPubMedBackend:
                 return {row[0]: row[1] for row in cur.fetchall()}
         except Exception as e:
             log.warning("localfetcher: DB error for batch of %d PMIDs: %s", len(pmids), e)
-            self._conn = None
+            self._ro_conn = None
             return {}
 
+    def store_xml(self, pmid: int | str, xml: str) -> None:
+        """
+        Write-through: persist NLM XML for a PMID fetched from NCBI.
+        Structured columns (title, authors, etc.) are left NULL; only the
+        raw XML needed by metapub is stored. Silently ignored on error.
+        """
+        try:
+            with self._rw_connection().cursor() as cur:
+                cur.execute(_UPSERT_XML, (int(pmid), xml))
+            log.debug("localfetcher: stored PMID %s in local DB", pmid)
+        except Exception as e:
+            log.warning("localfetcher: write-through store failed for PMID %s: %s", pmid, e)
+            self._rw_conn = None
 
-def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher):
+
+def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
+                               write_through: bool = True):
     """
     Return (article_by_pmid, articles_by_pmids) methods that use the local
     backend first and fall back to eutils for misses.
 
     `eutils_fetcher` is a bound method: the existing PubMedFetcher instance's
     `_eutils_article_by_pmid`.
+
+    When `write_through=True` (default), articles fetched from NCBI are stored
+    in the local DB so future lookups are served locally.
     """
     from .pubmedarticle import PubMedArticle
 
@@ -114,7 +145,13 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher):
             except Exception as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
-        return eutils_fetcher(pmid)
+        art = eutils_fetcher(pmid)
+        if write_through and art is not None:
+            try:
+                backend.store_xml(pmid, art.xml)
+            except Exception as e:
+                log.debug("localfetcher: write-through skipped for PMID %s: %s", pmid, e)
+        return art
 
     def articles_by_pmids(pmids: list) -> dict:
         """
@@ -145,6 +182,11 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher):
                     art = eutils_fetcher(pmid)
                     if art:
                         results[pmid] = art
+                        if write_through:
+                            try:
+                                backend.store_xml(pmid, art.xml)
+                            except Exception as e:
+                                log.debug("localfetcher: write-through skipped for PMID %s: %s", pmid, e)
                 except Exception as e:
                     log.warning("localfetcher: NCBI error for PMID %s: %s", pmid, e)
 

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -33,6 +33,8 @@ Requires psycopg2::
 import logging
 import os
 
+from .pubmedarticle import PubMedArticle
+
 log = logging.getLogger(__name__)
 
 try:
@@ -134,8 +136,6 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
     When `write_through=True` (default), articles fetched from NCBI are stored
     in the local DB so future lookups are served locally.
     """
-    from .pubmedarticle import PubMedArticle
-
     def article_by_pmid(pmid):
         xml = backend.fetch_xml(pmid)
         if xml:

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -33,6 +33,10 @@ Requires psycopg2::
 import logging
 import os
 
+from lxml import etree
+
+from .exceptions import MetaPubError
+
 log = logging.getLogger(__name__)
 
 try:
@@ -152,7 +156,7 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
             log.debug("localfetcher: hit for PMID %s", pmid)
             try:
                 return PubMedArticle(xml)
-            except Exception as e:
+            except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
         art = eutils_fetcher(pmid)
@@ -178,7 +182,7 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
                 try:
                     results[pmid] = PubMedArticle(xml)
                     continue
-                except Exception as e:
+                except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                     log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)
             ncbi_needed.append(pmid)
 

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -171,9 +171,14 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
         if xml:
             log.debug("localfetcher: hit for PMID %s", pmid)
             try:
-                return PubMedArticle(_ensure_article_set_wrapper(xml))
+                art = PubMedArticle(_ensure_article_set_wrapper(xml))
             except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
+            else:
+                if art.pmid is None:
+                    log.warning("localfetcher: DB XML for PMID %s parsed but yielded no PMID — falling back", pmid)
+                else:
+                    return art
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
         art = eutils_fetcher(pmid)
         if write_through and art is not None:
@@ -196,10 +201,15 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
             xml = local_xml.get(int(pmid))
             if xml:
                 try:
-                    results[pmid] = PubMedArticle(_ensure_article_set_wrapper(xml))
-                    continue
+                    art = PubMedArticle(_ensure_article_set_wrapper(xml))
                 except (etree.XMLSyntaxError, etree.ParserError, MetaPubError) as e:
                     log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)
+                else:
+                    if art.pmid is None:
+                        log.warning("localfetcher: DB XML for PMID %s parsed but yielded no PMID — falling back", pmid)
+                    else:
+                        results[pmid] = art
+                        continue
             ncbi_needed.append(pmid)
 
         if ncbi_needed:

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -14,7 +14,7 @@ Usage::
     from metapub import PubMedFetcher
 
     # Local-first with NCBI fallback
-    fetch = PubMedFetcher(db_url="postgresql://medgen:medgen@loki.local/medgen")
+    fetch = PubMedFetcher(db_url="postgresql://user:pass@host/dbname")
     article = fetch.article_by_pmid("27022295")
 
     # Bulk lookup (new — not available in eutils-only mode)
@@ -32,13 +32,6 @@ Requires psycopg2::
 
 import logging
 import os
-import threading
-
-from lxml import etree
-
-from .exceptions import MetaPubError
-from .ncbi_errors import NCBIServiceError
-from .pubmedarticle import PubMedArticle
 
 log = logging.getLogger(__name__)
 
@@ -68,25 +61,32 @@ class LocalPubMedBackend:
                 "Install it with: pip install psycopg2-binary"
             )
         self._db_url = db_url
-        self._local = threading.local()  # per-thread connection storage
+        self._ro_conn = None   # read-only connection (reads)
+        self._rw_conn = None   # read-write connection (write-through stores)
 
     def _connection(self):
-        """Return a per-thread read-only connection, reconnecting if needed."""
-        conn = getattr(self._local, 'ro_conn', None)
-        if conn is None or conn.closed:
-            conn = psycopg2.connect(self._db_url)
-            conn.set_session(readonly=True, autocommit=True)
-            self._local.ro_conn = conn
-        return conn
+        """Return a read-only connection, reconnecting if needed."""
+        if self._ro_conn is not None and not self._ro_conn.closed:
+            try:
+                self._ro_conn.cursor().execute("SELECT 1")
+            except psycopg2.OperationalError:
+                self._ro_conn = None
+        if self._ro_conn is None:
+            self._ro_conn = psycopg2.connect(self._db_url)
+            self._ro_conn.set_session(readonly=True, autocommit=True)
+        return self._ro_conn
 
     def _rw_connection(self):
-        """Return a per-thread read-write connection for write-through stores."""
-        conn = getattr(self._local, 'rw_conn', None)
-        if conn is None or conn.closed:
-            conn = psycopg2.connect(self._db_url)
-            conn.autocommit = True
-            self._local.rw_conn = conn
-        return conn
+        """Return a read-write connection for write-through stores."""
+        if self._rw_conn is not None and not self._rw_conn.closed:
+            try:
+                self._rw_conn.cursor().execute("SELECT 1")
+            except psycopg2.OperationalError:
+                self._rw_conn = None
+        if self._rw_conn is None:
+            self._rw_conn = psycopg2.connect(self._db_url)
+            self._rw_conn.autocommit = True
+        return self._rw_conn
 
     def fetch_xml(self, pmid: int | str) -> str | None:
         """Return raw NLM XML for a single PMID, or None if not in the local DB."""
@@ -95,9 +95,9 @@ class LocalPubMedBackend:
                 cur.execute(_SELECT_ONE, (int(pmid),))
                 row = cur.fetchone()
                 return row[0] if row else None
-        except psycopg2.Error as e:
-            log.warning("localfetcher: DB error for PMID %s: %s", pmid, e)
-            self._local.ro_conn = None   # force reconnect next time
+        except psycopg2.OperationalError as e:
+            log.error("localfetcher: DB connection error for PMID %s: %s", pmid, e)
+            self._ro_conn = None
             return None
 
     def fetch_xml_many(self, pmids: list[int | str]) -> dict[int, str]:
@@ -112,9 +112,9 @@ class LocalPubMedBackend:
             with self._connection().cursor() as cur:
                 cur.execute(_SELECT_MANY, (int_pmids,))
                 return {row[0]: row[1] for row in cur.fetchall()}
-        except psycopg2.Error as e:
-            log.warning("localfetcher: DB error for batch of %d PMIDs: %s", len(pmids), e)
-            self._local.ro_conn = None
+        except psycopg2.OperationalError as e:
+            log.error("localfetcher: DB connection error for batch of %d PMIDs: %s", len(pmids), e)
+            self._ro_conn = None
             return {}
 
     def store_xml(self, pmid: int | str, xml: str) -> None:
@@ -127,9 +127,9 @@ class LocalPubMedBackend:
             with self._rw_connection().cursor() as cur:
                 cur.execute(_UPSERT_XML, (int(pmid), xml))
             log.debug("localfetcher: stored PMID %s in local DB", pmid)
-        except psycopg2.Error as e:
+        except Exception as e:
             log.warning("localfetcher: write-through store failed for PMID %s: %s", pmid, e)
-            self._local.rw_conn = None
+            self._rw_conn = None
 
 
 def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
@@ -144,13 +144,15 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
     When `write_through=True` (default), articles fetched from NCBI are stored
     in the local DB so future lookups are served locally.
     """
+    from .pubmedarticle import PubMedArticle
+
     def article_by_pmid(pmid):
         xml = backend.fetch_xml(pmid)
         if xml:
             log.debug("localfetcher: hit for PMID %s", pmid)
             try:
                 return PubMedArticle(xml)
-            except (etree.XMLSyntaxError, etree.ParserError) as e:
+            except Exception as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
         art = eutils_fetcher(pmid)
@@ -163,26 +165,20 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
         Bulk fetch articles for a list of PMIDs.
         Returns {str(pmid): PubMedArticle} for all PMIDs that resolve.
         PMIDs not found in the local DB are fetched from NCBI individually.
-
-        Raises ValueError if any pmid cannot be converted to int.
         """
-        try:
-            int_pmids = [int(p) for p in pmids]
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"All pmids must be integer-like: {exc}") from exc
-
-        local_xml = backend.fetch_xml_many(int_pmids)
+        pmids = [str(p) for p in pmids]
+        local_xml = backend.fetch_xml_many(pmids)
 
         results: dict[str, PubMedArticle] = {}
-        ncbi_needed: list[int] = []
+        ncbi_needed = []
 
-        for pmid in int_pmids:
-            xml = local_xml.get(pmid)
+        for pmid in pmids:
+            xml = local_xml.get(int(pmid))
             if xml:
                 try:
-                    results[str(pmid)] = PubMedArticle(xml)
+                    results[pmid] = PubMedArticle(xml)
                     continue
-                except (etree.XMLSyntaxError, etree.ParserError) as e:
+                except Exception as e:
                     log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)
             ncbi_needed.append(pmid)
 
@@ -192,10 +188,10 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
                 try:
                     art = eutils_fetcher(pmid)
                     if art:
-                        results[str(pmid)] = art
+                        results[pmid] = art
                         if write_through:
                             backend.store_xml(pmid, art.xml)
-                except (MetaPubError, NCBIServiceError) as e:
+                except Exception as e:
                     log.warning("localfetcher: NCBI error for PMID %s: %s", pmid, e)
 
         return results

--- a/metapub/localfetcher.py
+++ b/metapub/localfetcher.py
@@ -32,7 +32,12 @@ Requires psycopg2::
 
 import logging
 import os
+import threading
 
+from lxml import etree
+
+from .exceptions import MetaPubError
+from .ncbi_errors import NCBIServiceError
 from .pubmedarticle import PubMedArticle
 
 log = logging.getLogger(__name__)
@@ -63,22 +68,25 @@ class LocalPubMedBackend:
                 "Install it with: pip install psycopg2-binary"
             )
         self._db_url = db_url
-        self._ro_conn = None   # read-only connection (reads)
-        self._rw_conn = None   # read-write connection (write-through stores)
+        self._local = threading.local()  # per-thread connection storage
 
     def _connection(self):
-        """Return a read-only connection, reconnecting if needed."""
-        if self._ro_conn is None or self._ro_conn.closed:
-            self._ro_conn = psycopg2.connect(self._db_url)
-            self._ro_conn.set_session(readonly=True, autocommit=True)
-        return self._ro_conn
+        """Return a per-thread read-only connection, reconnecting if needed."""
+        conn = getattr(self._local, 'ro_conn', None)
+        if conn is None or conn.closed:
+            conn = psycopg2.connect(self._db_url)
+            conn.set_session(readonly=True, autocommit=True)
+            self._local.ro_conn = conn
+        return conn
 
     def _rw_connection(self):
-        """Return a read-write connection for write-through stores."""
-        if self._rw_conn is None or self._rw_conn.closed:
-            self._rw_conn = psycopg2.connect(self._db_url)
-            self._rw_conn.autocommit = True
-        return self._rw_conn
+        """Return a per-thread read-write connection for write-through stores."""
+        conn = getattr(self._local, 'rw_conn', None)
+        if conn is None or conn.closed:
+            conn = psycopg2.connect(self._db_url)
+            conn.autocommit = True
+            self._local.rw_conn = conn
+        return conn
 
     def fetch_xml(self, pmid: int | str) -> str | None:
         """Return raw NLM XML for a single PMID, or None if not in the local DB."""
@@ -87,9 +95,9 @@ class LocalPubMedBackend:
                 cur.execute(_SELECT_ONE, (int(pmid),))
                 row = cur.fetchone()
                 return row[0] if row else None
-        except Exception as e:
+        except psycopg2.Error as e:
             log.warning("localfetcher: DB error for PMID %s: %s", pmid, e)
-            self._ro_conn = None   # force reconnect next time
+            self._local.ro_conn = None   # force reconnect next time
             return None
 
     def fetch_xml_many(self, pmids: list[int | str]) -> dict[int, str]:
@@ -104,9 +112,9 @@ class LocalPubMedBackend:
             with self._connection().cursor() as cur:
                 cur.execute(_SELECT_MANY, (int_pmids,))
                 return {row[0]: row[1] for row in cur.fetchall()}
-        except Exception as e:
+        except psycopg2.Error as e:
             log.warning("localfetcher: DB error for batch of %d PMIDs: %s", len(pmids), e)
-            self._ro_conn = None
+            self._local.ro_conn = None
             return {}
 
     def store_xml(self, pmid: int | str, xml: str) -> None:
@@ -119,9 +127,9 @@ class LocalPubMedBackend:
             with self._rw_connection().cursor() as cur:
                 cur.execute(_UPSERT_XML, (int(pmid), xml))
             log.debug("localfetcher: stored PMID %s in local DB", pmid)
-        except Exception as e:
+        except psycopg2.Error as e:
             log.warning("localfetcher: write-through store failed for PMID %s: %s", pmid, e)
-            self._rw_conn = None
+            self._local.rw_conn = None
 
 
 def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
@@ -142,15 +150,12 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
             log.debug("localfetcher: hit for PMID %s", pmid)
             try:
                 return PubMedArticle(xml)
-            except Exception as e:
+            except (etree.XMLSyntaxError, etree.ParserError) as e:
                 log.warning("localfetcher: XML parse error for PMID %s: %s — falling back", pmid, e)
         log.debug("localfetcher: miss for PMID %s — falling back to eutils", pmid)
         art = eutils_fetcher(pmid)
         if write_through and art is not None:
-            try:
-                backend.store_xml(pmid, art.xml)
-            except Exception as e:
-                log.debug("localfetcher: write-through skipped for PMID %s: %s", pmid, e)
+            backend.store_xml(pmid, art.xml)
         return art
 
     def articles_by_pmids(pmids: list) -> dict:
@@ -158,20 +163,26 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
         Bulk fetch articles for a list of PMIDs.
         Returns {str(pmid): PubMedArticle} for all PMIDs that resolve.
         PMIDs not found in the local DB are fetched from NCBI individually.
+
+        Raises ValueError if any pmid cannot be converted to int.
         """
-        pmids = [str(p) for p in pmids]
-        local_xml = backend.fetch_xml_many(pmids)
+        try:
+            int_pmids = [int(p) for p in pmids]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"All pmids must be integer-like: {exc}") from exc
+
+        local_xml = backend.fetch_xml_many(int_pmids)
 
         results: dict[str, PubMedArticle] = {}
-        ncbi_needed = []
+        ncbi_needed: list[int] = []
 
-        for pmid in pmids:
-            xml = local_xml.get(int(pmid))
+        for pmid in int_pmids:
+            xml = local_xml.get(pmid)
             if xml:
                 try:
-                    results[pmid] = PubMedArticle(xml)
+                    results[str(pmid)] = PubMedArticle(xml)
                     continue
-                except Exception as e:
+                except (etree.XMLSyntaxError, etree.ParserError) as e:
                     log.warning("localfetcher: XML parse error for PMID %s: %s", pmid, e)
             ncbi_needed.append(pmid)
 
@@ -181,13 +192,10 @@ def make_local_fetcher_methods(backend: LocalPubMedBackend, eutils_fetcher,
                 try:
                     art = eutils_fetcher(pmid)
                     if art:
-                        results[pmid] = art
+                        results[str(pmid)] = art
                         if write_through:
-                            try:
-                                backend.store_xml(pmid, art.xml)
-                            except Exception as e:
-                                log.debug("localfetcher: write-through skipped for PMID %s: %s", pmid, e)
-                except Exception as e:
+                            backend.store_xml(pmid, art.xml)
+                except (MetaPubError, NCBIServiceError) as e:
                     log.warning("localfetcher: NCBI error for PMID %s: %s", pmid, e)
 
         return results

--- a/metapub/pubmedfetcher.py
+++ b/metapub/pubmedfetcher.py
@@ -4,6 +4,7 @@ __doc__ = '''metapub.PubMedFetcher -- tools to deal with NCBI's E-utilities inte
 from lxml import etree
 import requests
 import logging
+import os
 
 from .eutils_common import get_eutils_client
 from .eutils_compat import EutilsRequestError
@@ -148,7 +149,6 @@ class PubMedFetcher(Borg):
         Note:
             This is a Borg singleton - all instances share the same state.
         """
-        import os
         self.method = method
         cachedir = kwargs.get("cachedir")
 

--- a/metapub/pubmedfetcher.py
+++ b/metapub/pubmedfetcher.py
@@ -142,6 +142,8 @@ class PubMedFetcher(Borg):
                 Also read from the ``METAPUB_DB_URL`` environment variable.
             **kwargs: Additional keyword arguments.
                 cachedir (str, optional): Custom cache directory for eutils responses.
+                write_through (bool, optional): When using local DB, store NCBI-fetched
+                    articles back into the local DB for future fast access. Default True.
 
         Note:
             This is a Borg singleton - all instances share the same state.
@@ -159,11 +161,13 @@ class PubMedFetcher(Borg):
 
         # Wire up local PostgreSQL backend if a db_url is available
         resolved_db_url = db_url or os.environ.get("METAPUB_DB_URL")
+        write_through = kwargs.get("write_through", True)
         if resolved_db_url:
             self.method = 'local'
             backend = LocalPubMedBackend(resolved_db_url)
             self.article_by_pmid, self.articles_by_pmids = \
-                make_local_fetcher_methods(backend, self._eutils_article_by_pmid)
+                make_local_fetcher_methods(backend, self._eutils_article_by_pmid,
+                                           write_through=write_through)
         elif method == 'eutils':
             self.article_by_pmid = self._eutils_article_by_pmid
         else:

--- a/metapub/pubmedfetcher.py
+++ b/metapub/pubmedfetcher.py
@@ -8,6 +8,7 @@ import logging
 from .eutils_common import get_eutils_client
 from .eutils_compat import EutilsRequestError
 from .cache_utils import get_cache_path
+from .localfetcher import LocalPubMedBackend, make_local_fetcher_methods
 from .pubmedarticle import PubMedArticle
 from .pubmedcentral import get_pmid_for_otherid
 from .pubmed_clinicalqueries import *
@@ -128,34 +129,48 @@ class PubMedFetcher(Borg):
 
     _cache_filename = 'pubmedfetcher.db'
 
-    def __init__(self, method='eutils', **kwargs):
+    def __init__(self, method='eutils', db_url=None, **kwargs):
         """Initialize PubMedFetcher with specified service method.
-        
+
         Args:
-            method (str, optional): Service method to use. Currently only 'eutils' 
-                is supported. Defaults to 'eutils'.
+            method (str, optional): Service method. 'eutils' (default) or 'local'.
+            db_url (str, optional): PostgreSQL connection URL for the local
+                medgen-stacks pubmed schema, e.g.
+                ``"postgresql://medgen:medgen@loki.local/medgen"``.
+                If provided, the local database is checked first and NCBI
+                eutils is used as a fallback for any missing PMIDs.
+                Also read from the ``METAPUB_DB_URL`` environment variable.
             **kwargs: Additional keyword arguments.
-                cachedir (str, optional): Custom directory for caching responses.
-                    If not provided, uses default cache directory.
-        
-        Raises:
-            NotImplementedError: If an unsupported method is specified.
-        
+                cachedir (str, optional): Custom cache directory for eutils responses.
+
         Note:
             This is a Borg singleton - all instances share the same state.
         """
+        import os
         self.method = method
         cachedir = kwargs.get("cachedir")
 
-        if method=='eutils':
-            self._cache_path = get_cache_path(cachedir, self._cache_filename)
-            self.qs = get_eutils_client(self._cache_path)
+        # Always set up eutils as the base (and fallback)
+        self._cache_path = get_cache_path(cachedir, self._cache_filename)
+        self.qs = get_eutils_client(self._cache_path)
+        self.article_by_pmcid = self._eutils_article_by_pmcid
+        self.article_by_doi = self._eutils_article_by_doi
+        self.pmids_for_query = self._eutils_pmids_for_query
+
+        # Wire up local PostgreSQL backend if a db_url is available
+        resolved_db_url = db_url or os.environ.get("METAPUB_DB_URL")
+        if resolved_db_url:
+            self.method = 'local'
+            backend = LocalPubMedBackend(resolved_db_url)
+            self.article_by_pmid, self.articles_by_pmids = \
+                make_local_fetcher_methods(backend, self._eutils_article_by_pmid)
+        elif method == 'eutils':
             self.article_by_pmid = self._eutils_article_by_pmid
-            self.article_by_pmcid = self._eutils_article_by_pmcid
-            self.article_by_doi = self._eutils_article_by_doi
-            self.pmids_for_query = self._eutils_pmids_for_query
         else:
-            raise NotImplementedError('Planned future options: "mysql", "cache-only"')
+            raise NotImplementedError(
+                f'Unknown method {method!r}. '
+                'Use method="eutils" or pass db_url for local PostgreSQL backend.'
+            )
 
     def _eutils_article_by_pmid(self, pmid):
         pmid = str(pmid)

--- a/metapub/pubmedfetcher.py
+++ b/metapub/pubmedfetcher.py
@@ -12,7 +12,7 @@ from .cache_utils import get_cache_path
 from .localfetcher import LocalPubMedBackend, make_local_fetcher_methods
 from .pubmedarticle import PubMedArticle
 from .pubmedcentral import get_pmid_for_otherid
-from .pubmed_clinicalqueries import *
+from .pubmed_clinicalqueries import clinical_query_map, medical_genetics_query_map
 from .utils import kpick, parameterize, lowercase_keys, remove_chars
 from .text_mining import re_pmid, is_ncbi_bookID, re_matching_quotes
 from .exceptions import MetaPubError, InvalidPMID, InvalidBookID
@@ -507,7 +507,13 @@ class PubMedFetcher(Borg):
         req = base_uri.format(**inp_dict)
         log.debug('pmids_for_citation: querying with %s', req)
 
-        content = requests.get(req, timeout=30).text
+        try:
+            response = requests.get(req, timeout=30)
+            response.raise_for_status()
+            content = response.text
+        except requests.RequestException as e:
+            log.warning("pmids_for_citation: request failed: %s", e)
+            return []
         pmids = []
         for item in content.split('\n'):
             if item.strip():

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,10 @@ setup(
         ],
     },
     install_requires=[
-        "setuptools",
-        "lxml",
-        "lxml_html_clean",
-        "requests",
+        "setuptools>=78.1.1",
+        "lxml>=4.9.1",
+        "lxml_html_clean>=0.4.4",
+        "requests>=2.32.4",
         "brotli",
         "habanero",
         "tabulate",
@@ -105,7 +105,7 @@ setup(
         "docopt",
         "coloredlogs",
         "python-Levenshtein",
-        "pyyaml",
+        "pyyaml>=5.4",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_localfetcher.py
+++ b/tests/test_localfetcher.py
@@ -63,6 +63,22 @@ _NLM_XML = """\
 # Same article without the PubmedArticleSet wrapper — as some DB tools store it
 _NLM_XML_BARE = _NLM_XML.split('<PubmedArticleSet>')[1].rsplit('</PubmedArticleSet>', 1)[0].strip()
 
+# Valid XML that parses successfully but contains no PMID element
+_NLM_XML_NO_PMID = """\
+<PubmedArticleSet>
+<PubmedArticle>
+  <MedlineCitation Status="MEDLINE" Owner="NLM">
+    <Article PubModel="Print">
+      <Journal><JournalIssue CitedMedium="Print"><PubDate><Year>2016</Year></PubDate></JournalIssue>
+        <Title>Test Journal</Title><ISOAbbreviation>Test J</ISOAbbreviation>
+      </Journal>
+      <ArticleTitle>No PMID article</ArticleTitle>
+    </Article>
+  </MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>
+"""
+
 
 def _make_backend(fetch_xml_return=None, fetch_xml_many_return=None):
     """Return a LocalPubMedBackend with mocked DB methods."""
@@ -295,6 +311,28 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         self.assertIn("27022295", results)
         self.assertEqual(str(results["27022295"].pmid), "27022295")
         eutils.assert_not_called()
+
+    def test_article_by_pmid_no_pmid_in_xml_falls_back_to_ncbi(self):
+        """DB XML that parses but yields pmid=None triggers eutils fallback."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article()
+        backend = _make_backend(fetch_xml_return=_NLM_XML_NO_PMID)
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIs(art, ncbi_art)
+        eutils.assert_called_once_with("27022295")
+
+    def test_articles_by_pmids_no_pmid_in_xml_falls_back_to_ncbi(self):
+        """Bulk DB XML that parses but yields pmid=None triggers eutils fallback."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article("27022295")
+        backend = _make_backend(fetch_xml_many_return={27022295: _NLM_XML_NO_PMID})
+        eutils = MagicMock(return_value=ncbi_art)
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295"])
+        self.assertIn("27022295", results)
+        eutils.assert_called_once_with('27022295')
 
     def test_article_by_pmid_empty_xml_falls_back_to_ncbi(self):
         """Empty string XML from DB (raises MetaPubError) triggers eutils fallback."""

--- a/tests/test_localfetcher.py
+++ b/tests/test_localfetcher.py
@@ -1,0 +1,275 @@
+"""
+Tests for metapub.localfetcher — all offline, no DB or NCBI required.
+
+Tests cover:
+  - LocalPubMedBackend.fetch_xml: DB hit, DB miss, DB error
+  - LocalPubMedBackend.fetch_xml_many: partial hits, empty list, DB error
+  - LocalPubMedBackend.store_xml: success, error (silent)
+  - make_local_fetcher_methods: hit path, miss+fallback, miss+write-through,
+    miss+no-write-through, bulk fetch
+  - PubMedFetcher with METAPUB_DB_URL env var wires up local backend
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+# Minimal NLM XML fixture — enough for PubMedArticle to parse
+_NLM_XML = """\
+<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2025//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_250101.dtd">
+<PubmedArticleSet>
+<PubmedArticle>
+  <MedlineCitation Status="MEDLINE" Owner="NLM">
+    <PMID Version="1">27022295</PMID>
+    <Article PubModel="Print">
+      <Journal>
+        <JournalIssue CitedMedium="Print">
+          <PubDate><Year>2016</Year></PubDate>
+        </JournalIssue>
+        <Title>Test Journal</Title>
+        <ISOAbbreviation>Test J</ISOAbbreviation>
+      </Journal>
+      <ArticleTitle>Test article title</ArticleTitle>
+      <Abstract><AbstractText>Test abstract.</AbstractText></Abstract>
+      <AuthorList CompleteYN="Y">
+        <Author ValidYN="Y">
+          <LastName>Smith</LastName>
+          <ForeName>Jane</ForeName>
+          <Initials>J</Initials>
+        </Author>
+      </AuthorList>
+      <Language>eng</Language>
+      <PublicationTypeList>
+        <PublicationType UI="D016428">Journal Article</PublicationType>
+      </PublicationTypeList>
+    </Article>
+  </MedlineCitation>
+  <PubmedData>
+    <ArticleIdList>
+      <ArticleId IdType="pubmed">27022295</ArticleId>
+    </ArticleIdList>
+  </PubmedData>
+</PubmedArticle>
+</PubmedArticleSet>
+"""
+
+
+def _make_backend(fetch_xml_return=None, fetch_xml_many_return=None):
+    """Return a LocalPubMedBackend with mocked DB methods."""
+    from metapub.localfetcher import LocalPubMedBackend
+    backend = LocalPubMedBackend.__new__(LocalPubMedBackend)
+    backend._db_url = "postgresql://mock/mock"
+    backend._ro_conn = None
+    backend._rw_conn = None
+    backend.fetch_xml = MagicMock(return_value=fetch_xml_return)
+    backend.fetch_xml_many = MagicMock(return_value=fetch_xml_many_return or {})
+    backend.store_xml = MagicMock()
+    return backend
+
+
+class TestLocalPubMedBackend(unittest.TestCase):
+    """Unit tests for LocalPubMedBackend DB methods (psycopg2 mocked)."""
+
+    def _make_conn(self, fetchone=None, fetchall=None):
+        """Build a mock psycopg2 connection/cursor."""
+        cur = MagicMock()
+        cur.__enter__ = lambda s: s
+        cur.__exit__ = MagicMock(return_value=False)
+        cur.fetchone.return_value = fetchone
+        cur.fetchall.return_value = fetchall or []
+        conn = MagicMock()
+        conn.closed = False
+        conn.cursor.return_value = cur
+        return conn, cur
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_fetch_xml_hit(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn, _ = self._make_conn(fetchone=(_NLM_XML,))
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        result = b.fetch_xml(27022295)
+        self.assertEqual(result, _NLM_XML)
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_fetch_xml_miss(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn, _ = self._make_conn(fetchone=None)
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        result = b.fetch_xml(99999999)
+        self.assertIsNone(result)
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_fetch_xml_db_error_returns_none(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn = MagicMock()
+        conn.closed = False
+        conn.cursor.side_effect = Exception("DB connection failed")
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        result = b.fetch_xml(27022295)
+        self.assertIsNone(result)
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_fetch_xml_many_partial(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn, _ = self._make_conn(fetchall=[(27022295, _NLM_XML)])
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        result = b.fetch_xml_many([27022295, 99999999])
+        self.assertIn(27022295, result)
+        self.assertNotIn(99999999, result)
+        self.assertEqual(result[27022295], _NLM_XML)
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_fetch_xml_many_empty_list(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        mock_psycopg2.connect.return_value = MagicMock()
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        result = b.fetch_xml_many([])
+        self.assertEqual(result, {})
+        mock_psycopg2.connect.assert_not_called()
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_store_xml_success(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn, cur = self._make_conn()
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        b.store_xml(27022295, _NLM_XML)
+        cur.execute.assert_called_once()
+        args = cur.execute.call_args[0]
+        self.assertIn(27022295, args[1])
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_store_xml_error_is_silent(self, mock_psycopg2):
+        from metapub.localfetcher import LocalPubMedBackend
+        conn = MagicMock()
+        conn.closed = False
+        conn.cursor.side_effect = Exception("write error")
+        mock_psycopg2.connect.return_value = conn
+        b = LocalPubMedBackend("postgresql://mock/mock")
+        # Must not raise
+        b.store_xml(27022295, _NLM_XML)
+
+    def test_requires_psycopg2(self):
+        with patch("metapub.localfetcher.HAS_PSYCOPG2", False):
+            from metapub.localfetcher import LocalPubMedBackend
+            with self.assertRaises(ImportError):
+                LocalPubMedBackend("postgresql://mock/mock")
+
+
+class TestMakeLocalFetcherMethods(unittest.TestCase):
+    """Tests for the article_by_pmid / articles_by_pmids closures."""
+
+    def _make_article(self, pmid="27022295"):
+        from metapub.pubmedarticle import PubMedArticle
+        art = PubMedArticle(_NLM_XML)
+        art.xml = _NLM_XML
+        return art
+
+    def test_article_by_pmid_db_hit(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=_NLM_XML)
+        eutils = MagicMock()
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIsNotNone(art)
+        self.assertEqual(str(art.pmid), "27022295")
+        eutils.assert_not_called()
+        backend.store_xml.assert_not_called()
+
+    def test_article_by_pmid_db_miss_falls_back_to_ncbi(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=None)
+        ncbi_art = self._make_article()
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIs(art, ncbi_art)
+        eutils.assert_called_once_with("27022295")
+
+    def test_article_by_pmid_miss_write_through(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=None)
+        ncbi_art = self._make_article()
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils, write_through=True)
+        article_by_pmid("27022295")
+        backend.store_xml.assert_called_once_with("27022295", _NLM_XML)
+
+    def test_article_by_pmid_miss_no_write_through(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=None)
+        ncbi_art = self._make_article()
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils, write_through=False)
+        article_by_pmid("27022295")
+        backend.store_xml.assert_not_called()
+
+    def test_article_by_pmid_ncbi_returns_none(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=None)
+        eutils = MagicMock(return_value=None)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("99999999")
+        self.assertIsNone(art)
+        backend.store_xml.assert_not_called()
+
+    def test_articles_by_pmids_all_local(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_many_return={27022295: _NLM_XML})
+        eutils = MagicMock()
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295"])
+        self.assertIn("27022295", results)
+        eutils.assert_not_called()
+
+    def test_articles_by_pmids_partial_ncbi_fallback(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article("99999999")
+        backend = _make_backend(fetch_xml_many_return={27022295: _NLM_XML})
+        eutils = MagicMock(return_value=ncbi_art)
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295", "99999999"])
+        self.assertIn("27022295", results)
+        self.assertIn("99999999", results)
+        eutils.assert_called_once_with("99999999")
+
+
+class TestPubMedFetcherLocalWiring(unittest.TestCase):
+    """PubMedFetcher picks up METAPUB_DB_URL and switches to local method."""
+
+    @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
+    @patch("metapub.localfetcher.psycopg2")
+    def test_env_var_activates_local_backend(self, mock_psycopg2):
+        mock_psycopg2.connect.return_value = MagicMock(closed=False)
+        with patch.dict(os.environ, {"METAPUB_DB_URL": "postgresql://mock/mock"}):
+            # Reset Borg state so a fresh instance is created
+            from metapub.pubmedfetcher import PubMedFetcher
+            PubMedFetcher._shared_state = {}
+            f = PubMedFetcher()
+            self.assertEqual(f.method, "local")
+            self.assertTrue(callable(f.article_by_pmid))
+
+    def test_no_env_var_stays_eutils(self):
+        env = {k: v for k, v in os.environ.items() if k != "METAPUB_DB_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            from metapub.pubmedfetcher import PubMedFetcher
+            PubMedFetcher._shared_state = {}
+            f = PubMedFetcher()
+            self.assertEqual(f.method, "eutils")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_localfetcher.py
+++ b/tests/test_localfetcher.py
@@ -11,8 +11,13 @@ Tests cover:
 """
 
 import os
+import threading
 import unittest
 from unittest.mock import MagicMock, patch, call
+
+
+class _Psycopg2Error(Exception):
+    """Stub for psycopg2.Error used when psycopg2 is fully mocked."""
 
 # Minimal NLM XML fixture — enough for PubMedArticle to parse
 _NLM_XML = """\
@@ -61,8 +66,7 @@ def _make_backend(fetch_xml_return=None, fetch_xml_many_return=None):
     from metapub.localfetcher import LocalPubMedBackend
     backend = LocalPubMedBackend.__new__(LocalPubMedBackend)
     backend._db_url = "postgresql://mock/mock"
-    backend._ro_conn = None
-    backend._rw_conn = None
+    backend._local = threading.local()
     backend.fetch_xml = MagicMock(return_value=fetch_xml_return)
     backend.fetch_xml_many = MagicMock(return_value=fetch_xml_many_return or {})
     backend.store_xml = MagicMock()
@@ -108,9 +112,10 @@ class TestLocalPubMedBackend(unittest.TestCase):
     @patch("metapub.localfetcher.psycopg2")
     def test_fetch_xml_db_error_returns_none(self, mock_psycopg2):
         from metapub.localfetcher import LocalPubMedBackend
+        mock_psycopg2.Error = _Psycopg2Error
         conn = MagicMock()
         conn.closed = False
-        conn.cursor.side_effect = Exception("DB connection failed")
+        conn.cursor.side_effect = _Psycopg2Error("DB connection failed")
         mock_psycopg2.connect.return_value = conn
         b = LocalPubMedBackend("postgresql://mock/mock")
         result = b.fetch_xml(27022295)
@@ -154,9 +159,10 @@ class TestLocalPubMedBackend(unittest.TestCase):
     @patch("metapub.localfetcher.psycopg2")
     def test_store_xml_error_is_silent(self, mock_psycopg2):
         from metapub.localfetcher import LocalPubMedBackend
+        mock_psycopg2.Error = _Psycopg2Error
         conn = MagicMock()
         conn.closed = False
-        conn.cursor.side_effect = Exception("write error")
+        conn.cursor.side_effect = _Psycopg2Error("write error")
         mock_psycopg2.connect.return_value = conn
         b = LocalPubMedBackend("postgresql://mock/mock")
         # Must not raise
@@ -244,7 +250,91 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         results = articles_by_pmids(["27022295", "99999999"])
         self.assertIn("27022295", results)
         self.assertIn("99999999", results)
-        eutils.assert_called_once_with("99999999")
+        eutils.assert_called_once_with(99999999)
+
+    def test_articles_by_pmids_invalid_pmid_raises(self):
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend()
+        eutils = MagicMock()
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        with self.assertRaises(ValueError):
+            articles_by_pmids(["not-a-number"])
+
+    def test_articles_by_pmids_cached_xml_parse_error_falls_back_to_ncbi(self):
+        """Corrupt XML in local cache triggers NCBI fallback for that PMID."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article("27022295")
+        backend = _make_backend(fetch_xml_many_return={27022295: "<<corrupt xml>>"})
+        eutils = MagicMock(return_value=ncbi_art)
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295"])
+        self.assertIn("27022295", results)
+        eutils.assert_called_once_with(27022295)
+
+    def test_articles_by_pmids_ncbi_error_returns_partial_results(self):
+        """An NCBI service error for one PMID does not abort the whole batch."""
+        from metapub.exceptions import MetaPubError
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article("27022295")
+        backend = _make_backend(fetch_xml_many_return={})
+        eutils = MagicMock(side_effect=[ncbi_art, MetaPubError("NCBI unavailable")])
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295", "99999999"])
+        self.assertIn("27022295", results)
+        self.assertNotIn("99999999", results)
+
+    def test_articles_by_pmids_ncbi_service_error_returns_partial_results(self):
+        """An NCBIServiceError for one PMID does not abort the whole batch."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        from metapub.ncbi_errors import NCBIServiceError
+        ncbi_art = self._make_article("27022295")
+        backend = _make_backend(fetch_xml_many_return={})
+        eutils = MagicMock(side_effect=[ncbi_art, NCBIServiceError("timeout")])
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295", "99999999"])
+        self.assertIn("27022295", results)
+        self.assertNotIn("99999999", results)
+
+    def test_article_by_pmid_cached_xml_parse_error_falls_back_to_ncbi(self):
+        """Corrupt XML in local cache for single-article path triggers NCBI fallback."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article()
+        backend = _make_backend(fetch_xml_return="<<corrupt xml>>")
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIs(art, ncbi_art)
+        eutils.assert_called_once_with("27022295")
+
+    def test_articles_by_pmids_thread_safety(self):
+        """Each thread gets its own result set; no cross-thread contamination."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_many_return={27022295: _NLM_XML})
+        eutils = MagicMock(return_value=None)
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+
+        results = {}
+        errors = []
+
+        def fetch(pmids, key):
+            try:
+                results[key] = articles_by_pmids(pmids)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=fetch, args=(["27022295"], "t1")),
+            threading.Thread(target=fetch, args=(["27022295"], "t2")),
+            threading.Thread(target=fetch, args=(["27022295"], "t3")),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertFalse(errors, f"Threads raised: {errors}")
+        for key in ("t1", "t2", "t3"):
+            self.assertIn("27022295", results[key])
 
 
 class TestPubMedFetcherLocalWiring(unittest.TestCase):
@@ -253,6 +343,7 @@ class TestPubMedFetcherLocalWiring(unittest.TestCase):
     @patch("metapub.localfetcher.HAS_PSYCOPG2", True)
     @patch("metapub.localfetcher.psycopg2")
     def test_env_var_activates_local_backend(self, mock_psycopg2):
+        mock_psycopg2.Error = _Psycopg2Error
         mock_psycopg2.connect.return_value = MagicMock(closed=False)
         with patch.dict(os.environ, {"METAPUB_DB_URL": "postgresql://mock/mock"}):
             # Reset Borg state so a fresh instance is created

--- a/tests/test_localfetcher.py
+++ b/tests/test_localfetcher.py
@@ -271,6 +271,28 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         self.assertIn("27022295", results)
         eutils.assert_called_once_with(27022295)
 
+    def test_article_by_pmid_empty_xml_falls_back_to_ncbi(self):
+        """Empty string XML from DB (raises MetaPubError) triggers eutils fallback."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article()
+        backend = _make_backend(fetch_xml_return="")
+        eutils = MagicMock(return_value=ncbi_art)
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIs(art, ncbi_art)
+        eutils.assert_called_once_with("27022295")
+
+    def test_articles_by_pmids_empty_xml_falls_back_to_ncbi(self):
+        """Empty string XML in bulk DB result (raises MetaPubError) triggers eutils fallback."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        ncbi_art = self._make_article("27022295")
+        backend = _make_backend(fetch_xml_many_return={27022295: ""})
+        eutils = MagicMock(return_value=ncbi_art)
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295"])
+        self.assertIn("27022295", results)
+        eutils.assert_called_once_with(27022295)
+
     def test_articles_by_pmids_ncbi_error_returns_partial_results(self):
         """An NCBI service error for one PMID does not abort the whole batch."""
         from metapub.exceptions import MetaPubError

--- a/tests/test_localfetcher.py
+++ b/tests/test_localfetcher.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch, call
 class _Psycopg2Error(Exception):
     """Stub for psycopg2.Error used when psycopg2 is fully mocked."""
 
-# Minimal NLM XML fixture — enough for PubMedArticle to parse
+# Minimal NLM XML fixture — full PubmedArticleSet wrapper (identical to efetch output)
 _NLM_XML = """\
 <?xml version="1.0" ?>
 <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2025//EN"
@@ -59,6 +59,9 @@ _NLM_XML = """\
 </PubmedArticle>
 </PubmedArticleSet>
 """
+
+# Same article without the PubmedArticleSet wrapper — as some DB tools store it
+_NLM_XML_BARE = _NLM_XML.split('<PubmedArticleSet>')[1].rsplit('</PubmedArticleSet>', 1)[0].strip()
 
 
 def _make_backend(fetch_xml_return=None, fetch_xml_many_return=None):
@@ -112,7 +115,7 @@ class TestLocalPubMedBackend(unittest.TestCase):
     @patch("metapub.localfetcher.psycopg2")
     def test_fetch_xml_db_error_returns_none(self, mock_psycopg2):
         from metapub.localfetcher import LocalPubMedBackend
-        mock_psycopg2.Error = _Psycopg2Error
+        mock_psycopg2.OperationalError = _Psycopg2Error
         conn = MagicMock()
         conn.closed = False
         conn.cursor.side_effect = _Psycopg2Error("DB connection failed")
@@ -250,7 +253,7 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         results = articles_by_pmids(["27022295", "99999999"])
         self.assertIn("27022295", results)
         self.assertIn("99999999", results)
-        eutils.assert_called_once_with(99999999)
+        eutils.assert_called_once_with('99999999')
 
     def test_articles_by_pmids_invalid_pmid_raises(self):
         from metapub.localfetcher import make_local_fetcher_methods
@@ -269,7 +272,29 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
         results = articles_by_pmids(["27022295"])
         self.assertIn("27022295", results)
-        eutils.assert_called_once_with(27022295)
+        eutils.assert_called_once_with('27022295')
+
+    def test_article_by_pmid_bare_xml_parses_correctly(self):
+        """Bare <PubmedArticle> XML (no PubmedArticleSet wrapper) parses correctly."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_return=_NLM_XML_BARE)
+        eutils = MagicMock()
+        article_by_pmid, _ = make_local_fetcher_methods(backend, eutils)
+        art = article_by_pmid("27022295")
+        self.assertIsNotNone(art)
+        self.assertEqual(str(art.pmid), "27022295")
+        eutils.assert_not_called()
+
+    def test_articles_by_pmids_bare_xml_parses_correctly(self):
+        """Bare <PubmedArticle> XML in bulk result (no wrapper) parses correctly."""
+        from metapub.localfetcher import make_local_fetcher_methods
+        backend = _make_backend(fetch_xml_many_return={27022295: _NLM_XML_BARE})
+        eutils = MagicMock()
+        _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
+        results = articles_by_pmids(["27022295"])
+        self.assertIn("27022295", results)
+        self.assertEqual(str(results["27022295"].pmid), "27022295")
+        eutils.assert_not_called()
 
     def test_article_by_pmid_empty_xml_falls_back_to_ncbi(self):
         """Empty string XML from DB (raises MetaPubError) triggers eutils fallback."""
@@ -291,7 +316,7 @@ class TestMakeLocalFetcherMethods(unittest.TestCase):
         _, articles_by_pmids = make_local_fetcher_methods(backend, eutils)
         results = articles_by_pmids(["27022295"])
         self.assertIn("27022295", results)
-        eutils.assert_called_once_with(27022295)
+        eutils.assert_called_once_with('27022295')
 
     def test_articles_by_pmids_ncbi_error_returns_partial_results(self):
         """An NCBI service error for one PMID does not abort the whole batch."""


### PR DESCRIPTION
## Summary

- Adds `LocalPubMedBackend` — a PostgreSQL-backed fetcher that looks up articles from a local `pubmed.article` table first, falling back to NCBI eutils on misses
- Write-through caching stores NCBI-fetched XML locally for future lookups
- `PubMedFetcher` automatically activates the local backend when `METAPUB_DB_URL` is set
- Offline unit test suite for the new backend (17 tests, no DB or NCBI required)

## Fixes (from code review)

- **Thread safety**: `LocalPubMedBackend` connection reconnect paths now protected by `threading.Lock`, preventing TOCTOU race under concurrent access
- **Exception specificity**: `except Exception` → `except psycopg2.Error` in all DB methods; XML parse errors now catch `etree.XMLSyntaxError`/`etree.ParserError`
- **Removed redundant nested try/except**: `store_xml` handles its own errors — callers no longer wrap it
- **Wildcard import replaced**: `from .pubmed_clinicalqueries import *` → explicit imports
- **`pmids_for_citation` error handling**: added `requests.RequestException` catch + `raise_for_status()`
- **Dependency version bounds**: minimum versions added to `setup.py` for `setuptools`, `lxml`, `lxml_html_clean`, `requests`, `pyyaml`

## Test plan

- [ ] `pytest -m "not live_network"` — full offline suite passes (637 tests)
- [ ] `pytest tests/test_localfetcher.py` — all 17 localfetcher unit tests pass
- [ ] Manual smoke test with a real PostgreSQL `pubmed.article` table and `METAPUB_DB_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)