### PR TITLE
feat(clinvar): #126: Support ID convenience properties. Fix xref node…

### DIFF
--- a/bin/demo_clinvar.py
+++ b/bin/demo_clinvar.py
@@ -23,6 +23,11 @@ with tempfile.TemporaryDirectory() as tmpdir:
             print(f"  HGVS_p: {var.hgvs_p}")
             print(f"  Location: {var.cytogenic_location}")
             print(f"  Species: {var.species}")
+            print(f"  rs id: {var.rsid}  (all: {var.rsids})")
+            print(f"  dbSNP id: {var.dbsnp_id}  (all: {var.dbsnp_ids})")
+            print(f"  OMIM id: {var.omim_id}  (all: {var.omim_ids})")
+            print(f"  Orphanet id: {var.orphanet_id}  (all: {var.orphanet_ids})")
+            print(f"  MedGen id: {var.medgen_id}  (all: {var.medgen_ids})")
         except Exception as error:
             print(f"  ERROR: {error}")
 

--- a/metapub/clinvarvariant.py
+++ b/metapub/clinvarvariant.py
@@ -2,11 +2,12 @@
 
 import logging
 from datetime import datetime
-
+from typing import Optional
 from lxml import etree
 
 from .base import MetaPubObject
 from .exceptions import MetaPubError, BaseXMLError
+from .types import XRef, XRefDb
 
 #TODO: Logging
 
@@ -32,9 +33,9 @@ class ClinVarVariant(MetaPubObject):
                     else:
                         raise BaseXMLError('No VariationArchive found in VCV format')
             else:
-                # Old format
+                # Old format: VariationReport is the root element itself, not a child to find
                 self._is_vcv_format = False
-                super(ClinVarVariant, self).__init__(xmlstr, 'VariationReport', args, kwargs)
+                super(ClinVarVariant, self).__init__(xmlstr, None, args, kwargs)
                 self.variation_archive = None
         except (etree.XMLSyntaxError, BaseXMLError) as e:
             # If XML parsing fails completely, let it bubble up
@@ -68,7 +69,6 @@ class ClinVarVariant(MetaPubObject):
         self.xrefs = self._get_xref_list()
         self.molecular_consequences = self._get_molecular_consequence_list()
         self.allele_frequencies = self._get_allele_frequency_list()
-
         # Clinical significance and classifications (new in VCV format)
         self.clinical_significance = self._get_clinical_significance()
         self.review_status = self._get_review_status()
@@ -342,21 +342,45 @@ class ClinVarVariant(MetaPubObject):
 
         return hgvs
 
-    def _get_xref_list(self):
-        xrefs = []
+    def _get_xref_list(self) -> list[XRef]:
+        """Return all allele-level ``<XRef>`` elements from this variant's XML.
 
-        if self._is_vcv_format:
-            simple_allele = self.variation_archive.find('ClassifiedRecord/SimpleAllele')
-            if simple_allele is not None:
-                xref_list = simple_allele.find('XRefList')
-                if xref_list is not None:
-                    for elem in xref_list.getchildren():
-                        xrefs.append(dict(elem.items()))
-        else:
-            xref_list = self.content.find('Allele/XRefList')
-            if xref_list is not None:
-                for elem in xref_list.getchildren():
-                    xrefs.append(dict(elem.items()))
+        For VCV-format records, collects ``<XRef>`` nodes from every
+        ``SimpleAllele/XRefList`` regardless of nesting depth — a ``SimpleAllele``
+        may be a direct child of ``ClassifiedRecord`` (simple variants) or nested
+        inside a ``Haplotype`` or ``Genotype`` element (complex variants). Using
+        ``findall('.//SimpleAllele/XRefList')`` ensures xrefs from all constituent
+        alleles are collected rather than only the first one.
+
+        For legacy ``VariationReport`` records (retired April 2019), collects from
+        ``Allele/XRefList`` instead.
+
+        :return: List of :class:`XRef` dicts, one per ``<XRef>`` element found.
+            Returns an empty list when no ``XRefList`` is present.
+        :rtype: list[XRef]
+        """
+        xrefs: list[XRef] = []
+
+        # BG: #126: SimpleAllele may be nested under Haplotype or Genotype for complex variants;
+        # BG: #126: .// ensures we collect rsIDs from all constituent alleles.
+        # BG: #126: Ex)
+        # ClassifiedRecord
+        # └── Haplotype
+        #     ├── SimpleAllele (AlleleID="404202", c.875T>C)
+        #     │   └── XRefList
+        #     │       ├── XRef DB="ClinGen"
+        #     │       ├── XRef Type="rs" ID="1060500602" DB="dbSNP"
+        #     │       └── XRef Type="Interpreted" DB="ClinVar"
+        #     └── SimpleAllele (AlleleID="929246", c.877C>T)
+        #         └── XRefList
+        #             ├── XRef DB="ClinGen"
+        #             ├── XRef Type="rs" ID="2081099943" DB="dbSNP"
+        #             └── XRef Type="Interpreted" DB="ClinVar"
+        path = './/SimpleAllele/XRefList' if self._is_vcv_format else './/Allele/XRefList'
+        for xref_list in self.content.findall(path):
+            for elem in xref_list:
+                xref: XRef = dict(elem.items())
+                xrefs.append(xref)
 
         return xrefs
 
@@ -401,6 +425,178 @@ class ClinVarVariant(MetaPubObject):
                 return []
 
         return freqs
+    
+    @property
+    def rsid(self) -> Optional[str]:
+        """Return the first dbSNP rsID for this variant as a bare numeric string.
+
+        :return: rsID digits (e.g. ``'28934872'``), or ``None`` if no dbSNP xref is present.
+        :rtype: str or None
+        """
+        rsids = self._get_rsids()
+        return rsids[0] if rsids else None
+
+    @property
+    def rsids(self) -> list[str]:
+        """Return all dbSNP rsIDs for this variant as bare numeric strings.
+
+        :return: List of rsID digit strings (e.g. ``['28934872']``), empty list if none.
+        :rtype: list[str]
+        """
+        return self._get_rsids()
+
+    def _get_rsids(self) -> list[str]:
+        """Return all dbSNP xref IDs normalized to bare numeric strings.
+
+        Handles the four ``<XRef DB="dbSNP">`` formats observed in real ClinVar XML:
+        ``Type="rs"``, ``Type="rsNumber"``, ``ID="rs1799945"`` (prefix in ID field),
+        and bare number with no ``Type`` attribute. All are normalized to plain digits
+        (e.g. ``'1799945'``). Deduplication occurs *after* normalization so that
+        ``"1799945"`` and ``"rs1799945"`` collapse to a single entry.
+
+        :return: Deduplicated list of rsID digit strings in first-seen order.
+        :rtype: list[str]
+        """
+
+        # BG: #128: Ensure all rsids are formatted as "<number>"
+        # BG: #128: The following formatted strings have been seen from ClinVar XML data:
+        # <XRef Type="rs" ID="1555371642" DB="dbSNP"/>      Y (Idiomatic)
+        # <XRef Type="rsNumber" ID="1799945" DB="dbSNP"/>  	N (Type mismatch)
+        # <XRef ID="rs1799945" DB="dbSNP"/> 			    N (rs joined to ID)
+        # <XRef ID="1799945" DB="dbSNP"/> 					N (Missing type)
+        # BG: #128: The return type is number as string to maintain consistency in the API surface
+        ids = self._get_xref_ids(XRefDb.DBSNP)
+        rs_prefix = "rs"
+
+        for i, rsid in enumerate(ids):
+            if rsid.startswith(rs_prefix):
+                ids[i] = rsid.removeprefix(rs_prefix)
+
+        # BG: Deduplicate with first-seen order preserved
+        ids_deduped = list(dict.fromkeys(ids))
+
+        return ids_deduped
+    
+    @property
+    def dbsnp_id(self) -> Optional[str]:
+        """Return the first dbSNP ID for this variant. Alias for :attr:`rsid`.
+
+        :return: dbSNP identifier string (e.g. ``'28934872'``), or ``None`` if not present.
+        :rtype: str or None
+        """
+        ids = self._get_rsids()
+        return ids[0] if ids else None
+    
+    @property
+    def dbsnp_ids(self) -> list[str]:
+        """Return all dbSNP IDs for this variant. Alias for :attr:`rsids`.
+
+        :return: List of dbSNP identifier strings, empty list if none.
+        :rtype: list[str]
+        """
+        return self._get_rsids()
+
+    @property
+    def omim_id(self) -> Optional[str]:
+        """Return the first OMIM ID for this variant.
+
+        :return: OMIM identifier string (e.g. ``'191092.0006'``), or ``None`` if not present.
+        :rtype: str or None
+        """
+        omim_ids = self._get_xref_ids(XRefDb.OMIM)
+        return omim_ids[0] if omim_ids else None
+
+    @property
+    def omim_ids(self) -> list[str]:
+        """Return all OMIM IDs for this variant.
+
+        :return: List of OMIM identifier strings, empty list if none.
+        :rtype: list[str]
+        """
+        return self._get_xref_ids(XRefDb.OMIM)
+
+    @property
+    def orphanet_id(self) -> Optional[str]:
+        """Return the first Orphanet ID for this variant.
+
+        .. note::
+            As of ``ClinVarVCVRelease_00-latest.xml.gz`` (scanned 2026-04-19),
+            Orphanet identifiers appear at the condition level (``RCVList``/``TraitSet``),
+            not in ``SimpleAllele/XRefList``, so this property may return ``None``
+            on all current VCV records. Use :attr:`associated_conditions` instead.
+
+        :return: Orphanet identifier string, or ``None`` if not present.
+        :rtype: str or None
+        """
+        orphanet_ids = self._get_xref_ids(XRefDb.ORPHANET)
+        return orphanet_ids[0] if orphanet_ids else None
+
+    @property
+    def orphanet_ids(self) -> list[str]:
+        """Return all Orphanet IDs for this variant.
+
+        .. note::
+            As of ``ClinVarVCVRelease_00-latest.xml.gz`` (scanned 2026-04-19),
+            this may return ``[]`` on all current VCV records. See :attr:`orphanet_id`.
+
+        :return: List of Orphanet identifier strings, empty list if none.
+        :rtype: list[str]
+        """
+        return self._get_xref_ids(XRefDb.ORPHANET)
+
+    @property
+    def medgen_id(self) -> Optional[str]:
+        """Return the first MedGen ID for this variant.
+
+        .. note::
+            As of ``ClinVarVCVRelease_00-latest.xml.gz`` (scanned 2026-04-19),
+            MedGen identifiers appear at the condition level (``RCVList``/``TraitSet``),
+            not in ``SimpleAllele/XRefList``, so this property may return ``None``
+            on all current VCV records. Use :attr:`associated_conditions` instead.
+
+        :return: MedGen identifier string, or ``None`` if not present.
+        :rtype: str or None
+        """
+        medgen_ids = self._get_xref_ids(XRefDb.MEDGEN)
+        return medgen_ids[0] if medgen_ids else None
+
+    @property
+    def medgen_ids(self) -> list[str]:
+        """Return all MedGen IDs for this variant.
+
+        .. note::
+            As of ``ClinVarVCVRelease_00-latest.xml.gz`` (scanned 2026-04-19),
+            this may return ``[]`` on all current VCV records. See :attr:`medgen_id`.
+
+        :return: List of MedGen identifier strings, empty list if none.
+        :rtype: list[str]
+        """
+        return self._get_xref_ids(XRefDb.MEDGEN)
+
+    def _get_xref_ids(self, db_name: str) -> list[str]:
+        """Return allele-level xref IDs for the specified database name.
+
+        Filters :attr:`xrefs` by the ``DB`` attribute, ignoring ``Type`` entirely.
+        Deduplicates with first-seen order preserved via ``dict.fromkeys``.
+
+        :param db_name: Database name to filter on (e.g. ``'dbSNP'``, ``'OMIM'``).
+            Use :class:`XRefDB` constants for safety.
+        :type db_name: str
+        :return: Deduplicated list of ``ID`` strings whose ``DB`` matches *db_name*.
+        :rtype: list[str]
+        """
+        ids: list[str] = []
+
+        # BG: Do not pay attention to "Type", just "DB" attribute.
+        # BG: Ex) <XRef Type="rs" ID="1555371642" DB="dbSNP"/> 
+        for xref in self.xrefs:
+            if xref['DB'] == db_name:
+                ids.append(xref['ID'])
+
+        # BG: Deduplicate with first-seen order preserved
+        ids = list(dict.fromkeys(ids))
+
+        return ids
 
     ### NEW VCV FORMAT ENHANCEMENTS ###
 
@@ -714,5 +910,3 @@ class ClinVarVariant(MetaPubObject):
         return assertions
 
     ### OBSERVATIONS
-
-

--- a/metapub/ncbi_client.py
+++ b/metapub/ncbi_client.py
@@ -362,13 +362,17 @@ class NCBIClient:
         if self.cache:
             cached_response = self.cache.get(url, request_params)
             if cached_response:
+                request_url = f"{url}?{urlencode(request_params)}"
+                log.debug(f"Returning cached response for request: {request_url}")
+
                 return cached_response
         
         # Rate limit
         self.rate_limiter.wait_if_needed()
         
         try:
-            log.debug(f"Making request to {endpoint} with params: {request_params}")
+            request_url = f"{url}?{urlencode(request_params)}"
+            log.debug(f"Making request to: {request_url}")
             response = self.session.get(url, params=request_params, timeout=30)
             response.raise_for_status()
             

--- a/metapub/types.py
+++ b/metapub/types.py
@@ -1,0 +1,56 @@
+"""metapub.types -- shared type definitions used across metapub modules."""
+
+from typing import NotRequired, TypedDict
+from enum import StrEnum
+
+
+class XRefDb(StrEnum):
+    """String enum of ``DB`` attribute values observed in ClinVar ``<XRef>`` nodes.
+
+    Example node: ``<XRef ID="CA390882941" DB="ClinGen"/>``
+
+    Full list at https://www.ncbi.nlm.nih.gov/clinvar/docs/identifiers/
+
+    Use these constants instead of bare strings when filtering
+    :attr:`ClinVarVariant.xrefs <metapub.clinvarvariant.ClinVarVariant.xrefs>`
+    to avoid silent typos (e.g. ``XRefDB.DBSNP`` instead of ``'dbSNP'``).
+    """
+    CLINGEN = 'ClinGen'
+    """ClinGen allele registry identifier."""
+    DBSNP = 'dbSNP'
+    """NCBI dbSNP rsID."""
+    BOOKSHELF = 'BookShelf'
+    """NCBI BookShelf reference."""
+    DBVAR = 'dbVar'
+    """NCBI dbVar structural variant identifier."""
+    GENE = 'Gene'
+    """NCBI Gene identifier."""
+    MEDGEN = 'MedGen'
+    """NCBI MedGen concept identifier (appears at condition level, not allele level)."""
+    PUBMED = 'PubMed'
+    """PubMed article identifier."""
+    PUBMEDCENTRAL = 'PubMedCentral'
+    """PubMed Central article identifier."""
+    OMIM = 'OMIM'
+    """Online Mendelian Inheritance in Man identifier."""
+    ORPHANET = 'Orphanet'
+    """Orphanet rare disease identifier (appears at condition level, not allele level)."""
+
+
+class XRef(TypedDict):
+    """Describes an ``<XRef>`` node parsed from ClinVar XML.
+
+    Example node: ``<XRef Type="rs" ID="1555371642" DB="dbSNP"/>``
+
+    :var ID: The cross-reference identifier (e.g. ``'28934872'``, ``'rs1799945'``).
+    :vartype ID: str
+    :var DB: The source database name (e.g. ``'dbSNP'``, ``'OMIM'``).
+        Full list at https://www.ncbi.nlm.nih.gov/clinvar/docs/identifiers/
+    :vartype DB: str
+    :var Type: Optional sub-type qualifier (e.g. ``'rs'``, ``'rsNumber'``).
+        Absent from some real ClinVar records — always use ``DB`` to identify the source.
+    :vartype Type: str, optional
+    """
+    ID: str
+    DB: str
+    Type: NotRequired[str]

--- a/tests/data/clinvar_old_format_minimal.manifest.txt
+++ b/tests/data/clinvar_old_format_minimal.manifest.txt
@@ -1,0 +1,39 @@
+Source:   Synthetic — hand-authored (old format no longer served by NCBI API)
+Date:     2026-04-18
+Variant:  VariationID=12397 — NM_000548.4(TSC2):c.1832G>A (p.Arg611Gln)
+          (same variant as clinvar_vcv_12000.xml, different format)
+Type:     Old pre-VCV VariationReport format (root tag: VariationReport, allele tag: Allele)
+Purpose:  Tests the _is_vcv_format=False branch of _get_xref_list, which uses
+          the .//Allele/XRefList XPath instead of .//SimpleAllele/XRefList.
+
+Investigation to confirm no real record can be fetched
+-------------------------------------------------------
+
+Step 1 — tried rettype=xml:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=12397&rettype=xml"
+  Result: HTML error page ("Error occurred: cannot get document summary")
+
+Step 2 — tried rettype=variation:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=12397&rettype=variation"
+  Result: explicit deprecation notice —
+    "Variation objects (blobs) are no longer supported. They were replaced by the
+     VCV XML, which you can retrieve using rettype=vcv. See our web release notes
+     from April 2019 (https://ftp.ncbi.nlm.nih.gov/pub/clinvar/release_notes/
+     web_2.0_alpha/20190404WebRelease.pdf) and our documentation on E-utilities
+     for ClinVar (https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/#api)"
+
+Step 3 — tried no rettype:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=12397"
+  Result: bare <IdList><Id>12397</Id></IdList> — no XML record body
+
+Conclusion: The old VariationReport format was retired by NCBI in April 2019. No
+combination of rettype values produces it today. The fixture is synthetic but
+structurally correct, cross-referenced against the known XRef values from the live
+VCV record VCV000012397: rs28934872 (dbSNP) and 191092.0006 (OMIM).
+
+Structure:
+  VariationReport (root — _is_vcv_format=False path)
+  └── Allele (AlleleID=27436)
+      └── XRefList
+          ├── XRef Type="rs" ID="28934872" DB="dbSNP"
+          └── XRef Type="Allelic variant" ID="191092.0006" DB="OMIM"

--- a/tests/data/clinvar_old_format_minimal.xml
+++ b/tests/data/clinvar_old_format_minimal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<VariationReport VariationID="12397" VariationName="NM_000548.4(TSC2):c.1832G>A (p.Arg611Gln)" VariationType="Variant">
+  <GeneList>
+    <Gene Symbol="TSC2" FullName="TSC complex subunit 2" GeneID="7249"/>
+  </GeneList>
+  <Allele AlleleID="27436">
+    <Name>NM_000548.4(TSC2):c.1832G&gt;A (p.Arg611Gln)</Name>
+    <VariantType>single nucleotide variant</VariantType>
+    <XRefList>
+      <XRef Type="rs" ID="28934872" DB="dbSNP"/>
+      <XRef Type="Allelic variant" ID="191092.0006" DB="OMIM"/>
+    </XRefList>
+  </Allele>
+</VariationReport>

--- a/tests/data/clinvar_vcv_4819894_glb1.manifest.txt
+++ b/tests/data/clinvar_vcv_4819894_glb1.manifest.txt
@@ -1,0 +1,29 @@
+Source:   NCBI ClinVar E-utilities (efetch)
+Date:     2026-04-19
+Variant:  VCV004819894 — NM_000404.4(GLB1):c.815G>T (p.Gly272Val)
+Type:     single nucleotide variant
+Purpose:  Real-record evidence that Orphanet and MedGen cross-references appear
+          at the condition level (RCVList, TraitSet), NOT in SimpleAllele/XRefList.
+          Motivates why orphanet_id and medgen_id always return None/[] on real
+          VCV records when using the current _get_xref_ids path.
+
+Fetch command:
+  curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=4819894&rettype=vcv&is_variationid=true" \
+    > clinvar_vcv_4819894_glb1.xml
+
+Orphanet/MedGen XRef locations in this record (confirmed by lxml inspection):
+  RCVList/RCVAccession/ClassifiedConditionList/ClassifiedCondition
+    → DB="MedGen" ID="C0268272"
+
+  Classifications/GermlineClassification/ConditionList/TraitSet/Trait/Name/XRef
+    → DB="Orphanet" ID="79256"
+
+  Classifications/GermlineClassification/ConditionList/TraitSet/Trait/XRef
+    → DB="Orphanet" ID="354"
+    → DB="Orphanet" ID="79256"
+    → DB="MedGen"   ID="C0268272"
+
+  SimpleAllele/XRefList — Orphanet/MedGen: NOT PRESENT
+
+Discovery: record found via esearch text search for "Orphanet[All Fields]", then
+batch-fetched and confirmed Orphanet/MedGen presence. One of 10 candidates checked.

--- a/tests/data/clinvar_vcv_4819894_glb1.xml
+++ b/tests/data/clinvar_vcv_4819894_glb1.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+                        
+<ClinVarResult-Set><VariationArchive VariationID="4819894" VariationName="NM_000404.4(GLB1):c.815G&gt;T (p.Gly272Val)" VariationType="single nucleotide variant" Accession="VCV004819894" Version="1" RecordType="classified" NumberOfSubmissions="1" NumberOfSubmitters="1" DateLastUpdated="2026-04-18" DateCreated="2026-04-13" MostRecentSubmission="2026-04-12">
+  <RecordStatus>current</RecordStatus>
+  <Species>Homo sapiens</Species>
+  <ClassifiedRecord>
+    <SimpleAllele AlleleID="4931002" VariationID="4819894">
+      <GeneList>
+        <Gene Symbol="GLB1" FullName="galactosidase beta 1" GeneID="2720" HGNC_ID="HGNC:4298" Source="submitted" RelationshipType="within single gene">
+          <Location>
+            <CytogeneticLocation>3p22.3</CytogeneticLocation>
+            <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="3" Accession="NC_000003.12" start="32961108" stop="33097146" display_start="32961108" display_stop="33097146" Strand="-"/>
+            <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="3" Accession="NC_000003.11" start="33038099" stop="33138693" display_start="33038099" display_stop="33138693" Strand="-"/>
+          </Location>
+          <OMIM>611458</OMIM>
+          <Haploinsufficiency last_evaluated="2015-03-25" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=GLB1">Gene associated with autosomal recessive phenotype</Haploinsufficiency>
+          <Triplosensitivity last_evaluated="2015-03-25" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=GLB1">No evidence available</Triplosensitivity>
+        </Gene>
+      </GeneList>
+      <Name>NM_000404.4(GLB1):c.815G&gt;T (p.Gly272Val)</Name>
+      <CanonicalSPDI>NC_000003.12:33051981:C:A</CanonicalSPDI>
+      <VariantType>single nucleotide variant</VariantType>
+      <Location>
+        <CytogeneticLocation>3p22.3</CytogeneticLocation>
+        <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" forDisplay="true" AssemblyStatus="current" Chr="3" Accession="NC_000003.12" start="33051982" stop="33051982" display_start="33051982" display_stop="33051982" variantLength="1" positionVCF="33051982" referenceAlleleVCF="C" alternateAlleleVCF="A"/>
+        <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="3" Accession="NC_000003.11" start="33093474" stop="33093474" display_start="33093474" display_stop="33093474" variantLength="1" positionVCF="33093474" referenceAlleleVCF="C" alternateAlleleVCF="A"/>
+      </Location>
+      <ProteinChange>G141V</ProteinChange>
+      <ProteinChange>G242V</ProteinChange>
+      <ProteinChange>G272V</ProteinChange>
+      <ProteinChange>G320V</ProteinChange>
+      <HGVSlist>
+        <HGVS Assembly="GRCh37" Type="genomic, top-level">
+          <NucleotideExpression sequenceAccessionVersion="NC_000003.11" sequenceAccession="NC_000003" sequenceVersion="11" change="g.33093474C&gt;A" Assembly="GRCh37">
+            <Expression>NC_000003.11:g.33093474C&gt;A</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Assembly="GRCh38" Type="genomic, top-level">
+          <NucleotideExpression sequenceAccessionVersion="NC_000003.12" sequenceAccession="NC_000003" sequenceVersion="12" change="g.33051982C&gt;A" Assembly="GRCh38">
+            <Expression>NC_000003.12:g.33051982C&gt;A</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="genomic">
+          <NucleotideExpression sequenceAccessionVersion="NG_009005.1" sequenceAccession="NG_009005" sequenceVersion="1" change="g.50221G&gt;T">
+            <Expression>NG_009005.1:g.50221G&gt;T</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="genomic">
+          <NucleotideExpression sequenceAccessionVersion="NG_009005.2" sequenceAccession="NG_009005" sequenceVersion="2" change="g.50164G&gt;T">
+            <Expression>NG_009005.2:g.50164G&gt;T</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_000404.4" sequenceAccession="NM_000404" sequenceVersion="4" change="c.815G&gt;T" MANESelect="true">
+            <Expression>NM_000404.4:c.815G&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_000395.3" sequenceAccession="NP_000395" sequenceVersion="3" change="p.Gly272Val" singleLetterProteinChange="G272V">
+            <Expression>NP_000395.3:p.Gly272Val</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_001079811.3" sequenceAccession="NM_001079811" sequenceVersion="3" change="c.725G&gt;T">
+            <Expression>NM_001079811.3:c.725G&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_001073279.2" sequenceAccession="NP_001073279" sequenceVersion="2" change="p.Gly242Val" singleLetterProteinChange="G242V">
+            <Expression>NP_001073279.2:p.Gly242Val</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_001135602.3" sequenceAccession="NM_001135602" sequenceVersion="3" change="c.422G&gt;T">
+            <Expression>NM_001135602.3:c.422G&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_001129074.2" sequenceAccession="NP_001129074" sequenceVersion="2" change="p.Gly141Val" singleLetterProteinChange="G141V">
+            <Expression>NP_001129074.2:p.Gly141Val</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_001317040.2" sequenceAccession="NM_001317040" sequenceVersion="2" change="c.959G&gt;T">
+            <Expression>NM_001317040.2:c.959G&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_001303969.2" sequenceAccession="NP_001303969" sequenceVersion="2" change="p.Gly320Val" singleLetterProteinChange="G320V">
+            <Expression>NP_001303969.2:p.Gly320Val</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_001393580.1" sequenceAccession="NM_001393580" sequenceVersion="1" change="c.815G&gt;T">
+            <Expression>NM_001393580.1:c.815G&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_001380509.1" sequenceAccession="NP_001380509" sequenceVersion="1" change="p.Gly272Val" singleLetterProteinChange="G272V">
+            <Expression>NP_001380509.1:p.Gly272Val</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+      </HGVSlist>
+    </SimpleAllele>
+    <RCVList>
+      <RCVAccession Title="NM_000404.4(GLB1):c.815G&gt;T (p.Gly272Val) AND GM1 gangliosidosis type 2" Accession="RCV006647104" Version="1">
+        <ClassifiedConditionList TraitSetID="245">
+          <ClassifiedCondition DB="MedGen" ID="C0268272">GM1 gangliosidosis type 2</ClassifiedCondition>
+        </ClassifiedConditionList>
+        <RCVClassifications>
+          <GermlineClassification>
+            <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+            <Description DateLastEvaluated="2025-10-23" SubmissionCount="1">Likely pathogenic</Description>
+          </GermlineClassification>
+        </RCVClassifications>
+      </RCVAccession>
+    </RCVList>
+    <Classifications>
+      <GermlineClassification DateLastEvaluated="2025-10-23" NumberOfSubmissions="1" NumberOfSubmitters="1" DateCreated="2026-04-13" MostRecentSubmission="2026-04-12">
+        <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+        <Description>Likely pathogenic</Description>
+        <Citation Type="general">
+          <ID Source="PubMed">16941474</ID>
+        </Citation>
+        <ConditionList>
+          <TraitSet ID="245" Type="Disease" ContributesToAggregateClassification="true">
+            <Trait ID="1390" Type="Disease">
+              <Name>
+                <ElementValue Type="Alternate">Gangliosidosis, Generalized GM1, Type 2</ElementValue>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">GANGLIOSIDOSIS, GENERALIZED GM1, JUVENILE TYPE</ElementValue>
+                <XRef Type="MIM" ID="230600" DB="OMIM"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">GANGLIOSIDOSIS, GENERALIZED GM1, TYPE II</ElementValue>
+                <XRef Type="MIM" ID="230600" DB="OMIM"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Preferred">GM1 gangliosidosis type 2</ElementValue>
+                <XRef ID="MONDO:0009261" DB="MONDO"/>
+                <XRef ID="79256" DB="Orphanet"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">GM1-GANGLIOSIDOSIS, TYPE II</ElementValue>
+                <XRef Type="MIM" ID="230600" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="611458.0003" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="611458.0022" DB="OMIM"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">Juvenile GM&gt;1&lt; gangliosidosis</ElementValue>
+                <XRef ID="18756002" DB="SNOMED CT"/>
+              </Name>
+              <AttributeSet>
+                <Attribute Type="keyword">GLB1-Related Disorders</Attribute>
+              </AttributeSet>
+              <AttributeSet>
+                <Attribute Type="public definition">GLB1-related disorders comprise two phenotypically distinct lysosomal storage disorders: GM1 gangliosidosis and mucopolysaccharidosis type IVB (MPS IVB). The phenotype of GM1 gangliosidosis constitutes a spectrum ranging from severe (infantile) to intermediate (late-infantile and juvenile) to mild (chronic/adult). Type I (infantile) GM1 gangliosidosis begins before age 12 months. Prenatal manifestations may include nonimmune hydrops fetalis, intrauterine growth restriction, and placental vacuolization; congenital dermal melanocytosis (Mongolian spots) may be observed. Macular cherry-red spot is detected on eye exam. Progressive central nervous system dysfunction leads to spasticity and rapid regression; blindness, deafness, decerebrate rigidity, seizures, feeding difficulties, and oral secretions are observed. Life expectancy is two to three years. Type II can be subdivided into the late-infantile (onset age 1-3 years) and juvenile (onset age 3-10 years) phenotypes. Central nervous system dysfunction manifests as progressive cognitive, motor, and speech decline as measured by psychometric testing. There may be mild corneal clouding, hepatosplenomegaly, and/or cardiomyopathy; the typical course is characterized by progressive neurologic decline, progressive skeletal disease in some individuals (including kyphosis and avascular necrosis of the femoral heads), and progressive feeding difficulties leading to aspiration risk. Type III begins in late childhood to the third decade with generalized dystonia leading to unsteady gait and speech disturbance followed by extrapyramidal signs including akinetic-rigid parkinsonism. Cardiomyopathy develops in some and skeletal involvement occurs in most. Intellectual impairment is common late in the disease with prognosis directly related to the degree of neurologic impairment. MPS IVB is characterized by skeletal dysplasia with specific findings of axial and appendicular dysostosis multiplex, short stature (below 15th centile in adults), kyphoscoliosis, coxa/genu valga, joint laxity, platyspondyly, and odontoid hypoplasia. First signs and symptoms may be apparent at birth. Bony involvement is progressive, with more than 84% of adults requiring ambulation aids; life span does not appear to be limited. Corneal clouding is detected in some individuals and cardiac valvular disease may develop.</Attribute>
+                <XRef ID="NBK164500" DB="GeneReviews"/>
+              </AttributeSet>
+              <AttributeSet>
+                <Attribute Type="GARD id" integerValue="10126"/>
+                <XRef ID="10126" DB="Office of Rare Diseases"/>
+              </AttributeSet>
+              <Citation Type="review" Abbrev="GeneReviews">
+                <ID Source="PubMed">24156116</ID>
+                <ID Source="BookShelf">NBK164500</ID>
+              </Citation>
+              <XRef ID="354" DB="Orphanet"/>
+              <XRef ID="79256" DB="Orphanet"/>
+              <XRef ID="C0268272" DB="MedGen"/>
+              <XRef ID="MONDO:0009261" DB="MONDO"/>
+              <XRef Type="MIM" ID="230600" DB="OMIM"/>
+              <Comment DataSource="NCBI curation" Type="public">REVIEWED: Set the orphanet value to preferred to avoid the annotation for the subscript</Comment>
+            </Trait>
+          </TraitSet>
+        </ConditionList>
+      </GermlineClassification>
+    </Classifications>
+    <ClinicalAssertionList>
+      <ClinicalAssertion ID="14398006" SubmissionDate="2026-03-17" ContributesToAggregateClassification="true" DateLastUpdated="2026-04-12" DateCreated="2026-04-12">
+        <ClinVarSubmissionID localKey="3-33051982-C-A|OMIM:230600" submittedAssembly="GRCh38"/>
+        <ClinVarAccession Accession="SCV007540044" DateUpdated="2026-04-12" DateCreated="2026-04-12" Type="SCV" Version="1" SubmitterName="3billion" OrgID="507830" OrganizationCategory="other" OrgAbbreviation="3billion"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification DateLastEvaluated="2025-10-23">
+          <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+          <GermlineClassification>Likely pathogenic</GermlineClassification>
+          <Citation>
+            <ID Source="PubMed">16941474</ID>
+          </Citation>
+          <Comment Type="public">The variant is not observed in the gnomAD v4.1.0 dataset. Predicted Consequence/Location: Missense variant In silico tool predictions suggest damaging effect of the variant on gene or gene product [REVEL: 0.97 (&gt;=0.6, sensitivity 0.68 and specificity 0.92); 3Cnet: 0.99 (&gt; 0.75, sensitivity 0.96 and precision 0.92)]. A different missense change at the same codon (p.Gly272Asp) has been reported to be associated with GLB1-related disorder (PMID: 16941474). Therefore, this variant is classified as Likely pathogenic (PM2_M, PM3_M, PM5_P, PP3_P) according to the recommendation of ACMG/AMP guideline.</Comment>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <AttributeSet>
+          <Attribute Type="AssertionMethod">ACMG Guidelines, 2015</Attribute>
+          <Citation>
+            <ID Source="PubMed">25741868</ID>
+          </Citation>
+        </AttributeSet>
+        <ObservedInList>
+          <ObservedIn>
+            <Sample>
+              <Origin>germline</Origin>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>yes</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>genome sequencing</Description>
+              <MethodType>clinical testing</MethodType>
+            </Method>
+            <ObservedData>
+              <Attribute Type="Description">not provided</Attribute>
+            </ObservedData>
+          </ObservedIn>
+        </ObservedInList>
+        <SimpleAllele>
+          <GeneList>
+            <Gene Symbol="GLB1"/>
+          </GeneList>
+          <VariantType>Variation</VariantType>
+          <AttributeSet>
+            <Attribute Type="HGVS">NM_000404.4:c.815G&gt;T</Attribute>
+          </AttributeSet>
+        </SimpleAllele>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <XRef DB="OMIM" ID="230600" Type="MIM"/>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16054657</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+    </ClinicalAssertionList>
+    <TraitMappingList>
+      <TraitMapping ClinicalAssertionID="14398006" TraitType="Disease" MappingType="XRef" MappingValue="230600" MappingRef="OMIM">
+        <MedGen CUI="C0268272" Name="GM1 gangliosidosis type 2"/>
+      </TraitMapping>
+    </TraitMappingList>
+  </ClassifiedRecord>
+</VariationArchive>
+</ClinVarResult-Set>

--- a/tests/data/clinvar_vcv_genotype_minimal.manifest.txt
+++ b/tests/data/clinvar_vcv_genotype_minimal.manifest.txt
@@ -1,0 +1,66 @@
+Source:   Synthetic — hand-authored (no real NCBI record exists in current VCV format)
+Date:     2026-04-18
+Variant:  VCV000999001 (fictional) — NM_000001.1(GENE1):c.[100A>G];[200C>T]
+Type:     Genotype (two SimpleAllele elements under ClassifiedRecord/Genotype)
+Purpose:  Tests that _get_xref_list collects XRefs from SimpleAlleles nested under
+          a Genotype element (same .//SimpleAllele/XRefList XPath as Haplotype).
+
+Investigation to confirm no real Genotype-type VCV record can be fetched
+-------------------------------------------------------------------------
+
+Step 1 — tried esearch with VariationType field:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=genotype[VariationType]&retmax=5"
+  Result: FieldNotFound for "VariationType"; fell back to all-fields text match;
+          returned SNV records (e.g., TERT VCV004819006) not Genotype-type records.
+
+Step 2 — tried esearch with vtype field:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=Genotype[vtype]&retmax=5"
+  Result: FieldNotFound for "vtype"; same all-fields fallback to 5,614 text matches.
+
+Step 3 — tried "variation type:Genotype" phrase:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=%22variation+type%3AGenotype%22&retmax=5"
+  Result: 0 results, PhraseNotFound.
+
+Step 4 — tried "Compound heterozygote"[Variant type]:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=%22Compound+heterozygote%22%5BVariant+type%5D&retmax=5"
+  Result: FieldNotFound for "Variant type"; fell back to all-fields; returned 525
+          text matches. Fetched top 5 IDs — all VariationType="single nucleotide variant".
+
+Step 5 — tried "Compound heterozygous" text search (50 results):
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=%22Compound+heterozygous%22&retmax=50"
+  Batch-fetched all 50 via efetch with rettype=vcv&is_variationid=true.
+  Result: zero records with VariationType="Genotype"; all were SNV/Deletion/Duplication.
+
+Step 6 — tried CFTR gene + compound heterozygous (classic disease model):
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=CFTR%5Bgene%5D+AND+%22compound+heterozygous%22&retmax=10"
+  Returned 10 IDs; fetched all — VariationTypes were "single nucleotide variant",
+  "Deletion", "Duplication". None were Genotype-type.
+
+Step 7 — scanned ClinVar FTP variant_summary.txt (first ~2MB):
+  curl --range 0-2000000 "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz" | gunzip | awk ...
+  Result: Type column values observed: single nucleotide variant, Deletion,
+          Duplication, Microsatellite, Indel, Insertion, Variation, Inversion,
+          Translocation, Complex, copy number gain. No "Genotype" type present.
+
+Step 8 — scanned ClinVar full VCV XML release (first 100MB):
+  curl --range 0-100000000 "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/ClinVarVCVRelease_00-latest.xml.gz" | gunzip | grep 'VariationType='
+  Result: ~113K records across 15 VariationType values observed:
+    single nucleotide variant (54320), Deletion (15693), copy number gain (14427),
+    copy number loss (11811), Duplication (9545), Microsatellite (4620),
+    Insertion (1318), Indel (897), Variation (228), Translocation (61),
+    Inversion (49), Haplotype (12), Complex (6), fusion (4), protein only (3).
+  VariationType="Genotype" does not appear.
+
+Conclusion: VariationType="Genotype" does not exist in the current ClinVar VCV XML
+format. It was a type in the legacy VariationReport format (retired April 2019) that
+was not carried over when NCBI migrated to VCV. The code path being tested exists for
+backwards compatibility with pre-2019 cached XML. This synthetic fixture is the only
+way to exercise it.
+
+Structure:
+  ClinVarResult-Set
+  └── VariationArchive (VariationType="Genotype")
+      └── ClassifiedRecord
+          └── Genotype
+              ├── SimpleAllele (AlleleID=111001) — XRefList: dbSNP + OMIM
+              └── SimpleAllele (AlleleID=111002) — XRefList: dbSNP only

--- a/tests/data/clinvar_vcv_genotype_minimal.xml
+++ b/tests/data/clinvar_vcv_genotype_minimal.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ClinVarResult-Set>
+  <VariationArchive VariationID="999001" VariationName="NM_000001.1(GENE1):c.[100A>G];[200C>T]" VariationType="Genotype" Accession="VCV000999001" Version="1" RecordType="classified" NumberOfSubmissions="1" NumberOfSubmitters="1" DateLastUpdated="2024-01-01" DateCreated="2024-01-01" MostRecentSubmission="2024-01-01">
+    <RecordStatus>current</RecordStatus>
+    <Species>Homo sapiens</Species>
+    <ClassifiedRecord>
+      <Genotype VariationID="999001">
+        <SimpleAllele AlleleID="111001" VariationID="999002">
+          <GeneList>
+            <Gene Symbol="GENE1" FullName="Gene 1" GeneID="11111" HGNC_ID="HGNC:11111" Source="submitted" RelationshipType="within single gene"/>
+          </GeneList>
+          <Name>NM_000001.1(GENE1):c.100A&gt;G (p.Thr34Ala)</Name>
+          <VariantType>single nucleotide variant</VariantType>
+          <XRefList>
+            <XRef Type="rs" ID="111111111" DB="dbSNP"/>
+            <XRef Type="Allelic variant" ID="100001.0001" DB="OMIM"/>
+          </XRefList>
+        </SimpleAllele>
+        <SimpleAllele AlleleID="111002" VariationID="999003">
+          <GeneList>
+            <Gene Symbol="GENE1" FullName="Gene 1" GeneID="11111" HGNC_ID="HGNC:11111" Source="submitted" RelationshipType="within single gene"/>
+          </GeneList>
+          <Name>NM_000001.1(GENE1):c.200C&gt;T (p.Ala67Val)</Name>
+          <VariantType>single nucleotide variant</VariantType>
+          <XRefList>
+            <XRef Type="rs" ID="222222222" DB="dbSNP"/>
+          </XRefList>
+        </SimpleAllele>
+      </Genotype>
+    </ClassifiedRecord>
+  </VariationArchive>
+</ClinVarResult-Set>

--- a/tests/data/clinvar_vcv_haplotype_kcnq2.manifest.txt
+++ b/tests/data/clinvar_vcv_haplotype_kcnq2.manifest.txt
@@ -1,0 +1,13 @@
+Source:   NCBI ClinVar E-utilities (efetch)
+Date:     2026-04-18
+Variant:  VCV004818726 — NM_172107.4(KCNQ2):c.[875T>C;877C>T]
+Type:     Haplotype (two SimpleAllele elements under ClassifiedRecord/Haplotype)
+Purpose:  Tests that _get_xref_list collects XRefs from all constituent SimpleAlleles,
+          not just the first one (guards against find() vs findall() regression).
+
+Fetch command:
+  curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=4818726&rettype=vcv&is_variationid=true" \
+    > clinvar_vcv_haplotype_kcnq2.xml
+
+Discovery command (used to find a haplotype Variation ID):
+  curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=haplotype[variant+type]&retmax=5"

--- a/tests/data/clinvar_vcv_haplotype_kcnq2.xml
+++ b/tests/data/clinvar_vcv_haplotype_kcnq2.xml
@@ -1,0 +1,696 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+                        
+<ClinVarResult-Set><VariationArchive VariationID="4818726" VariationName="NM_172107.4(KCNQ2):c.[875T&gt;C;877C&gt;T]" VariationType="Haplotype" Accession="VCV004818726" Version="1" RecordType="classified" NumberOfSubmissions="5" NumberOfSubmitters="1" DateLastUpdated="2026-04-13" DateCreated="2026-04-04" MostRecentSubmission="2026-04-04">
+  <RecordStatus>current</RecordStatus>
+  <Species>Homo sapiens</Species>
+  <ClassifiedRecord>
+    <Haplotype VariationID="4818726" NumberOfChromosomes="1">
+      <SimpleAllele AlleleID="404202" VariationID="405208">
+        <GeneList>
+          <Gene Symbol="KCNQ2" FullName="potassium voltage-gated channel subfamily Q member 2" GeneID="3785" HGNC_ID="HGNC:6296" Source="submitted" RelationshipType="within single gene">
+            <Location>
+              <CytogeneticLocation>20q13.33</CytogeneticLocation>
+              <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="20" Accession="NC_000020.11" start="63400208" stop="63472655" display_start="63400208" display_stop="63472655" Strand="-"/>
+              <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="20" Accession="NT_187625.1" start="183" stop="33239" display_start="183" display_stop="33239" Strand="-"/>
+              <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="20" Accession="NC_000020.10" start="62037541" stop="62103992" display_start="62037541" display_stop="62103992" Strand="-"/>
+            </Location>
+            <OMIM>602235</OMIM>
+            <Haploinsufficiency last_evaluated="2013-07-18" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=KCNQ2">Sufficient evidence for dosage pathogenicity</Haploinsufficiency>
+            <Triplosensitivity last_evaluated="2013-07-18" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=KCNQ2">No evidence available</Triplosensitivity>
+          </Gene>
+        </GeneList>
+        <Name>NM_172107.4(KCNQ2):c.875T&gt;C (p.Leu292Pro)</Name>
+        <CanonicalSPDI>NC_000020.11:63439649:A:G</CanonicalSPDI>
+        <VariantType>single nucleotide variant</VariantType>
+        <Location>
+          <CytogeneticLocation>20q13.33</CytogeneticLocation>
+          <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" forDisplay="true" AssemblyStatus="current" Chr="20" Accession="NC_000020.11" start="63439650" stop="63439650" display_start="63439650" display_stop="63439650" variantLength="1" positionVCF="63439650" referenceAlleleVCF="A" alternateAlleleVCF="G"/>
+          <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="20" Accession="NC_000020.10" start="62071003" stop="62071003" display_start="62071003" display_stop="62071003" variantLength="1" positionVCF="62071003" referenceAlleleVCF="A" alternateAlleleVCF="G"/>
+        </Location>
+        <ProteinChange>L292P</ProteinChange>
+        <HGVSlist>
+          <HGVS Assembly="GRCh37" Type="genomic, top-level">
+            <NucleotideExpression sequenceAccessionVersion="NC_000020.10" sequenceAccession="NC_000020" sequenceVersion="10" change="g.62071003A&gt;G" Assembly="GRCh37">
+              <Expression>NC_000020.10:g.62071003A&gt;G</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Assembly="GRCh38" Type="genomic, top-level">
+            <NucleotideExpression sequenceAccessionVersion="NC_000020.11" sequenceAccession="NC_000020" sequenceVersion="11" change="g.63439650A&gt;G" Assembly="GRCh38">
+              <Expression>NC_000020.11:g.63439650A&gt;G</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Type="genomic">
+            <NucleotideExpression sequenceAccessionVersion="NG_009004.2" sequenceAccession="NG_009004" sequenceVersion="2" change="g.37991T&gt;C">
+              <Expression>NG_009004.2:g.37991T&gt;C</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_004518.6" sequenceAccession="NM_004518" sequenceVersion="6" change="c.875T&gt;C">
+              <Expression>NM_004518.6:c.875T&gt;C</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_004509.2" sequenceAccession="NP_004509" sequenceVersion="2" change="p.Leu292Pro" singleLetterProteinChange="L292P">
+              <Expression>NP_004509.2:p.Leu292Pro</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172106.3" sequenceAccession="NM_172106" sequenceVersion="3" change="c.875T&gt;C">
+              <Expression>NM_172106.3:c.875T&gt;C</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742104.1" sequenceAccession="NP_742104" sequenceVersion="1" change="p.Leu292Pro" singleLetterProteinChange="L292P">
+              <Expression>NP_742104.1:p.Leu292Pro</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172107.4" sequenceAccession="NM_172107" sequenceVersion="4" change="c.875T&gt;C" MANESelect="true">
+              <Expression>NM_172107.4:c.875T&gt;C</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742105.1" sequenceAccession="NP_742105" sequenceVersion="1" change="p.Leu292Pro" singleLetterProteinChange="L292P">
+              <Expression>NP_742105.1:p.Leu292Pro</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172108.5" sequenceAccession="NM_172108" sequenceVersion="5" change="c.875T&gt;C">
+              <Expression>NM_172108.5:c.875T&gt;C</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742106.1" sequenceAccession="NP_742106" sequenceVersion="1" change="p.Leu292Pro" singleLetterProteinChange="L292P">
+              <Expression>NP_742106.1:p.Leu292Pro</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172109.3" sequenceAccession="NM_172109" sequenceVersion="3" change="c.875T&gt;C">
+              <Expression>NM_172109.3:c.875T&gt;C</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742107.1" sequenceAccession="NP_742107" sequenceVersion="1" change="p.Leu292Pro" singleLetterProteinChange="L292P">
+              <Expression>NP_742107.1:p.Leu292Pro</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+        </HGVSlist>
+        <Classifications>
+          <GermlineClassification DateLastEvaluated="2025-06-09" DateCreated="2017-04-13" MostRecentSubmission="2026-02-10" NumberOfSubmissions="2" NumberOfSubmitters="2">
+            <ReviewStatus>criteria provided, multiple submitters, no conflicts</ReviewStatus>
+            <Description>Pathogenic/Likely pathogenic</Description>
+            <Citation Type="general">
+              <ID Source="PubMed">29644095</ID>
+            </Citation>
+            <Citation Type="general">
+              <ID Source="PubMed">29655203</ID>
+            </Citation>
+            <DescriptionHistory Dated="2026-02-10">
+              <Description>Likely pathogenic</Description>
+            </DescriptionHistory>
+            <DescriptionHistory Dated="2020-07-15">
+              <Description>Conflicting classifications of pathogenicity</Description>
+            </DescriptionHistory>
+            <DescriptionHistory Dated="2019-10-18">
+              <Description>Uncertain significance</Description>
+            </DescriptionHistory>
+            <ConditionList>
+              <TraitSet ID="105574" Type="Disease" ContributesToAggregateClassification="true">
+                <Trait ID="78150" Type="Disease">
+                  <Name>
+                    <ElementValue Type="Alternate">Ohtahara syndrome</ElementValue>
+                    <XRef ID="1934" DB="Orphanet"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">Early infantile epileptic encephalopathy with suppression bursts</ElementValue>
+                    <XRef ID="230429005" DB="SNOMED CT"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">Early infantile epileptic encephalopathy</ElementValue>
+                    <XRef ID="1934" DB="Orphanet"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Preferred">Early-infantile DEE</ElementValue>
+                    <XRef ID="MONDO:0800491" DB="MONDO"/>
+                  </Name>
+                  <AttributeSet>
+                    <Attribute Type="GARD id" integerValue="27299"/>
+                    <XRef ID="27299" DB="Office of Rare Diseases"/>
+                  </AttributeSet>
+                  <XRef ID="1934" DB="Orphanet"/>
+                  <XRef ID="C0393706" DB="MedGen"/>
+                  <XRef ID="MONDO:0800491" DB="MONDO"/>
+                </Trait>
+              </TraitSet>
+              <TraitSet ID="6737" Type="Disease" ContributesToAggregateClassification="true">
+                <Trait ID="15768" Type="Disease">
+                  <Name>
+                    <ElementValue Type="Alternate">Early infantile epileptic encephalopathy 7</ElementValue>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Preferred">Developmental and epileptic encephalopathy, 7</ElementValue>
+                    <XRef ID="MONDO:0013387" DB="MONDO"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">KCNQ2-Related Neonatal Epileptic Encephalopathy</ElementValue>
+                  </Name>
+                  <Symbol>
+                    <ElementValue Type="Preferred">DEE7</ElementValue>
+                    <XRef Type="MIM" ID="613720" DB="OMIM"/>
+                  </Symbol>
+                  <AttributeSet>
+                    <Attribute Type="public definition">KCNQ2-related disorders represent a continuum of overlapping neonatal epileptic phenotypes ranging from self-limited familial neonatal epilepsy (SLFNE) at the mild end to neonatal-onset developmental and epileptic encephalopathy (NEO-DEE) at the severe end. Additional, less common phenotypes consisting of neonatal encephalopathy with non-epileptic myoclonus, infantile or childhood-onset developmental and epileptic encephalopathy (DEE), and isolated intellectual disability (ID) without epilepsy have also been described. KCNQ2-SLFNE is characterized by seizures that start in otherwise healthy infants between two and eight days after term birth and spontaneously disappear between the first and the sixth to 12th month of life. There is always a seizure-free interval between birth and the onset of seizures. Seizures are characterized by sudden onset with prominent motor involvement, often accompanied by apnea and cyanosis; video EEG identifies seizures as focal onset with tonic stiffening of limb(s) and some migration during each seizure's evolution. About 30% of individuals with KCNQ2-SLFNE develop epileptic seizures later in life. KCNQ2-NEO-DEE is characterized by multiple daily seizures beginning in the first week of life that are mostly tonic, with associated focal motor and autonomic features. Seizures generally cease between ages nine months and four years. At onset, EEG shows a burst-suppression pattern or multifocal epileptiform activity; early brain MRI can show basal ganglia hyperdensities and later MRIs may show white matter or general volume loss. Moderate-to-profound developmental impairment is present.</Attribute>
+                    <XRef ID="NBK32534" DB="GeneReviews"/>
+                  </AttributeSet>
+                  <AttributeSet>
+                    <Attribute Type="GARD id" integerValue="13060"/>
+                    <XRef ID="13060" DB="Office of Rare Diseases"/>
+                  </AttributeSet>
+                  <AttributeSet>
+                    <Attribute Type="keyword">KCNQ2-Related Disorders</Attribute>
+                  </AttributeSet>
+                  <Citation Type="review" Abbrev="GeneReviews">
+                    <ID Source="PubMed">20437616</ID>
+                    <ID Source="BookShelf">NBK32534</ID>
+                  </Citation>
+                  <XRef ID="439218" DB="Orphanet"/>
+                  <XRef ID="C3150986" DB="MedGen"/>
+                  <XRef ID="MONDO:0013387" DB="MONDO"/>
+                  <XRef Type="MIM" ID="613720" DB="OMIM"/>
+                </Trait>
+              </TraitSet>
+            </ConditionList>
+          </GermlineClassification>
+        </Classifications>
+        <XRefList>
+          <XRef ID="CA16616483" DB="ClinGen"/>
+          <XRef Type="rs" ID="1060500602" DB="dbSNP"/>
+          <XRef Type="Interpreted" ID="4818726" DB="ClinVar"/>
+        </XRefList>
+      </SimpleAllele>
+      <SimpleAllele AlleleID="929246" VariationID="948377">
+        <GeneList>
+          <Gene Symbol="KCNQ2" FullName="potassium voltage-gated channel subfamily Q member 2" GeneID="3785" HGNC_ID="HGNC:6296" Source="submitted" RelationshipType="within single gene">
+            <Location>
+              <CytogeneticLocation>20q13.33</CytogeneticLocation>
+              <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="20" Accession="NC_000020.11" start="63400208" stop="63472655" display_start="63400208" display_stop="63472655" Strand="-"/>
+              <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="20" Accession="NT_187625.1" start="183" stop="33239" display_start="183" display_stop="33239" Strand="-"/>
+              <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="20" Accession="NC_000020.10" start="62037541" stop="62103992" display_start="62037541" display_stop="62103992" Strand="-"/>
+            </Location>
+            <OMIM>602235</OMIM>
+            <Haploinsufficiency last_evaluated="2013-07-18" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=KCNQ2">Sufficient evidence for dosage pathogenicity</Haploinsufficiency>
+            <Triplosensitivity last_evaluated="2013-07-18" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=KCNQ2">No evidence available</Triplosensitivity>
+          </Gene>
+        </GeneList>
+        <Name>NM_172107.4(KCNQ2):c.877C&gt;T (p.Leu293Phe)</Name>
+        <CanonicalSPDI>NC_000020.11:63439647:G:A</CanonicalSPDI>
+        <VariantType>single nucleotide variant</VariantType>
+        <Location>
+          <CytogeneticLocation>20q13.33</CytogeneticLocation>
+          <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" forDisplay="true" AssemblyStatus="current" Chr="20" Accession="NC_000020.11" start="63439648" stop="63439648" display_start="63439648" display_stop="63439648" variantLength="1" positionVCF="63439648" referenceAlleleVCF="G" alternateAlleleVCF="A"/>
+          <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="20" Accession="NC_000020.10" start="62071001" stop="62071001" display_start="62071001" display_stop="62071001" variantLength="1" positionVCF="62071001" referenceAlleleVCF="G" alternateAlleleVCF="A"/>
+        </Location>
+        <ProteinChange>L293F</ProteinChange>
+        <HGVSlist>
+          <HGVS Assembly="GRCh37" Type="genomic, top-level">
+            <NucleotideExpression sequenceAccessionVersion="NC_000020.10" sequenceAccession="NC_000020" sequenceVersion="10" change="g.62071001G&gt;A" Assembly="GRCh37">
+              <Expression>NC_000020.10:g.62071001G&gt;A</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Assembly="GRCh38" Type="genomic, top-level">
+            <NucleotideExpression sequenceAccessionVersion="NC_000020.11" sequenceAccession="NC_000020" sequenceVersion="11" change="g.63439648G&gt;A" Assembly="GRCh38">
+              <Expression>NC_000020.11:g.63439648G&gt;A</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Type="genomic">
+            <NucleotideExpression sequenceAccessionVersion="NG_009004.2" sequenceAccession="NG_009004" sequenceVersion="2" change="g.37993C&gt;T">
+              <Expression>NG_009004.2:g.37993C&gt;T</Expression>
+            </NucleotideExpression>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_001382235.1" sequenceAccession="NM_001382235" sequenceVersion="1" change="c.877C&gt;T">
+              <Expression>NM_001382235.1:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_001369164.1" sequenceAccession="NP_001369164" sequenceVersion="1" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_001369164.1:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_004518.6" sequenceAccession="NM_004518" sequenceVersion="6" change="c.877C&gt;T">
+              <Expression>NM_004518.6:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_004509.2" sequenceAccession="NP_004509" sequenceVersion="2" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_004509.2:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172106.3" sequenceAccession="NM_172106" sequenceVersion="3" change="c.877C&gt;T">
+              <Expression>NM_172106.3:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742104.1" sequenceAccession="NP_742104" sequenceVersion="1" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_742104.1:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172107.4" sequenceAccession="NM_172107" sequenceVersion="4" change="c.877C&gt;T" MANESelect="true">
+              <Expression>NM_172107.4:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742105.1" sequenceAccession="NP_742105" sequenceVersion="1" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_742105.1:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172108.5" sequenceAccession="NM_172108" sequenceVersion="5" change="c.877C&gt;T">
+              <Expression>NM_172108.5:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742106.1" sequenceAccession="NP_742106" sequenceVersion="1" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_742106.1:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+          <HGVS Type="coding">
+            <NucleotideExpression sequenceAccessionVersion="NM_172109.3" sequenceAccession="NM_172109" sequenceVersion="3" change="c.877C&gt;T">
+              <Expression>NM_172109.3:c.877C&gt;T</Expression>
+            </NucleotideExpression>
+            <ProteinExpression sequenceAccessionVersion="NP_742107.1" sequenceAccession="NP_742107" sequenceVersion="1" change="p.Leu293Phe" singleLetterProteinChange="L293F">
+              <Expression>NP_742107.1:p.Leu293Phe</Expression>
+            </ProteinExpression>
+            <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+          </HGVS>
+        </HGVSlist>
+        <Classifications>
+          <GermlineClassification DateLastEvaluated="2025-06-09" DateCreated="2020-07-12" MostRecentSubmission="2026-02-10" NumberOfSubmissions="1" NumberOfSubmitters="1">
+            <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+            <Description>Uncertain significance</Description>
+            <Citation Type="general">
+              <ID Source="PubMed">29655203</ID>
+            </Citation>
+            <ConditionList>
+              <TraitSet ID="105574" Type="Disease" ContributesToAggregateClassification="true">
+                <Trait ID="78150" Type="Disease">
+                  <Name>
+                    <ElementValue Type="Preferred">Early-infantile DEE</ElementValue>
+                    <XRef ID="MONDO:0800491" DB="MONDO"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">Early infantile epileptic encephalopathy</ElementValue>
+                    <XRef ID="1934" DB="Orphanet"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">Ohtahara syndrome</ElementValue>
+                    <XRef ID="1934" DB="Orphanet"/>
+                  </Name>
+                  <Name>
+                    <ElementValue Type="Alternate">Early infantile epileptic encephalopathy with suppression bursts</ElementValue>
+                    <XRef ID="230429005" DB="SNOMED CT"/>
+                  </Name>
+                  <AttributeSet>
+                    <Attribute Type="GARD id" integerValue="27299"/>
+                    <XRef ID="27299" DB="Office of Rare Diseases"/>
+                  </AttributeSet>
+                  <XRef ID="1934" DB="Orphanet"/>
+                  <XRef ID="C0393706" DB="MedGen"/>
+                  <XRef ID="MONDO:0800491" DB="MONDO"/>
+                </Trait>
+              </TraitSet>
+            </ConditionList>
+          </GermlineClassification>
+        </Classifications>
+        <XRefList>
+          <XRef ID="CA409652590" DB="ClinGen"/>
+          <XRef Type="rs" ID="2081099943" DB="dbSNP"/>
+          <XRef Type="Interpreted" ID="4818726" DB="ClinVar"/>
+        </XRefList>
+      </SimpleAllele>
+      <Name>NM_172107.4(KCNQ2):c.[875T&gt;C;877C&gt;T]</Name>
+      <VariationType>Haplotype</VariationType>
+      <HGVSlist>
+        <HGVS Type="coding">
+          <NucleotideExpression MANESelect="true">
+            <Expression>NM_172107.4:c.[875T&gt;C;877C&gt;T]</Expression>
+          </NucleotideExpression>
+        </HGVS>
+      </HGVSlist>
+    </Haplotype>
+    <RCVList>
+      <RCVAccession Title="NM_172107.4(KCNQ2):c.[875T&gt;C;877C&gt;T] AND not provided" Accession="RCV006645436" Version="1">
+        <ClassifiedConditionList TraitSetID="9460">
+          <ClassifiedCondition DB="MedGen" ID="C3661900">not provided</ClassifiedCondition>
+        </ClassifiedConditionList>
+        <RCVClassifications>
+          <NoClassification>
+            <ReviewStatus>no classification provided</ReviewStatus>
+            <Description SubmissionCount="5">evidence_only</Description>
+          </NoClassification>
+        </RCVClassifications>
+      </RCVAccession>
+    </RCVList>
+    <Classifications>
+      <NoClassification DateCreated="2026-03-30" MostRecentSubmission="2026-04-01" NumberOfSubmissions="5" NumberOfSubmitters="1">
+        <ReviewStatus>no classification provided</ReviewStatus>
+        <Description>evidence_only</Description>
+        <ConditionList>
+          <TraitSet ID="9460" Type="Disease" ContributesToAggregateClassification="false">
+            <Trait ID="17556" Type="Disease">
+              <Name>
+                <ElementValue Type="Preferred">not provided</ElementValue>
+                <XRef ID="13DG0619" DB="Genomic Medicine Center of Excellence, King Faisal Specialist Hospital and Research Centre"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">none provided</ElementValue>
+              </Name>
+              <AttributeSet>
+                <Attribute Type="public definition">The term 'not provided' is registered in MedGen to support identification of submissions to ClinVar for which no condition was named when assessing the variant. 'not provided' differs from 'not specified', which is used when a variant is asserted to be benign, likely benign, or of uncertain significance for conditions that have not been specified.</Attribute>
+              </AttributeSet>
+              <XRef ID="C3661900" DB="MedGen"/>
+            </Trait>
+          </TraitSet>
+        </ConditionList>
+      </NoClassification>
+    </Classifications>
+    <ClinicalAssertionList>
+      <ClinicalAssertion ID="14383418" SubmissionDate="2026-02-11" ContributesToAggregateClassification="false" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_172107.4:c.[875T&gt;C;877C&gt;T]|not provided|NoClassification|EFO:0022948|BD51259B0AD12F6AA07E2AB223E8973E" submittedAssembly="not applicable"/>
+        <ClinVarAccession Accession="SCV007537089" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Channelopathy-Associated Epilepsy Research Center" OrgID="507249" OrganizationCategory="consortium" OrgAbbreviation="CAERC"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification>
+          <ReviewStatus>no classification provided</ReviewStatus>
+          <NoClassification>evidence_only</NoClassification>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <ObservedInList>
+          <ObservedIn Type="Functional">
+            <Sample>
+              <Origin>not applicable</Origin>
+              <CellLine>HEK293T</CellLine>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>not applicable</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>Whole-cell voltage clamp assay in HEK293T cells measuring Current density at -20 mV</Description>
+              <MethodType>in vitro</MethodType>
+              <AssayType Id="EFO:0022948" Source="EFO: The Experimental Factor Ontology">patch clamp</AssayType>
+              <MolecularPhenotypeMeasured>Current density at -20 mV</MolecularPhenotypeMeasured>
+            </Method>
+            <FunctionalData>
+              <FunctionalEffect Id="SO:0002218" Source="Sequence Ontology">functionally abnormal</FunctionalEffect>
+              <FunctionalConsequence Id="FENICS-0084" Source="Functional Epilepsy Nomenclature for Ion Channels">Decrease in peak current</FunctionalConsequence>
+              <Result>Decrease in peak current at -20 mV</Result>
+            </FunctionalData>
+          </ObservedIn>
+        </ObservedInList>
+        <Haplotype>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.875T&gt;C</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.877C&gt;T</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+        </Haplotype>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <Name>
+              <ElementValue Type="Preferred">not provided</ElementValue>
+            </Name>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16001976</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+      <ClinicalAssertion ID="14383529" SubmissionDate="2026-02-11" ContributesToAggregateClassification="false" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_172107.4:c.[875T&gt;C;877C&gt;T]|not provided|NoClassification|EFO:0022948|A63E3C0FF69C8920A4FABC12F32804F9" submittedAssembly="not applicable"/>
+        <ClinVarAccession Accession="SCV007537200" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Channelopathy-Associated Epilepsy Research Center" OrgID="507249" OrganizationCategory="consortium" OrgAbbreviation="CAERC"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification>
+          <ReviewStatus>no classification provided</ReviewStatus>
+          <NoClassification>evidence_only</NoClassification>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <ObservedInList>
+          <ObservedIn Type="Functional">
+            <Sample>
+              <Origin>not applicable</Origin>
+              <CellLine>HEK293T</CellLine>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>not applicable</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>Whole-cell voltage clamp assay in HEK293T cells measuring Current density at +40 mV</Description>
+              <MethodType>in vitro</MethodType>
+              <AssayType Id="EFO:0022948" Source="EFO: The Experimental Factor Ontology">patch clamp</AssayType>
+              <MolecularPhenotypeMeasured>Current density at +40 mV</MolecularPhenotypeMeasured>
+            </Method>
+            <FunctionalData>
+              <FunctionalEffect Id="SO:0002218" Source="Sequence Ontology">functionally abnormal</FunctionalEffect>
+              <FunctionalConsequence Id="FENICS-0084" Source="Functional Epilepsy Nomenclature for Ion Channels">Decrease in peak current</FunctionalConsequence>
+              <Result>Decrease in peak current at +40 mV</Result>
+            </FunctionalData>
+          </ObservedIn>
+        </ObservedInList>
+        <Haplotype>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.875T&gt;C</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.877C&gt;T</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+        </Haplotype>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <Name>
+              <ElementValue Type="Preferred">not provided</ElementValue>
+            </Name>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16001976</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+      <ClinicalAssertion ID="14383640" SubmissionDate="2026-02-11" ContributesToAggregateClassification="false" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_172107.4:c.[875T&gt;C;877C&gt;T]|not provided|NoClassification|EFO:0022948|9C289D375D37A035F5FE2F8F904F89B9" submittedAssembly="not applicable"/>
+        <ClinVarAccession Accession="SCV007537311" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Channelopathy-Associated Epilepsy Research Center" OrgID="507249" OrganizationCategory="consortium" OrgAbbreviation="CAERC"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification>
+          <ReviewStatus>no classification provided</ReviewStatus>
+          <NoClassification>evidence_only</NoClassification>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <ObservedInList>
+          <ObservedIn Type="Functional">
+            <Sample>
+              <Origin>not applicable</Origin>
+              <CellLine>HEK293T</CellLine>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>not applicable</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>Whole-cell voltage clamp assay in HEK293T cells measuring Voltage dependence of activation V1/2</Description>
+              <MethodType>in vitro</MethodType>
+              <AssayType Id="EFO:0022948" Source="EFO: The Experimental Factor Ontology">patch clamp</AssayType>
+              <MolecularPhenotypeMeasured>Voltage dependence of activation V1/2</MolecularPhenotypeMeasured>
+            </Method>
+            <FunctionalData>
+              <FunctionalEffect Id="SO:0002219" Source="Sequence Ontology">functionally normal</FunctionalEffect>
+              <FunctionalConsequence Id="FENICS-0032" Source="Functional Epilepsy Nomenclature for Ion Channels">Normal voltage dependence of activation</FunctionalConsequence>
+              <Result>Normal voltage dependence of activation</Result>
+            </FunctionalData>
+          </ObservedIn>
+        </ObservedInList>
+        <Haplotype>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.875T&gt;C</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.877C&gt;T</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+        </Haplotype>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <Name>
+              <ElementValue Type="Preferred">not provided</ElementValue>
+            </Name>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16001976</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+      <ClinicalAssertion ID="14383709" SubmissionDate="2026-02-11" ContributesToAggregateClassification="false" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_172107.4:c.[875T&gt;C;877C&gt;T]|not provided|NoClassification|EFO:0022948|F5759552A2EE9FACFC0A79281DB4BC46" submittedAssembly="not applicable"/>
+        <ClinVarAccession Accession="SCV007537380" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Channelopathy-Associated Epilepsy Research Center" OrgID="507249" OrganizationCategory="consortium" OrgAbbreviation="CAERC"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification>
+          <ReviewStatus>no classification provided</ReviewStatus>
+          <NoClassification>evidence_only</NoClassification>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <ObservedInList>
+          <ObservedIn Type="Functional">
+            <Sample>
+              <Origin>not applicable</Origin>
+              <CellLine>HEK293T</CellLine>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>not applicable</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>Whole-cell voltage clamp assay in HEK293T cells measuring Slope of activation</Description>
+              <MethodType>in vitro</MethodType>
+              <AssayType Id="EFO:0022948" Source="EFO: The Experimental Factor Ontology">patch clamp</AssayType>
+              <MolecularPhenotypeMeasured>Slope of activation</MolecularPhenotypeMeasured>
+            </Method>
+            <FunctionalData>
+              <FunctionalEffect Id="SO:0002218" Source="Sequence Ontology">functionally abnormal</FunctionalEffect>
+              <FunctionalConsequence Id="FENICS-0035" Source="Functional Epilepsy Nomenclature for Ion Channels">Increase in slope of activation</FunctionalConsequence>
+              <Result>Increase in slope of activation</Result>
+            </FunctionalData>
+          </ObservedIn>
+        </ObservedInList>
+        <Haplotype>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.875T&gt;C</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.877C&gt;T</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+        </Haplotype>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <Name>
+              <ElementValue Type="Preferred">not provided</ElementValue>
+            </Name>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16001976</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+      <ClinicalAssertion ID="14383720" SubmissionDate="2026-02-11" ContributesToAggregateClassification="false" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_172107.4:c.[875T&gt;C;877C&gt;T]|not provided|NoClassification|EFO:0022948|1903BDD93CE0926C9C3E6E7F6EC771F2" submittedAssembly="not applicable"/>
+        <ClinVarAccession Accession="SCV007537391" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Channelopathy-Associated Epilepsy Research Center" OrgID="507249" OrganizationCategory="consortium" OrgAbbreviation="CAERC"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification>
+          <ReviewStatus>no classification provided</ReviewStatus>
+          <NoClassification>evidence_only</NoClassification>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <ObservedInList>
+          <ObservedIn Type="Functional">
+            <Sample>
+              <Origin>not applicable</Origin>
+              <CellLine>HEK293T</CellLine>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>not applicable</AffectedStatus>
+            </Sample>
+            <Method>
+              <Description>Whole-cell voltage clamp assay in HEK293T cells measuring Activation time constant</Description>
+              <MethodType>in vitro</MethodType>
+              <AssayType Id="EFO:0022948" Source="EFO: The Experimental Factor Ontology">patch clamp</AssayType>
+              <MolecularPhenotypeMeasured>Activation time constant</MolecularPhenotypeMeasured>
+            </Method>
+            <FunctionalData>
+              <FunctionalEffect Id="SO:0002219" Source="Sequence Ontology">functionally normal</FunctionalEffect>
+              <FunctionalConsequence Id="FENICS-0011" Source="Functional Epilepsy Nomenclature for Ion Channels">Normal rate of activation</FunctionalConsequence>
+              <Result>Normal rate of activation</Result>
+            </FunctionalData>
+          </ObservedIn>
+        </ObservedInList>
+        <Haplotype>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.875T&gt;C</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+          <SimpleAllele>
+            <GeneList>
+              <Gene Symbol="KCNQ2"/>
+            </GeneList>
+            <VariantType>Variation</VariantType>
+            <AttributeSet>
+              <Attribute Type="HGVS">NM_172107.4:c.877C&gt;T</Attribute>
+            </AttributeSet>
+          </SimpleAllele>
+        </Haplotype>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <Name>
+              <ElementValue Type="Preferred">not provided</ElementValue>
+            </Name>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16001976</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+    </ClinicalAssertionList>
+    <TraitMappingList>
+      <TraitMapping ClinicalAssertionID="14383418" TraitType="Disease" MappingType="Name" MappingValue="not provided" MappingRef="Preferred">
+        <MedGen CUI="C3661900" Name="not provided"/>
+      </TraitMapping>
+      <TraitMapping ClinicalAssertionID="14383529" TraitType="Disease" MappingType="Name" MappingValue="not provided" MappingRef="Preferred">
+        <MedGen CUI="C3661900" Name="not provided"/>
+      </TraitMapping>
+      <TraitMapping ClinicalAssertionID="14383640" TraitType="Disease" MappingType="Name" MappingValue="not provided" MappingRef="Preferred">
+        <MedGen CUI="C3661900" Name="not provided"/>
+      </TraitMapping>
+      <TraitMapping ClinicalAssertionID="14383709" TraitType="Disease" MappingType="Name" MappingValue="not provided" MappingRef="Preferred">
+        <MedGen CUI="C3661900" Name="not provided"/>
+      </TraitMapping>
+      <TraitMapping ClinicalAssertionID="14383720" TraitType="Disease" MappingType="Name" MappingValue="not provided" MappingRef="Preferred">
+        <MedGen CUI="C3661900" Name="not provided"/>
+      </TraitMapping>
+    </TraitMappingList>
+  </ClassifiedRecord>
+</VariationArchive>
+</ClinVarResult-Set>

--- a/tests/data/clinvar_vcv_no_xreflist_tert.manifest.txt
+++ b/tests/data/clinvar_vcv_no_xreflist_tert.manifest.txt
@@ -1,0 +1,15 @@
+Source:   NCBI ClinVar E-utilities (efetch)
+Date:     2026-04-18
+Variant:  VCV004819006 — NM_198253.3(TERT):c.68C>T (p.Pro23Leu)
+Type:     single nucleotide variant (SimpleAllele has no XRefList element)
+Purpose:  Tests that _get_xref_list returns [] without crashing when the
+          SimpleAllele element contains no XRefList child.
+
+Fetch command:
+  curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=clinvar&id=4819006&rettype=vcv&is_variationid=true" \
+    > clinvar_vcv_no_xreflist_tert.xml
+
+Discovery note:
+  Confirmed via XML inspection that SimpleAllele contains no XRefList element.
+  Other XRef elements appear elsewhere in the record (e.g. under RCV conditions)
+  but not under SimpleAllele, which is the path _get_xref_list traverses.

--- a/tests/data/clinvar_vcv_no_xreflist_tert.xml
+++ b/tests/data/clinvar_vcv_no_xreflist_tert.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+                        
+<ClinVarResult-Set><VariationArchive VariationID="4819006" VariationName="NM_198253.3(TERT):c.68C&gt;T (p.Pro23Leu)" VariationType="single nucleotide variant" Accession="VCV004819006" Version="1" RecordType="classified" NumberOfSubmissions="1" NumberOfSubmitters="1" DateLastUpdated="2026-04-04" DateCreated="2026-04-04" MostRecentSubmission="2026-04-04">
+  <RecordStatus>current</RecordStatus>
+  <Species>Homo sapiens</Species>
+  <ClassifiedRecord>
+    <SimpleAllele AlleleID="4930130" VariationID="4819006">
+      <GeneList>
+        <Gene Symbol="LOC110806263" FullName="TERT 5' regulatory region" GeneID="110806263" Source="calculated" RelationshipType="within multiple genes by overlap">
+          <Location>
+            <CytogeneticLocation>5p15.33</CytogeneticLocation>
+            <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="5" Accession="NC_000005.10" start="1294628" stop="1298988" display_start="1294628" display_stop="1298988" Strand="+"/>
+          </Location>
+        </Gene>
+        <Gene Symbol="TERT" FullName="telomerase reverse transcriptase" GeneID="7015" HGNC_ID="HGNC:11730" Source="submitted" RelationshipType="within multiple genes by overlap">
+          <Location>
+            <CytogeneticLocation>5p15.33</CytogeneticLocation>
+            <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" AssemblyStatus="current" Chr="5" Accession="NC_000005.10" start="1253167" stop="1295068" display_start="1253167" display_stop="1295068" Strand="-"/>
+            <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="5" Accession="NC_000005.9" start="1253281" stop="1295161" display_start="1253281" display_stop="1295161" Strand="-"/>
+          </Location>
+          <OMIM>187270</OMIM>
+          <Haploinsufficiency last_evaluated="2025-06-24" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=TERT">Little evidence for dosage pathogenicity</Haploinsufficiency>
+          <Triplosensitivity last_evaluated="2025-06-24" ClinGen="https://www.ncbi.nlm.nih.gov/projects/dbvar/ISCA/isca_gene.cgi?sym=TERT">No evidence available</Triplosensitivity>
+        </Gene>
+      </GeneList>
+      <Name>NM_198253.3(TERT):c.68C&gt;T (p.Pro23Leu)</Name>
+      <CanonicalSPDI>NC_000005.10:1294921:G:A</CanonicalSPDI>
+      <VariantType>single nucleotide variant</VariantType>
+      <Location>
+        <CytogeneticLocation>5p15.33</CytogeneticLocation>
+        <SequenceLocation Assembly="GRCh38" AssemblyAccessionVersion="GCF_000001405.38" forDisplay="true" AssemblyStatus="current" Chr="5" Accession="NC_000005.10" start="1294922" stop="1294922" display_start="1294922" display_stop="1294922" variantLength="1" positionVCF="1294922" referenceAlleleVCF="G" alternateAlleleVCF="A"/>
+        <SequenceLocation Assembly="GRCh37" AssemblyAccessionVersion="GCF_000001405.25" AssemblyStatus="previous" Chr="5" Accession="NC_000005.9" start="1295037" stop="1295037" display_start="1295037" display_stop="1295037" variantLength="1" positionVCF="1295037" referenceAlleleVCF="G" alternateAlleleVCF="A"/>
+      </Location>
+      <ProteinChange>P23L</ProteinChange>
+      <HGVSlist>
+        <HGVS Assembly="GRCh38" Type="genomic, top-level">
+          <NucleotideExpression sequenceAccessionVersion="NC_000005.10" sequenceAccession="NC_000005" sequenceVersion="10" change="g.1294922G&gt;A" Assembly="GRCh38">
+            <Expression>NC_000005.10:g.1294922G&gt;A</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Assembly="GRCh37" Type="genomic, top-level">
+          <NucleotideExpression sequenceAccessionVersion="NC_000005.9" sequenceAccession="NC_000005" sequenceVersion="9" change="g.1295037G&gt;A" Assembly="GRCh37">
+            <Expression>NC_000005.9:g.1295037G&gt;A</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="genomic">
+          <NucleotideExpression sequenceAccessionVersion="NG_009265.1" sequenceAccession="NG_009265" sequenceVersion="1" change="g.5126C&gt;T">
+            <Expression>NG_009265.1:g.5126C&gt;T</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="genomic">
+          <NucleotideExpression sequenceAccessionVersion="NG_055467.1" sequenceAccession="NG_055467" sequenceVersion="1" change="g.395G&gt;A">
+            <Expression>NG_055467.1:g.395G&gt;A</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_001193376.3" sequenceAccession="NM_001193376" sequenceVersion="3" change="c.68C&gt;T">
+            <Expression>NM_001193376.3:c.68C&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_001180305.1" sequenceAccession="NP_001180305" sequenceVersion="1" change="p.Pro23Leu" singleLetterProteinChange="P23L">
+            <Expression>NP_001180305.1:p.Pro23Leu</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="NM_198253.3" sequenceAccession="NM_198253" sequenceVersion="3" change="c.68C&gt;T" MANESelect="true">
+            <Expression>NM_198253.3:c.68C&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="NP_937983.2" sequenceAccession="NP_937983" sequenceVersion="2" change="p.Pro23Leu" singleLetterProteinChange="P23L">
+            <Expression>NP_937983.2:p.Pro23Leu</Expression>
+          </ProteinExpression>
+          <MolecularConsequence ID="SO:0001583" Type="missense variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="non-coding">
+          <NucleotideExpression sequenceAccessionVersion="NR_149162.3" sequenceAccession="NR_149162" sequenceVersion="3" change="n.147C&gt;T">
+            <Expression>NR_149162.3:n.147C&gt;T</Expression>
+          </NucleotideExpression>
+          <MolecularConsequence ID="SO:0001619" Type="non-coding transcript variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="non-coding">
+          <NucleotideExpression sequenceAccessionVersion="NR_149163.3" sequenceAccession="NR_149163" sequenceVersion="3" change="n.147C&gt;T">
+            <Expression>NR_149163.3:n.147C&gt;T</Expression>
+          </NucleotideExpression>
+          <MolecularConsequence ID="SO:0001619" Type="non-coding transcript variant" DB="SO"/>
+        </HGVS>
+        <HGVS Type="genomic">
+          <NucleotideExpression sequenceAccessionVersion="LRG_343" sequenceAccession="LRG_343">
+            <Expression>LRG_343:g.5126C&gt;T</Expression>
+          </NucleotideExpression>
+        </HGVS>
+        <HGVS Type="coding">
+          <NucleotideExpression sequenceAccessionVersion="LRG_343t1" sequenceAccession="LRG_343t1">
+            <Expression>LRG_343t1:c.68C&gt;T</Expression>
+          </NucleotideExpression>
+          <ProteinExpression sequenceAccessionVersion="LRG_343p1" sequenceAccession="LRG_343p1" change="p.Pro23Leu">
+            <Expression>LRG_343p1:p.Pro23Leu</Expression>
+          </ProteinExpression>
+        </HGVS>
+      </HGVSlist>
+    </SimpleAllele>
+    <RCVList>
+      <RCVAccession Title="NM_198253.3(TERT):c.68C&gt;T (p.Pro23Leu) AND Pulmonary fibrosis and/or bone marrow failure, Telomere-related, 1" Accession="RCV006645710" Version="1">
+        <ClassifiedConditionList TraitSetID="8796">
+          <ClassifiedCondition DB="MedGen" ID="C3553617">Pulmonary fibrosis and/or bone marrow failure, Telomere-related, 1</ClassifiedCondition>
+        </ClassifiedConditionList>
+        <RCVClassifications>
+          <GermlineClassification>
+            <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+            <Description DateLastEvaluated="2025-12-29" SubmissionCount="1">Uncertain significance</Description>
+          </GermlineClassification>
+        </RCVClassifications>
+      </RCVAccession>
+    </RCVList>
+    <Classifications>
+      <GermlineClassification DateLastEvaluated="2025-12-29" NumberOfSubmissions="1" NumberOfSubmitters="1" DateCreated="2026-04-04" MostRecentSubmission="2026-04-04">
+        <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+        <Description>Uncertain significance</Description>
+        <Citation Type="review" Abbrev="GeneReviews">
+          <ID Source="PubMed">20301779</ID>
+          <ID Source="BookShelf">NBK22301</ID>
+        </Citation>
+        <ConditionList>
+          <TraitSet ID="8796" Type="Disease" ContributesToAggregateClassification="true">
+            <Trait ID="17340" Type="Disease">
+              <Name>
+                <ElementValue Type="Preferred">Pulmonary fibrosis and/or bone marrow failure, Telomere-related, 1</ElementValue>
+                <XRef ID="MONDO:0013878" DB="MONDO"/>
+              </Name>
+              <Name>
+                <ElementValue Type="Alternate">PULMONARY FIBROSIS AND/OR BONE MARROW FAILURE SYNDROME, TELOMERE-RELATED, 1</ElementValue>
+                <XRef Type="MIM" ID="614742" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0001" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0016" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0019" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0020" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0002" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0009" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0010" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0015" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0017" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0005" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0008" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0018" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0021" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0003" DB="OMIM"/>
+                <XRef Type="Allelic variant" ID="187270.0004" DB="OMIM"/>
+              </Name>
+              <Symbol>
+                <ElementValue Type="Alternate">PFBMFT1</ElementValue>
+                <XRef Type="MIM" ID="614742" DB="OMIM"/>
+              </Symbol>
+              <AttributeSet>
+                <Attribute Type="public definition">Dyskeratosis congenita and related telomere biology disorders (DC/TBD) are caused by impaired telomere maintenance resulting in short or very short telomeres. The phenotypic spectrum of telomere biology disorders is broad and includes individuals with classic dyskeratosis congenita (DC) as well as those with very short telomeres and an isolated physical finding. Classic DC is characterized by a triad of dysplastic nails, lacy reticular pigmentation of the upper chest and/or neck, and oral leukoplakia, although this may not be present in all individuals. People with DC/TBD are at increased risk for progressive bone marrow failure (BMF), myelodysplastic syndrome or acute myelogenous leukemia, solid tumors (usually squamous cell carcinoma of the head/neck or anogenital cancer), and pulmonary fibrosis. Other findings can include eye abnormalities (epiphora, blepharitis, sparse eyelashes, ectropion, entropion, trichiasis), taurodontism, liver disease, gastrointestinal telangiectasias, and avascular necrosis of the hips or shoulders. Although most persons with DC/TBD have normal psychomotor development and normal neurologic function, significant developmental delay is present in both forms; additional findings include cerebellar hypoplasia (Hoyeraal Hreidarsson syndrome) and bilateral exudative retinopathy and intracranial calcifications (Revesz syndrome and Coats plus syndrome). Onset and progression of manifestations of DC/TBD vary: at the mild end of the spectrum are those who have only minimal physical findings with normal bone marrow function, and at the severe end are those who have the diagnostic triad and early-onset BMF.</Attribute>
+                <XRef ID="NBK22301" DB="GeneReviews"/>
+              </AttributeSet>
+              <AttributeSet>
+                <Attribute Type="GARD id" integerValue="24959"/>
+                <XRef ID="24959" DB="Office of Rare Diseases"/>
+              </AttributeSet>
+              <Citation Type="review" Abbrev="GeneReviews">
+                <ID Source="PubMed">20301408</ID>
+                <ID Source="BookShelf">NBK1230</ID>
+              </Citation>
+              <Citation Type="review" Abbrev="GeneReviews">
+                <ID Source="PubMed">20301779</ID>
+                <ID Source="BookShelf">NBK22301</ID>
+              </Citation>
+              <XRef ID="88" DB="Orphanet"/>
+              <XRef ID="C3553617" DB="MedGen"/>
+              <XRef ID="MONDO:0013878" DB="MONDO"/>
+              <XRef Type="MIM" ID="614742" DB="OMIM"/>
+            </Trait>
+          </TraitSet>
+        </ConditionList>
+      </GermlineClassification>
+    </Classifications>
+    <ClinicalAssertionList>
+      <ClinicalAssertion ID="14393192" SubmissionDate="2026-03-05" ContributesToAggregateClassification="true" DateLastUpdated="2026-04-04" DateCreated="2026-04-04">
+        <ClinVarSubmissionID localKey="NM_198253.3:c.68C&gt;T|OMIM:614742" submittedAssembly="GRCh38"/>
+        <ClinVarAccession Accession="SCV007538001" DateUpdated="2026-04-04" DateCreated="2026-04-04" Type="SCV" Version="1" SubmitterName="Victorian Clinical Genetics Services, Murdoch Childrens Research Institute" OrgID="500104" OrganizationCategory="laboratory" OrgAbbreviation="VCGS"/>
+        <RecordStatus>current</RecordStatus>
+        <Classification DateLastEvaluated="2025-12-29">
+          <ReviewStatus>criteria provided, single submitter</ReviewStatus>
+          <GermlineClassification>Uncertain significance</GermlineClassification>
+          <Citation>
+            <ID Source="PubMed">20301779</ID>
+          </Citation>
+          <Comment Type="public">This variant is classified as VUS-3B. Evidence in support of pathogenic classification: Variant is absent from gnomAD (v2, v3 and v4); Missense variant in a region that is highly intolerant to missense variation (high constraint region in DECIPHER). Additional information: Variant is predicted to result in a missense amino acid change from Pro to Leu; This variant is heterozygous; This gene is associated with both recessive and dominant disease. No specific genotype-phenotype correlations have been established (PMID: 20301779); This variant has no previous evidence of pathogenicity; No published evidence of segregation with disease has been identified for this variant; No published functional evidence has been identified for this variant; Other missense variant(s) comparable to the one identified in this case have inconclusive previous evidence for pathogenicity. p.(Pro23Gln) and p.(Pro23Ser) have been classified as VUS by clinical laboratories in ClinVar; Missense variant with inconclusive in silico prediction and/or uninformative conservation; Loss of function is a known mechanism of disease in this gene and is associated with autosomal dominant dyskeratosis congenita 2 and autosomal recessive dyskeratosis congenita 4 (MIM#613989) and telomere-related pulmonary fibrosis and/or bone marrow failure 1 (MIM#614742); Variants in this gene are known to have variable expressivity. Phenotypic variability is well reported for dyskeratosis congenita (OMIM, PMID: 20301779); Inheritance information for this variant is not currently available in this individual.</Comment>
+        </Classification>
+        <Assertion>variation to disease</Assertion>
+        <AttributeSet>
+          <Attribute Type="AssertionMethod">ACMG Guidelines, 2015</Attribute>
+          <Citation>
+            <ID Source="PubMed">25741868</ID>
+          </Citation>
+        </AttributeSet>
+        <ObservedInList>
+          <ObservedIn>
+            <Sample>
+              <Origin>germline</Origin>
+              <Species TaxonomyId="9606">human</Species>
+              <AffectedStatus>yes</AffectedStatus>
+            </Sample>
+            <Method>
+              <MethodType>clinical testing</MethodType>
+            </Method>
+            <ObservedData>
+              <Attribute Type="Description">not provided</Attribute>
+            </ObservedData>
+          </ObservedIn>
+        </ObservedInList>
+        <SimpleAllele>
+          <GeneList>
+            <Gene Symbol="TERT"/>
+          </GeneList>
+          <VariantType>Variation</VariantType>
+          <AttributeSet>
+            <Attribute Type="HGVS">NM_198253.3:c.68C&gt;T</Attribute>
+          </AttributeSet>
+        </SimpleAllele>
+        <TraitSet Type="Disease">
+          <Trait Type="Disease">
+            <XRef DB="OMIM" ID="614742" Type="MIM"/>
+          </Trait>
+        </TraitSet>
+        <SubmissionNameList>
+          <SubmissionName>SUB16044525</SubmissionName>
+        </SubmissionNameList>
+      </ClinicalAssertion>
+    </ClinicalAssertionList>
+    <TraitMappingList>
+      <TraitMapping ClinicalAssertionID="14393192" TraitType="Disease" MappingType="XRef" MappingValue="614742" MappingRef="OMIM">
+        <MedGen CUI="C3553617" Name="Pulmonary fibrosis and/or bone marrow failure, Telomere-related, 1"/>
+      </TraitMapping>
+    </TraitMappingList>
+  </ClassifiedRecord>
+</VariationArchive>
+</ClinVarResult-Set>

--- a/tests/data/clinvar_vcv_orphanet_medgen.manifest.txt
+++ b/tests/data/clinvar_vcv_orphanet_medgen.manifest.txt
@@ -1,0 +1,42 @@
+Source:   Synthetic — hand-authored (no real NCBI record has Orphanet/MedGen in SimpleAllele/XRefList)
+Date:     2026-04-19
+Variant:  VCV000999003 (fictional) — NM_000001.1(GENE1):c.200A>G (p.Tyr67Cys)
+Type:     single nucleotide variant
+Purpose:  Tests orphanet_id, orphanet_ids, medgen_id, medgen_ids properties, which
+          filter self.xrefs (sourced from SimpleAllele/XRefList) by DB name.
+
+Investigation to confirm no real record can be fetched
+-------------------------------------------------------
+
+Step 1 — searched for ClinVar records with Orphanet text:
+  curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=clinvar&term=Orphanet[All+Fields]&retmax=10"
+  Returned IDs: 4819894, 4819876, 4819856, 4819823, 4819757, 4819684, 4819682,
+                4819460, 4819454, 4819370
+
+Step 2 — batch-fetched those 10 records and inspected SimpleAllele/XRefList:
+  curl "...efetch.fcgi?db=clinvar&id=<IDS>&rettype=vcv&is_variationid=true"
+  Parsed with lxml: root.findall('.//SimpleAllele/XRefList/XRef')
+  Result: 0 records had Orphanet or MedGen in SimpleAllele/XRefList.
+  Orphanet/MedGen xrefs in those records appear only in condition/RCV sections.
+
+Step 3 — scanned first 200MB of ClinVarVCVRelease_00-latest.xml.gz via iterparse:
+  curl --range 0-200000000 "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/ClinVarVCVRelease_00-latest.xml.gz"
+  | gunzip | python3 iterparse for VariationArchive, checked .//SimpleAllele/XRefList/XRef
+  Result: 0 records found with DB="Orphanet" or DB="MedGen" in SimpleAllele/XRefList.
+
+Conclusion: Orphanet and MedGen cross-references are stored at the condition/RCV level
+in ClinVar, not at the SimpleAllele level. The orphanet_id and medgen_id properties
+use _get_xref_ids which filters self.xrefs (sourced from SimpleAllele/XRefList), so
+they will return None/[] on all real VCV records. This synthetic fixture exercises
+the code path to confirm the filtering and return-type behavior is correct.
+
+Structure:
+  ClinVarResult-Set
+  └── VariationArchive (VariationType="single nucleotide variant")
+      └── ClassifiedRecord
+          └── SimpleAllele
+              └── XRefList
+                  ├── XRef Type="rs" ID="987654321" DB="dbSNP"
+                  ├── XRef ID="ORPHA:123456" DB="Orphanet"
+                  ├── XRef ID="ORPHA:789012" DB="Orphanet"   (tests plural form)
+                  └── XRef ID="C0123456" DB="MedGen"

--- a/tests/data/clinvar_vcv_orphanet_medgen.xml
+++ b/tests/data/clinvar_vcv_orphanet_medgen.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ClinVarResult-Set>
+  <VariationArchive VariationID="999003" VariationName="NM_000001.1(GENE1):c.200A>G (p.Tyr67Cys)" VariationType="single nucleotide variant" Accession="VCV000999003" Version="1" RecordType="classified" NumberOfSubmissions="1" NumberOfSubmitters="1" DateLastUpdated="2024-01-01" DateCreated="2024-01-01" MostRecentSubmission="2024-01-01">
+    <RecordStatus>current</RecordStatus>
+    <Species>Homo sapiens</Species>
+    <ClassifiedRecord>
+      <SimpleAllele AlleleID="333001" VariationID="999003">
+        <GeneList>
+          <Gene Symbol="GENE1" FullName="Gene 1" GeneID="11111" Source="submitted" RelationshipType="within single gene"/>
+        </GeneList>
+        <Name>NM_000001.1(GENE1):c.200A&gt;G (p.Tyr67Cys)</Name>
+        <VariantType>single nucleotide variant</VariantType>
+        <XRefList>
+          <XRef Type="rs" ID="987654321" DB="dbSNP"/>
+          <XRef ID="ORPHA:123456" DB="Orphanet"/>
+          <XRef ID="ORPHA:789012" DB="Orphanet"/>
+          <XRef ID="C0123456" DB="MedGen"/>
+        </XRefList>
+      </SimpleAllele>
+    </ClassifiedRecord>
+  </VariationArchive>
+</ClinVarResult-Set>

--- a/tests/data/clinvar_vcv_rsid_formats.manifest.txt
+++ b/tests/data/clinvar_vcv_rsid_formats.manifest.txt
@@ -1,0 +1,24 @@
+Source:   Synthetic — hand-authored
+Date:     2026-04-18
+Variant:  VCV000999002 (fictional) — NM_000001.1(GENE1):c.1A>G (p.Met1Val)
+Type:     single nucleotide variant
+Purpose:  Tests two properties of _get_rsids:
+          (1) Type-agnostic collection — all four documented dbSNP XRef formats
+              must be captured regardless of the Type attribute value.
+          (2) Cross-format deduplication — bare "1799945" and prefixed "rs1799945"
+              represent the same variant; after normalization both become "1799945"
+              and must collapse to a single entry.
+
+Why synthetic:
+  The four XRef formats are drawn from real ClinVar XML observations documented
+  in _get_rsids comments, but a record containing all four for the same ID
+  simultaneously does not need to be a real accession — the point is to exercise
+  the normalization and dedup logic in isolation.
+
+XRef entries in the fixture (all for rsID 1799945):
+  <XRef Type="rs"       ID="1799945"   DB="dbSNP"/>  -- idiomatic
+  <XRef Type="rsNumber" ID="1799945"   DB="dbSNP"/>  -- non-standard Type
+  <XRef               ID="rs1799945"  DB="dbSNP"/>  -- rs prefix in ID field
+  <XRef               ID="1799945"    DB="dbSNP"/>  -- bare number, no Type
+
+Expected result: rsids == ['1799945']  (one entry, no "rs" prefix, no duplicates)

--- a/tests/data/clinvar_vcv_rsid_formats.xml
+++ b/tests/data/clinvar_vcv_rsid_formats.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ClinVarResult-Set>
+  <VariationArchive VariationID="999002" VariationName="NM_000001.1(GENE1):c.1A>G (p.Met1Val)" VariationType="single nucleotide variant" Accession="VCV000999002" Version="1" RecordType="classified" NumberOfSubmissions="1" NumberOfSubmitters="1" DateLastUpdated="2024-01-01" DateCreated="2024-01-01" MostRecentSubmission="2024-01-01">
+    <RecordStatus>current</RecordStatus>
+    <Species>Homo sapiens</Species>
+    <ClassifiedRecord>
+      <SimpleAllele AlleleID="222001" VariationID="999002">
+        <GeneList>
+          <Gene Symbol="GENE1" FullName="Gene 1" GeneID="11111" Source="submitted" RelationshipType="within single gene"/>
+        </GeneList>
+        <Name>NM_000001.1(GENE1):c.1A&gt;G (p.Met1Val)</Name>
+        <VariantType>single nucleotide variant</VariantType>
+        <XRefList>
+          <XRef Type="rs" ID="1799945" DB="dbSNP"/>
+          <XRef Type="rsNumber" ID="1799945" DB="dbSNP"/>
+          <XRef ID="rs1799945" DB="dbSNP"/>
+          <XRef ID="1799945" DB="dbSNP"/>
+        </XRefList>
+      </SimpleAllele>
+    </ClassifiedRecord>
+  </VariationArchive>
+</ClinVarResult-Set>

--- a/tests/test_clinvar_fetcher.py
+++ b/tests/test_clinvar_fetcher.py
@@ -211,11 +211,108 @@ class TestClinVarFetcher(unittest.TestCase):
         self.assertIsNotNone(var.protein_change)
         self.assertIsInstance(var.associated_conditions, list)
         self.assertIsInstance(var.gene_dosage_info, list)
+        self.assertEqual(var.rsid, '28934872')
+        self.assertEqual(var.rsids, ['28934872'])
+        self.assertEqual(var.omim_id, '191092.0006')
+        self.assertEqual(var.omim_ids, ['191092.0006'])
+
+        # Orphanet/MedGen xrefs never appear in SimpleAllele/XRefList in real records
+        # (they live in condition/RCV sections); see clinvar_vcv_orphanet_medgen.manifest.txt
+        self.assertIsNone(var.orphanet_id)
+        self.assertEqual(var.orphanet_ids, [])
+        self.assertIsNone(var.medgen_id)
+        self.assertEqual(var.medgen_ids, [])
         
         # Verify TSC2 gene dosage info is present
         self.assertTrue(len(var.gene_dosage_info) > 0)
         self.assertEqual(var.gene_dosage_info[0]['symbol'], 'TSC2')
         self.assertIn('haploinsufficiency', var.gene_dosage_info[0])
+
+    def _load_fixture(self, filename):
+        xml_file_path = os.path.join(os.path.dirname(__file__), 'data', filename)
+        with open(xml_file_path, 'rb') as f:
+            return ClinVarVariant(f.read())
+
+    def test_xref_list_simple_vcv(self):
+        """Simple VCV variant (TSC2, VCV000012397) has 4 xrefs from its single SimpleAllele."""
+        var = self._load_fixture('clinvar_vcv_12000.xml')
+        xrefs = var.xrefs
+        dbs = [x['DB'] for x in xrefs]
+        self.assertIn('dbSNP', dbs)
+        self.assertIn('OMIM', dbs)
+        self.assertEqual(var.rsid, '28934872')
+        self.assertEqual(var.omim_id, '191092.0006')
+
+    def test_xref_list_haplotype_collects_all_alleles(self):
+        """Haplotype VCV (KCNQ2, VCV004818726) has two SimpleAlleles; xrefs from both must be collected."""
+        var = self._load_fixture('clinvar_vcv_haplotype_kcnq2.xml')
+        xrefs = var.xrefs
+        # Both alleles contribute xrefs — expect 6 total (3 per allele)
+        self.assertEqual(len(xrefs), 6)
+        # Both dbSNP rsIDs must be present
+        dbsnp_ids = [x['ID'] for x in xrefs if x.get('DB') == 'dbSNP']
+        self.assertIn('1060500602', dbsnp_ids)
+        self.assertIn('2081099943', dbsnp_ids)
+        # rsids property returns both
+        self.assertIn('1060500602', var.rsids)
+        self.assertIn('2081099943', var.rsids)
+
+    def test_xref_list_no_xreflist_returns_empty(self):
+        """Variant with no XRefList element (TERT, VCV004819006) must return empty list without crashing."""
+        var = self._load_fixture('clinvar_vcv_no_xreflist_tert.xml')
+        self.assertEqual(var.xrefs, [])
+        self.assertIsNone(var.rsid)
+        self.assertEqual(var.rsids, [])
+
+    def test_xref_list_genotype_collects_all_alleles(self):
+        """Genotype VCV (synthetic) nests SimpleAlleles under Genotype; xrefs from both must be collected."""
+        var = self._load_fixture('clinvar_vcv_genotype_minimal.xml')
+        xrefs = var.xrefs
+        # Two SimpleAlleles: first has 2 xrefs (dbSNP + OMIM), second has 1 (dbSNP)
+        self.assertEqual(len(xrefs), 3)
+        dbsnp_ids = [x['ID'] for x in xrefs if x.get('DB') == 'dbSNP']
+        self.assertIn('111111111', dbsnp_ids)
+        self.assertIn('222222222', dbsnp_ids)
+        omim_ids = [x['ID'] for x in xrefs if x.get('DB') == 'OMIM']
+        self.assertIn('100001.0001', omim_ids)
+
+    def test_rsid_normalization_and_dedup(self):
+        """All four observed dbSNP XRef formats for the same rsID collapse to one bare number.
+
+        The four formats documented in _get_rsids comments:
+          Type="rs"       ID="1799945"   -- idiomatic
+          Type="rsNumber" ID="1799945"   -- non-standard Type (Type-agnostic collection)
+          (no Type)       ID="rs1799945" -- rs prefix joined into ID field
+          (no Type)       ID="1799945"   -- bare number, missing Type entirely
+        All represent the same variant and must deduplicate to ['1799945'].
+        """
+        var = self._load_fixture('clinvar_vcv_rsid_formats.xml')
+        self.assertEqual(var.rsids, ['1799945'])
+        self.assertEqual(var.rsid, '1799945')
+
+    def test_orphanet_and_medgen_ids(self):
+        """Orphanet and MedGen IDs in SimpleAllele/XRefList are returned by orphanet_id/medgen_id.
+
+        Note: no real VCV record has these DBs in SimpleAllele/XRefList (they appear only
+        in condition/RCV sections). This synthetic fixture tests the filtering code path.
+        """
+        var = self._load_fixture('clinvar_vcv_orphanet_medgen.xml')
+        self.assertEqual(var.orphanet_id, 'ORPHA:123456')
+        self.assertEqual(var.orphanet_ids, ['ORPHA:123456', 'ORPHA:789012'])
+        self.assertEqual(var.medgen_id, 'C0123456')
+        self.assertEqual(var.medgen_ids, ['C0123456'])
+        self.assertEqual(var.rsid, '987654321')
+
+    def test_xref_list_old_format(self):
+        """Old VariationReport format (TSC2 c.1832G>A, pre-VCV) uses Allele/XRefList path."""
+        var = self._load_fixture('clinvar_old_format_minimal.xml')
+        xrefs = var.xrefs
+        self.assertEqual(len(xrefs), 2)
+        dbs = [x['DB'] for x in xrefs]
+        self.assertIn('dbSNP', dbs)
+        self.assertIn('OMIM', dbs)
+        self.assertEqual(var.rsid, '28934872')
+        self.assertEqual(var.omim_id, '191092.0006')
 
     def test_backward_compatibility(self):
         """Test that all existing properties still work with new format"""


### PR DESCRIPTION
# PR: Add `rsid`, `dbsnp_id`, and related XRef convenience properties to `ClinVarVariant`

**Branch:** `dev/bgracia/rsid_dbsnpid` → `pathogenicity_summary`
**Issue:** #126

---

## Summary

Implements `rsid`/`rsids`, `dbsnp_id`/`dbsnp_ids`, `omim_id`/`omim_ids`, `orphanet_id`/`orphanet_ids`, and `medgen_id`/`medgen_ids` as convenience properties on `ClinVarVariant`, surfacing allele-level cross-references from `xrefs` without requiring callers to filter the raw list themselves.

Two pre-existing bugs in `_get_xref_list` were discovered and fixed in the process.

---

## Bugs Fixed

### 1. `_get_xref_list` silently dropped all but the first allele in haplotype/genotype variants

The old implementation used `find('ClassifiedRecord/SimpleAllele')` — which returns only the first match — then called the deprecated `.getchildren()`. For haplotype records with multiple `SimpleAllele` elements (e.g. KCNQ2, VCV004818726), all xrefs from the second allele onward were silently lost.

Fixed by switching to `.//SimpleAllele/XRefList` via `findall`, collecting xrefs from all constituent alleles regardless of nesting depth.

### 2. Old-format `VariationReport` parsing always returned `None` for `self.content`

The `super().__init__` call passed `'VariationReport'` as the `root` argument, causing `dom.find('VariationReport')` to search for a *child* of the root element — which is itself the `VariationReport` — returning `None`. Fixed by passing `None`, consistent with the VCV format path.

---

## Implementation

**`_get_xref_list`** now uses:
- `.//SimpleAllele/XRefList` for VCV format (handles `SimpleAllele` nested under `Haplotype` or `Genotype`)
- `.//Allele/XRefList` for legacy pre-2019 `VariationReport` format

**`_get_xref_ids(db_name)`** — new shared helper that filters `self.xrefs` by `DB` attribute, ignoring `Type` entirely, and deduplicates with first-seen order via `dict.fromkeys`.

**`_get_rsids()`** — normalizes all four observed dbSNP ID formats to bare numeric strings, then deduplicates *after* normalization. Deduplicating before normalization would allow `"1799945"` and `"rs1799945"` to survive as distinct entries, then both normalize to the same value.

The four dbSNP formats seen in real ClinVar XML:

```xml
<XRef Type="rs"       ID="1799945"  DB="dbSNP"/>  <!-- idiomatic -->
<XRef Type="rsNumber" ID="1799945"  DB="dbSNP"/>  <!-- non-standard Type -->
<XRef               ID="rs1799945" DB="dbSNP"/>   <!-- rs prefix in ID field -->
<XRef               ID="1799945"   DB="dbSNP"/>   <!-- bare number, no Type -->
```

All properties return bare numeric strings (e.g. `'28934872'`), not rs-prefixed. `dbsnp_id`/`dbsnp_ids` are aliases for `rsid`/`rsids`.

> **Note on `orphanet_id`/`medgen_id`:** These are implemented and work correctly against `self.xrefs`, but will always return `None`/`[]` on real VCV records — Orphanet and MedGen identifiers appear at the condition level (`RCVList`, `TraitSet`), not in `SimpleAllele/XRefList`. Confirmed by scanning 200MB of `ClinVarVCVRelease_00-latest.xml.gz`. Condition-level MedGen IDs are accessible via `associated_conditions`. The properties are included for completeness and documented accordingly.

---

## API Changes

### New public properties on `ClinVarVariant`

| Property | Returns | Description |
|---|---|---|
| `rsid` | `str \| None` | First dbSNP ID as bare numeric string (e.g. `'28934872'`), or `None` |
| `rsids` | `list[str]` | All distinct dbSNP IDs, first-seen order, bare numeric strings |
| `dbsnp_id` | `str \| None` | Alias for `rsid` |
| `dbsnp_ids` | `list[str]` | Alias for `rsids` |
| `omim_id` | `str \| None` | First OMIM ID, or `None` |
| `omim_ids` | `list[str]` | All distinct OMIM IDs, first-seen order |
| `orphanet_id` | `str \| None` | First Orphanet ID, or `None` (always `None` on real VCV records — see note below) |
| `orphanet_ids` | `list[str]` | All distinct Orphanet IDs (always `[]` on real VCV records) |
| `medgen_id` | `str \| None` | First MedGen ID, or `None` (always `None` on real VCV records — see note below) |
| `medgen_ids` | `list[str]` | All distinct MedGen IDs (always `[]` on real VCV records) |

### Modified methods on `ClinVarVariant`

| Method | Change |
|---|---|
| `_get_xref_list() -> list[XRef]` | Fixed: now uses `findall` with `.//SimpleAllele/XRefList` to collect xrefs from all alleles in haplotype/genotype variants; was silently returning only the first allele's xrefs. Return type is now typed. |
| `__init__` | Fixed: old-format `VariationReport` parsing no longer passes `'VariationReport'` as root to `super().__init__`, which caused `self.content` to always be `None`. |

### New private methods on `ClinVarVariant`

| Method | Returns | Description |
|---|---|---|
| `_get_rsids()` | `list[str]` | Normalizes all four dbSNP ID formats to bare numeric strings; deduplicates after normalization |
| `_get_xref_ids(db_name: str)` | `list[str]` | Filters `self.xrefs` by `DB` attribute (ignores `Type`); deduplicates with first-seen order |

### Minor changes

**`ncbi_client.py`** — debug logging now emits the full constructed URL (including query string) for both live requests and cache hits. No behavior change.

---

## New Types

```python
class XRefDB(StrEnum):
    DBSNP = 'dbSNP'
    OMIM = 'OMIM'
    ORPHANET = 'Orphanet'
    MEDGEN = 'MedGen'
    # + ClinGen, Gene, PubMed, PubMedCentral, BookShelf, dbVar

class XRef(TypedDict):
    ID: str
    DB: str
    Type: NotRequired[str]  # observed to be absent in some real records
```

---

## Tests

7 new offline tests in `test_clinvar_fetcher.py`, each backed by a dedicated fixture with a manifest documenting provenance:

| Test | Fixture | Covers |
|---|---|---|
| `test_xref_list_simple_vcv` | `clinvar_vcv_12000.xml` (existing) | Baseline: single `SimpleAllele`, `rsid`/`omim_id` |
| `test_xref_list_haplotype_collects_all_alleles` | `clinvar_vcv_haplotype_kcnq2.xml` | Two `SimpleAllele`s under `Haplotype` — both rsIDs collected |
| `test_xref_list_no_xreflist_returns_empty` | `clinvar_vcv_no_xreflist_tert.xml` | Missing `XRefList` → `[]`, no crash |
| `test_xref_list_genotype_collects_all_alleles` | `clinvar_vcv_genotype_minimal.xml` | `SimpleAllele`s under `Genotype` |
| `test_rsid_normalization_and_dedup` | `clinvar_vcv_rsid_formats.xml` | All four dbSNP formats collapse to one bare number |
| `test_orphanet_and_medgen_ids` | `clinvar_vcv_orphanet_medgen.xml` | `orphanet_id`/`medgen_id` filtering and return types |
| `test_xref_list_old_format` | `clinvar_old_format_minimal.xml` | Pre-2019 `VariationReport` format, `Allele/XRefList` path |

**Real vs synthetic fixtures** — each synthetic fixture includes a manifest with the investigation steps taken to confirm no real record could be fetched:

| Fixture | Type | Reason if synthetic |
|---|---|---|
| `clinvar_vcv_haplotype_kcnq2.xml` | Real (VCV004818726) | — |
| `clinvar_vcv_no_xreflist_tert.xml` | Real (VCV004819006) | — |
| `clinvar_vcv_4819894_glb1.xml` | Real (VCV004819894) | Evidence record: shows Orphanet/MedGen at condition level |
| `clinvar_vcv_genotype_minimal.xml` | Synthetic | `VariationType="Genotype"` absent from current VCV format; confirmed by scanning 200MB of full release |
| `clinvar_old_format_minimal.xml` | Synthetic | NCBI retired `VariationReport` format April 2019; `rettype=variation` returns explicit deprecation notice |
| `clinvar_vcv_orphanet_medgen.xml` | Synthetic | Orphanet/MedGen never present in `SimpleAllele/XRefList` in real records; confirmed by scanning 200MB of full release |
| `clinvar_vcv_rsid_formats.xml` | Synthetic | Exercises all four dbSNP ID formats simultaneously; real records have at most two |

## Tests passed

```sh
% pytest tests
================================= test session starts ==================================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/bgracia/Documents/School/SchoolCode/17780/team1-s26/metapub
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 684 items                                                                    

tests/findit/test_aaas.py ..........                                             [  1%]
tests/findit/test_acm.py ....                                                    [  2%]
tests/findit/test_acs.py .......                                                 [  3%]
tests/findit/test_ajph.py ............                                           [  4%]
tests/findit/test_annualreviews.py .................                             [  7%]
tests/findit/test_apa.py ..................                                      [  9%]
tests/findit/test_aps.py .......                                                 [ 10%]
tests/findit/test_asm.py .................                                       [ 13%]
tests/findit/test_asme.py .........                                              [ 14%]
tests/findit/test_ats.py ...............                                         [ 16%]
tests/findit/test_bentham.py ..........                                          [ 18%]
tests/findit/test_biochemsoc.py ............                                     [ 20%]
tests/findit/test_bmj.py .......                                                 [ 21%]
tests/findit/test_brill.py ..........                                            [ 22%]
tests/findit/test_cambridge.py ...                                               [ 23%]
tests/findit/test_degruyter.py ........                                          [ 24%]
tests/findit/test_dovepress.py .....                                             [ 25%]
tests/findit/test_dustri.py ...                                                  [ 25%]
tests/findit/test_hilaris.py ...............                                     [ 27%]
tests/findit/test_inderscience.py ...........                                    [ 29%]
tests/findit/test_ingentaconnect.py ...........                                  [ 30%]
tests/findit/test_iop.py ........                                                [ 32%]
tests/findit/test_jama.py ...                                                    [ 32%]
tests/findit/test_jci.py .......                                                 [ 33%]
tests/findit/test_jstage.py .......                                              [ 34%]
tests/findit/test_liebert.py ....                                                [ 35%]
tests/findit/test_longdom.py .....                                               [ 35%]
tests/findit/test_lww.py ...                                                     [ 36%]
tests/findit/test_mdpi.py ..........                                             [ 37%]
tests/findit/test_nature.py .......                                              [ 38%]
tests/findit/test_nejm.py ......                                                 [ 39%]
tests/findit/test_oatext.py .........                                            [ 40%]
tests/findit/test_oxford_academic.py ............                                [ 42%]
tests/findit/test_plos.py ......                                                 [ 43%]
tests/findit/test_pmc.py .                                                       [ 43%]
tests/findit/test_pnas.py .......                                                [ 44%]
tests/findit/test_projectmuse.py ....................                            [ 47%]
tests/findit/test_rsc.py .........                                               [ 48%]
tests/findit/test_scielo.py ............                                         [ 50%]
tests/findit/test_sciencedirect.py ............                                  [ 52%]
tests/findit/test_sciendo.py .....                                               [ 53%]
tests/findit/test_scirp.py .......                                               [ 54%]
tests/findit/test_taylor_francis.py .........                                    [ 55%]
tests/findit/test_thieme.py ..............                                       [ 57%]
tests/findit/test_uchicago.py ......                                             [ 58%]
tests/findit/test_walshmedia.py ...............                                  [ 60%]
tests/findit/test_wiley.py ...............                                       [ 62%]
tests/findit/test_wjgnet.py ..........                                           [ 64%]
tests/findit/test_wolterskluwer.py ......                                        [ 65%]
tests/findit/test_worldscientific.py ..........                                  [ 66%]
tests/test_asciify.py ....                                                       [ 67%]
tests/test_base.py ...                                                           [ 67%]
tests/test_bibtex_citation.py ...................                                [ 70%]
tests/test_citation_formatting.py ......                                         [ 71%]
tests/test_citation_html_regression.py ........                                  [ 72%]
tests/test_clinvar_fetcher.py .....................                              [ 75%]
tests/test_consolidated_publishers.py ...............                            [ 77%]
tests/test_convert.py ...                                                        [ 78%]
tests/test_crossref_work.py ................                                     [ 80%]
tests/test_eutils_common.py ..                                                   [ 80%]
tests/test_findit.py ...........                                                 [ 82%]
tests/test_findit_handlers.py .................                                  [ 84%]
tests/test_findit_offline_construction.py .........                              [ 86%]
tests/test_html_citation_protection.py ..............                            [ 88%]
tests/test_medgen_fetcher.py ...                                                 [ 88%]
tests/test_ncbi_health_check.py .....................                            [ 91%]
tests/test_pmids_for_citation.py ....                                            [ 92%]
tests/test_pubmed_advquery.py ......                                             [ 93%]
tests/test_pubmed_article.py .....................                               [ 96%]
tests/test_pubmed_fetcher.py ....                                                [ 96%]
tests/test_registry_dance_consistency.py ....                                    [ 97%]
tests/test_text_mining.py .........                                              [ 98%]
tests/test_urlreverse_offline.py .....                                           [ 99%]
tests/test_utils.py ...                                                          [100%]

=========================== 684 passed in 354.44s (0:05:54) ============================
```