### PR TITLE
test: make live-eutils loop tests deterministic (offline fixtures + live_network)

### DIFF
--- a/tests/findit/test_longdom.py
+++ b/tests/findit/test_longdom.py
@@ -82,23 +82,29 @@ class TestLongdomDance(BaseDanceTest):
         assert url.endswith('.pdf')
         print(f"Test 2 - PDF URL: {url}")
 
+    @patch('metapub.findit.dances.longdom.the_doi_2step')
     @patch('metapub.findit.dances.longdom.verify_pdf_url')
-    def test_verification_success(self, mock_verify):
+    def test_verification_success(self, mock_verify, mock_doi_2step):
         """Test 3: Successful verification using standard verify_pdf_url."""
+        # the_doi_2step does a live dx.doi.org resolve; mock it so this stays a unit test.
+        mock_doi_2step.return_value = 'https://www.longdom.org/open-access/test-article.pdf'
         expected_pdf_url = 'https://www.longdom.org/open-access/test-article.pdf'
         mock_verify.return_value = expected_pdf_url
-        
+
         result = the_longdom_hustle(self.mock_pma, verify=True)
         
         assert result == expected_pdf_url
         mock_verify.assert_called_once()
         print(f"Test 3 - Successful verification: {result}")
 
+    @patch('metapub.findit.dances.longdom.the_doi_2step')
     @patch('metapub.findit.dances.longdom.verify_pdf_url')
-    def test_verification_access_denied_bubbles_up(self, mock_verify):
+    def test_verification_access_denied_bubbles_up(self, mock_verify, mock_doi_2step):
         """Test 4: AccessDenied from verify_pdf_url bubbles up correctly."""
+        # the_doi_2step does a live dx.doi.org resolve; mock it so this stays a unit test.
+        mock_doi_2step.return_value = 'https://www.longdom.org/open-access/test-article.pdf'
         mock_verify.side_effect = AccessDenied('DENIED: Access forbidden')
-        
+
         with pytest.raises(AccessDenied):
             the_longdom_hustle(self.mock_pma, verify=True)
         

--- a/tests/findit/test_scielo.py
+++ b/tests/findit/test_scielo.py
@@ -196,7 +196,7 @@ class TestScieloDance(BaseDanceTest):
         print(f"Test 7 - Correctly handled missing data: {exc_info.value}")
 
     @patch('metapub.findit.dances.scielo.etree.fromstring')
-    @patch('requests.get')
+    @patch('metapub.findit.dances.scielo.unified_uri_get')
     def test_scielo_chula_html_parsing_error(self, mock_get, mock_etree):
         """Test 8: HTML parsing error handling.
         
@@ -213,8 +213,8 @@ class TestScieloDance(BaseDanceTest):
         from lxml import etree
         mock_etree.side_effect = etree.XMLSyntaxError("XML parsing failed", None, 0, 0)
 
-        pma = self.fetch.article_by_pmid('23657305')
-        
+        pma = load_pmid_xml('23657305')
+
         # Test - should handle parsing error
         with pytest.raises(NoPDFLink) as exc_info:
             the_scielo_chula(pma, verify=False)

--- a/tests/fixtures/pmid_xml/1000.xml
+++ b/tests/fixtures/pmid_xml/1000.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">1000</PMID>
+      <DateCompleted>
+        <Year>1976</Year>
+        <Month>02</Month>
+        <Day>21</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>05</Month>
+        <Day>01</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0264-6021</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>149</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>1975</Year>
+              <Month>Sep</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>The Biochemical journal</Title>
+          <ISOAbbreviation>Biochem J</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>The amino acid sequence of Neurospora NADP-specific glutamate dehydrogenase. The tryptic peptides.</ArticleTitle>
+        <Pagination>
+          <StartPage>739</StartPage>
+          <EndPage>748</EndPage>
+          <MedlinePgn>739-48</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>The NADP-specific glutamate dehydrogenase of Neurospora crassa was digested with trypsin, and peptides accounting for 441 out of the 452 residues of the polypeptide chain were isolated and substantially sequenced. Additional experimental detail has been deposited as Supplementary Publication SUP 50052 (11 pages) with the British Library (Lending Division), Boston Spa, Wetherby, W. Yorkshire LS23 7BQ, U.K., from whom copies may be obtained under the terms given in Biochem J. (1975) 145, 5.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Wootton</LastName>
+            <ForeName>J C</ForeName>
+            <Initials>JC</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Taylor</LastName>
+            <ForeName>J G</ForeName>
+            <Initials>JG</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Jackson</LastName>
+            <ForeName>A A</ForeName>
+            <Initials>AA</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Chambers</LastName>
+            <ForeName>G K</ForeName>
+            <Initials>GK</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Fincham</LastName>
+            <ForeName>J R</ForeName>
+            <Initials>JR</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Biochem J</MedlineTA>
+        <NlmUniqueID>2984726R</NlmUniqueID>
+        <ISSNLinking>0264-6021</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000577">Amides</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000596">Amino Acids</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D010446">Peptide Fragments</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>53-59-8</RegistryNumber>
+          <NameOfSubstance UI="D009249">NADP</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 1.4.1.2</RegistryNumber>
+          <NameOfSubstance UI="D005969">Glutamate Dehydrogenase</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 3.4.21.4</RegistryNumber>
+          <NameOfSubstance UI="D014357">Trypsin</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000577" MajorTopicYN="N">Amides</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="N">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000595" MajorTopicYN="N">Amino Acid Sequence</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000596" MajorTopicYN="N">Amino Acids</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="N">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005969" MajorTopicYN="N">Glutamate Dehydrogenase</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="Y">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009249" MajorTopicYN="N">NADP</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009491" MajorTopicYN="N">Neurospora</DescriptorName>
+          <QualifierName UI="Q000201" MajorTopicYN="Y">enzymology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009492" MajorTopicYN="N">Neurospora crassa</DescriptorName>
+          <QualifierName UI="Q000201" MajorTopicYN="Y">enzymology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010446" MajorTopicYN="N">Peptide Fragments</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="N">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014357" MajorTopicYN="N">Trypsin</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1975</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1975</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1975</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>1976</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">1000</ArticleId>
+        <ArticleId IdType="pmc">PMC1165682</ArticleId>
+        <ArticleId IdType="doi">10.1042/bj1490739</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Biochem J. 1975 Sep;149(3):749-55</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1001</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Mol Biol. 1966 Jun;17(2):503-12</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">5963081</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Mol Biol. 1963 May;6:361-73</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">13945206</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Mol Biol. 1964 Dec;10:423-37</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">14255110</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biol Chem. 1975 May 25;250(10):3644-54</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">236297</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Biochem Biophys Res Commun. 1970 Sep 10;40(5):1173-8</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4100801</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Anal Biochem. 1972 Aug;48(2):546-56</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4115984</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biol Chem. 1973 Sep 10;248(17):6002-8</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4146914</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Mol Biol. 1962 Apr;4:257-74</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">13892910</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Genet Res. 1965 Feb;6:121-9</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">14297590</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biol Chem. 1967 May 10;242(9):2134-8</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4381526</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nature. 1966 Aug 6;211(5049):591-3</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">5968723</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Proc Natl Acad Sci U S A. 1974 Nov;71(11):4361-5</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4155068</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Biochem J. 1974 Nov;143(2):317-29</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4156826</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biol Chem. 1972 Oct 25;247(20):6720-6</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4627743</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Biochem J. 1970 Oct;119(5):805-22</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">4923920</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Biochem J. 1975 Sep;149(3):757-73</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1002</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/100000.xml
+++ b/tests/fixtures/pmid_xml/100000.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">100000</PMID>
+      <DateCompleted>
+        <Year>1978</Year>
+        <Month>11</Month>
+        <Day>18</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>10</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0160-3450</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>18</Volume>
+            <Issue>10</Issue>
+            <PubDate>
+              <Year>1978</Year>
+              <Month>Sep</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>American pharmacy</Title>
+          <ISOAbbreviation>Am Pharm</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Drugs and the high cost of health care.</ArticleTitle>
+        <Pagination>
+          <StartPage>20</StartPage>
+          <EndPage>21</EndPage>
+          <MedlinePgn>20-1</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Roffe</LastName>
+            <ForeName>B D</ForeName>
+            <Initials>BD</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lamy</LastName>
+            <ForeName>P P</ForeName>
+            <Initials>PP</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Am Pharm</MedlineTA>
+        <NlmUniqueID>7801164</NlmUniqueID>
+        <ISSNLinking>0160-3450</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D004358" MajorTopicYN="N">Drug Therapy</DescriptorName>
+          <QualifierName UI="Q000191" MajorTopicYN="Y">economics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004363" MajorTopicYN="N">Drug Utilization</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005102" MajorTopicYN="Y">Health Expenditures</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1978</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1978</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1978</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">100000</ArticleId>
+        <ArticleId IdType="doi">10.1016/s0160-3450(15)32607-6</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/10440612.xml
+++ b/tests/fixtures/pmid_xml/10440612.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">10440612</PMID>
+      <DateCompleted>
+        <Year>1999</Year>
+        <Month>09</Month>
+        <Day>27</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>08</Month>
+        <Day>14</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0036-5521</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>34</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>1999</Year>
+              <Month>Jun</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Scandinavian journal of gastroenterology</Title>
+          <ISOAbbreviation>Scand J Gastroenterol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Germline and somatic mutations in exon 15 of the APC gene and K-ras mutations in duodenal adenomas in patients with familial adenomatous polyposis.</ArticleTitle>
+        <Pagination>
+          <StartPage>611</StartPage>
+          <EndPage>617</EndPage>
+          <MedlinePgn>611-7</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText Label="BACKGROUND" NlmCategory="BACKGROUND">In sporadic colorectal adenomas mutations in the adenomatous polyposis gene (APC) are among the first gene aberrations to appear. In familial adenomatous polyposis (FAP) the patients already have a germline mutation in the APC gene. To investigate the natural history of duodenal adenomas in FAP patients, we examined germline and somatic mutations of the APC gene and K-ras mutations in these lesions.</AbstractText>
+          <AbstractText Label="METHODS" NlmCategory="METHODS">Frozen sections from 54 duodenal polyps from 31 FAP patients were used to histologically verify the presence of adenomatous growth in the mucosa; the rest of each biopsy specimen was processed for DNA extraction. APC exon 15 was investigated with the protein truncation test (PTT), using four overlapping polymerase chain reaction (PCR) fragments, and samples showing an APC mutation were thereafter sequenced. The adenomas were examined for K-ras mutations by use of a combination of the 'enriched PCR method' and temporal temperature gradient electrophoresis.</AbstractText>
+          <AbstractText Label="RESULTS" NlmCategory="RESULTS">APC germline mutations in exon 15 were found in 19 of 31 (61%) patients, whereas somatic mutations were localized to 12 of 54 (22%) duodenal adenomas. In seven adenomas both the germline and the somatic mutations were found, whereas five small adenomas showed somatic mutations only. There was no tendency for more mutations to be detected in large and severely dysplastic adenomas compared with small and mildly dysplastic ones. K-ras mutations were found in four (7%) duodenal adenomas.</AbstractText>
+          <AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">The low rate of somatic APC and K-ras mutations in duodenal adenomas may indicate another neoplastic pathway than in FAP adenomas of the large bowel, or that a modifier gene is cosegregating with the disease.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Norheim Andersen</LastName>
+            <ForeName>S</ForeName>
+            <Initials>S</Initials>
+            <AffiliationInfo>
+              <Affiliation>Institute of Forensic Medicine and Medical Dept. A, Rikshospitalet, The National Hospital, University of Oslo, Norway.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>L&#248;vig</LastName>
+            <ForeName>T</ForeName>
+            <Initials>T</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Fausa</LastName>
+            <ForeName>O</ForeName>
+            <Initials>O</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rognum</LastName>
+            <ForeName>T O</ForeName>
+            <Initials>TO</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Scand J Gastroenterol</MedlineTA>
+        <NlmUniqueID>0060105</NlmUniqueID>
+        <ISSNLinking>0036-5521</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <CommentsCorrectionsList>
+        <CommentsCorrections RefType="CommentIn">
+          <RefSource>Scand J Gastroenterol. 1999 Jun;34(6):545. doi: 10.1080/003655299750025976.</RefSource>
+          <PMID Version="1">10440601</PMID>
+        </CommentsCorrections>
+      </CommentsCorrectionsList>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000236" MajorTopicYN="N">Adenoma</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011125" MajorTopicYN="N">Adenomatous Polyposis Coli</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004252" MajorTopicYN="N">DNA Mutational Analysis</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004379" MajorTopicYN="N">Duodenal Neoplasms</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004591" MajorTopicYN="N">Electrophoresis, Polyacrylamide Gel</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005091" MajorTopicYN="N">Exons</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017491" MajorTopicYN="Y">Genes, APC</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011905" MajorTopicYN="Y">Genes, ras</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018095" MajorTopicYN="N">Germ-Line Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019656" MajorTopicYN="N">Loss of Heterozygosity</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016133" MajorTopicYN="N">Polymerase Chain Reaction</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017384" MajorTopicYN="N">Sequence Deletion</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1999</Year>
+          <Month>8</Month>
+          <Day>10</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1999</Year>
+          <Month>8</Month>
+          <Day>10</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1999</Year>
+          <Month>8</Month>
+          <Day>10</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">10440612</ArticleId>
+        <ArticleId IdType="doi">10.1080/003655299750026083</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/1234567.xml
+++ b/tests/fixtures/pmid_xml/1234567.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">1234567</PMID>
+      <DateCompleted>
+        <Year>1977</Year>
+        <Month>01</Month>
+        <Day>29</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>10</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0301-3073</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>3</Volume>
+            <PubDate>
+              <Year>1975</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Frontiers of hormone research</Title>
+          <ISOAbbreviation>Front Horm Res</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>The effect of castration and peroral estrogen therapy on some psychological functions.</ArticleTitle>
+        <Pagination>
+          <StartPage>94</StartPage>
+          <EndPage>104</EndPage>
+          <MedlinePgn>94-104</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Rauramo</LastName>
+            <ForeName>L</ForeName>
+            <Initials>L</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lagerspetz</LastName>
+            <ForeName>K</ForeName>
+            <Initials>K</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Engblom</LastName>
+            <ForeName>P</ForeName>
+            <Initials>P</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Punnonen</LastName>
+            <ForeName>R</ForeName>
+            <Initials>R</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Switzerland</Country>
+        <MedlineTA>Front Horm Res</MedlineTA>
+        <NlmUniqueID>0320246</NlmUniqueID>
+        <ISSNLinking>0301-3073</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>4TI98Z838E</RegistryNumber>
+          <NameOfSubstance UI="D004958">Estradiol</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001007" MajorTopicYN="N">Anxiety</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002369" MajorTopicYN="Y">Castration</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004644" MajorTopicYN="N">Emotions</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004958" MajorTopicYN="N">Estradiol</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="Y">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007044" MajorTopicYN="N">Hysterectomy</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008568" MajorTopicYN="N">Memory</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008593" MajorTopicYN="Y">Menopause</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011581" MajorTopicYN="N">Psychological Tests</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1975</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1975</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1975</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">1234567</ArticleId>
+        <ArticleId IdType="doi">10.1159/000398269</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/15764155.xml
+++ b/tests/fixtures/pmid_xml/15764155.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">15764155</PMID>
+      <DateCompleted>
+        <Year>2005</Year>
+        <Month>07</Month>
+        <Day>15</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2026</Year>
+        <Month>01</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0036-5521</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>40</Volume>
+            <Issue>2</Issue>
+            <PubDate>
+              <Year>2005</Year>
+              <Month>Feb</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Scandinavian journal of gastroenterology</Title>
+          <ISOAbbreviation>Scand J Gastroenterol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Mutations N34S and P55S of the SPINK1 gene in patients with chronic pancreatitis or pancreatic cancer and in healthy subjects: a report from Finland.</ArticleTitle>
+        <Pagination>
+          <StartPage>225</StartPage>
+          <EndPage>230</EndPage>
+          <MedlinePgn>225-30</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText Label="OBJECTIVE" NlmCategory="OBJECTIVE">Mutations in the Kazal type 1 serine protease inhibitor (SPINK1) gene have recently been associated with chronic pancreatitis (CP), an established risk factor for pancreatic cancer. The aim of this study was to investigate the frequency of the SPINK1 gene mutations (N34S and P55S) in patients with CP, or pancreatic cancer, and in healthy subjects in Finland.</AbstractText>
+          <AbstractText Label="MATERIAL AND METHODS" NlmCategory="METHODS">The N34S and P55S mutations were determined by PCR amplification followed by solid-phase minisequencing in 116 patients with CP and in 188 with pancreatic cancer. In patients with CP, alcohol was the aetiological factor in 87 (75%), pancreas divisum in 4 (3%), gallstones in 5 (5%) and 20 patients (17%) had an idiopathic disease; 459 healthy individuals were enrolled as controls.</AbstractText>
+          <AbstractText Label="RESULTS" NlmCategory="RESULTS">The frequency of the N34S mutation was significantly higher in patients with CP (14/116, 12%) than in controls (12/459, 2.6%) (p&lt;0.0001). There was no difference in the frequency of the P55S mutation between patients with CP (1/116, 0.9%) and controls (6/459, 1.3%). The N34S mutation was present in 9 (10%) out of 87 patients with alcoholic CP, and in 5 (25%) patients with idiopathic CP. No SPINK1 mutations were found in patients with CP caused by anatomical variations or gallstones. Among the 188 patients with a pancreatic malignant tumour, the N34S mutation was present in 7 cases (3.7%). The frequency of the N34S mutation in healthy controls in this study was significantly higher than earlier reported in other countries (p=0.03).</AbstractText>
+          <AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">The SPINK1 N34S mutation was significantly associated with an increased risk of CP. The association of the N34S mutation with alcoholic CP was marginally stronger than in earlier studies, whereas in the Finnish population in general, this mutation was significantly more frequent than reported elsewhere.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Lempinen</LastName>
+            <ForeName>Marko</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Fourth Department of Surgery, Helsinki University Central Hospital, FI-00029 Helsinki, Finland. marko.lempinen@hus.fi</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Paju</LastName>
+            <ForeName>Annukka</ForeName>
+            <Initials>A</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kemppainen</LastName>
+            <ForeName>Esko</ForeName>
+            <Initials>E</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Smura</LastName>
+            <ForeName>Teemu</ForeName>
+            <Initials>T</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kyl&#228;np&#228;&#228;</LastName>
+            <ForeName>Marja-Leena</ForeName>
+            <Initials>ML</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Nevanlinna</LastName>
+            <ForeName>Heli</ForeName>
+            <Initials>H</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Stenman</LastName>
+            <ForeName>Jakob</ForeName>
+            <Initials>J</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Stenman</LastName>
+            <ForeName>Ulf-H&#229;kan</ForeName>
+            <Initials>UH</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Scand J Gastroenterol</MedlineTA>
+        <NlmUniqueID>0060105</NlmUniqueID>
+        <ISSNLinking>0036-5521</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D002352">Carrier Proteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="C486642">SPINK1 protein, human</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>50936-63-5</RegistryNumber>
+          <NameOfSubstance UI="D014359">Trypsin Inhibitor, Kazal Pancreatic</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000369" MajorTopicYN="N">Aged, 80 and over</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002352" MajorTopicYN="N">Carrier Proteins</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002908" MajorTopicYN="N">Chronic Disease</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005387" MajorTopicYN="N" Type="Geographic">Finland</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009154" MajorTopicYN="N">Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010190" MajorTopicYN="N">Pancreatic Neoplasms</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010195" MajorTopicYN="N">Pancreatitis</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014359" MajorTopicYN="N">Trypsin Inhibitor, Kazal Pancreatic</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2005</Year>
+          <Month>3</Month>
+          <Day>15</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2005</Year>
+          <Month>7</Month>
+          <Day>16</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2005</Year>
+          <Month>3</Month>
+          <Day>15</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">15764155</ArticleId>
+        <ArticleId IdType="doi">10.1080/00365520510011560</ArticleId>
+        <ArticleId IdType="pii">HR3YPC6AWB33CDKF</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/18393105.xml
+++ b/tests/fixtures/pmid_xml/18393105.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">18393105</PMID>
+      <DateCompleted>
+        <Year>2008</Year>
+        <Month>07</Month>
+        <Day>10</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2008</Year>
+        <Month>04</Month>
+        <Day>08</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1472-4472</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>9</Volume>
+            <Issue>4</Issue>
+            <PubDate>
+              <Year>2008</Year>
+              <Month>Apr</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Current opinion in investigational drugs (London, England : 2000)</Title>
+          <ISOAbbreviation>Curr Opin Investig Drugs</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Advances in glycogen phosphorylase inhibitor design.</ArticleTitle>
+        <Pagination>
+          <StartPage>379</StartPage>
+          <EndPage>395</EndPage>
+          <MedlinePgn>379-95</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>The regulation of glycogen metabolism is a major therapeutic strategy for blood glucose control in type 2 diabetes. Because glycogen phosphorylase catalyzes the first step in the phosphorolysis of glycogen, it has become a potential key target for controlling hyperglycemia in this disease. This review focuses on advances in new, mostly synthetic, molecules that inhibit glycogen phosphorylase, and describes progress in our understanding of the mechanism of action of these inhibitors gained through X-ray crystallographic studies.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Oikonomakos</LastName>
+            <ForeName>Nikos G</ForeName>
+            <Initials>NG</Initials>
+            <AffiliationInfo>
+              <Affiliation>National Hellenic Research Foundation, Institute of Organic and Pharmaceutical Chemistry, 48 Vassileos Constantinou Avenue, Athens 11635, Greece. ngo@eie.gr</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Soms&#225;k</LastName>
+            <ForeName>L&#225;szl&#243;</ForeName>
+            <Initials>L</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Curr Opin Investig Drugs</MedlineTA>
+        <NlmUniqueID>100965718</NlmUniqueID>
+        <ISSNLinking>1472-4472</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D004791">Enzyme Inhibitors</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D007004">Hypoglycemic Agents</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9005-79-2</RegistryNumber>
+          <NameOfSubstance UI="D006003">Glycogen</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 2.4.1.-</RegistryNumber>
+          <NameOfSubstance UI="D024981">Glycogen Phosphorylase</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000494" MajorTopicYN="N">Allosteric Regulation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000495" MajorTopicYN="N">Allosteric Site</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000818" MajorTopicYN="N">Animals</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001665" MajorTopicYN="N">Binding Sites</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018360" MajorTopicYN="N">Crystallography, X-Ray</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015195" MajorTopicYN="Y">Drug Design</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004791" MajorTopicYN="N">Enzyme Inhibitors</DescriptorName>
+          <QualifierName UI="Q000737" MajorTopicYN="Y">chemistry</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006003" MajorTopicYN="N">Glycogen</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D024981" MajorTopicYN="N">Glycogen Phosphorylase</DescriptorName>
+          <QualifierName UI="Q000037" MajorTopicYN="N">antagonists &amp; inhibitors</QualifierName>
+          <QualifierName UI="Q000737" MajorTopicYN="Y">chemistry</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007004" MajorTopicYN="N">Hypoglycemic Agents</DescriptorName>
+          <QualifierName UI="Q000737" MajorTopicYN="Y">chemistry</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008958" MajorTopicYN="N">Models, Molecular</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015394" MajorTopicYN="N">Molecular Structure</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011485" MajorTopicYN="N">Protein Binding</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011487" MajorTopicYN="N">Protein Conformation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013329" MajorTopicYN="N">Structure-Activity Relationship</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013678" MajorTopicYN="N">Technology, Pharmaceutical</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="Y">methods</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <NumberOfReferences>54</NumberOfReferences>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2008</Year>
+          <Month>4</Month>
+          <Day>9</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2008</Year>
+          <Month>7</Month>
+          <Day>11</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2008</Year>
+          <Month>4</Month>
+          <Day>9</Day>
+          <Hour>9</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">18393105</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/20095872.xml
+++ b/tests/fixtures/pmid_xml/20095872.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">20095872</PMID>
+      <DateCompleted>
+        <Year>2011</Year>
+        <Month>03</Month>
+        <Day>29</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2020</Year>
+        <Month>11</Month>
+        <Day>13</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1651-2251</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>130</Volume>
+            <Issue>7</Issue>
+            <PubDate>
+              <Year>2010</Year>
+              <Month>Jul</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Acta oto-laryngologica</Title>
+          <ISOAbbreviation>Acta Otolaryngol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Three common GJB2 mutations causing nonsyndromic hearing loss in Chinese populations are retained in the endoplasmic reticulum.</ArticleTitle>
+        <Pagination>
+          <StartPage>799</StartPage>
+          <EndPage>803</EndPage>
+          <MedlinePgn>799-803</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.3109/00016480903443191</ELocationID>
+        <Abstract>
+          <AbstractText Label="CONCLUSION" NlmCategory="CONCLUSIONS">The three most common GJB2 mutations found in the Chinese populations, c.235delC, c.299-300delAT, and c.176-191de1 (16) bp, cannot form gap junctons (GJs) in the plasma membrane. These mutant proteins were retained in the endoplasmic reticulum (ER), suggesting that ER stress (ERS) and subsequent ERS-induced cell death may be responsible for hearing loss caused by these GJB2 truncation mutations.</AbstractText>
+          <AbstractText Label="OBJECTIVES" NlmCategory="OBJECTIVE">The objective of this study was to investigate the subcellular location of the protein products of three GJB2 mutants (c.235de1C, c.299-300delAT, and c.176-191de1 (16) bp) and to explore the deafness mechanism caused by these GJB2 truncation mutations.</AbstractText>
+          <AbstractText Label="METHODS" NlmCategory="METHODS">Mutant-eGFP fusion protein vectors were constructed by PCR and TA cloning. HEK293 cells were transfected by a liposome-mediated method. Transfected cells were incubated with ER-Tracker and observed under a confocal microscope.</AbstractText>
+          <AbstractText Label="RESULTS" NlmCategory="RESULTS">Cells transfected with wild type gave characteristic punctuate patterns of GJs in the cell membrane. In contrast, c.235de1C, c.299-300delAT, and c.176-191de1 (16) bp mutant proteins were found to be trapped in the ER, and were therefore unable to form GJs in the plasma membrane.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Zhang</LastName>
+            <ForeName>Yanping</ForeName>
+            <Initials>Y</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Otolaryngology, Hospital of Chinese PLA, Beijing, China. yanping309@yahoo.com &lt;yanping309@yahoo.com&gt;</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wang</LastName>
+            <ForeName>Ju</ForeName>
+            <Initials>J</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Li</LastName>
+            <ForeName>Lina</ForeName>
+            <Initials>L</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Sun</LastName>
+            <ForeName>Yurui</ForeName>
+            <Initials>Y</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Feng</LastName>
+            <ForeName>Bo</ForeName>
+            <Initials>B</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Acta Otolaryngol</MedlineTA>
+        <NlmUniqueID>0370354</NlmUniqueID>
+        <ISSNLinking>0001-6489</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D017630">Connexins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="C000607042">GJB2 protein, human</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D050505">Mutant Proteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>127120-53-0</RegistryNumber>
+          <NameOfSubstance UI="D000072259">Connexin 26</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D015153" MajorTopicYN="N">Blotting, Western</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002681" MajorTopicYN="N" Type="Geographic">China</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000072259" MajorTopicYN="N">Connexin 26</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017630" MajorTopicYN="N">Connexins</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004721" MajorTopicYN="N">Endoplasmic Reticulum</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006319" MajorTopicYN="N">Hearing Loss, Sensorineural</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018613" MajorTopicYN="N">Microscopy, Confocal</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D050505" MajorTopicYN="N">Mutant Proteins</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009154" MajorTopicYN="N">Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014162" MajorTopicYN="N">Transfection</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2010</Year>
+          <Month>1</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2010</Year>
+          <Month>1</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2011</Year>
+          <Month>3</Month>
+          <Day>30</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">20095872</ArticleId>
+        <ArticleId IdType="doi">10.3109/00016480903443191</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/20301546.xml
+++ b/tests/fixtures/pmid_xml/20301546.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedBookArticle>
+    <BookDocument>
+      <PMID Version="1">20301546</PMID>
+      <ArticleIdList>
+        <ArticleId IdType="bookaccession">NBK1372</ArticleId>
+      </ArticleIdList>
+      <Book>
+        <Publisher>
+          <PublisherName>University of Washington, Seattle</PublisherName>
+          <PublisherLocation>Seattle (WA)</PublisherLocation>
+        </Publisher>
+        <BookTitle book="gene">GeneReviews<sup>&#174;</sup></BookTitle>
+        <PubDate>
+          <Year>1993</Year>
+        </PubDate>
+        <BeginningDate>
+          <Year>1993</Year>
+        </BeginningDate>
+        <EndingDate>
+          <Year>2026</Year>
+        </EndingDate>
+        <AuthorList Type="editors" CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Adam</LastName>
+            <ForeName>Margaret P</ForeName>
+            <Initials>MP</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Bick</LastName>
+            <ForeName>Sarah</ForeName>
+            <Initials>S</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Mirzaa</LastName>
+            <ForeName>Ghayda M</ForeName>
+            <Initials>GM</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Pagon</LastName>
+            <ForeName>Roberta A</ForeName>
+            <Initials>RA</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wallace</LastName>
+            <ForeName>Stephanie E</ForeName>
+            <Initials>SE</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Amemiya</LastName>
+            <ForeName>Anne</ForeName>
+            <Initials>A</Initials>
+          </Author>
+        </AuthorList>
+        <Medium>Internet</Medium>
+      </Book>
+      <ArticleTitle book="gene" part="accpn">Hereditary Motor and Sensory Neuropathy with Agenesis of the Corpus Callosum</ArticleTitle>
+      <Language>eng</Language>
+      <AuthorList Type="authors" CompleteYN="Y">
+        <Author ValidYN="Y">
+          <LastName>Gauvreau</LastName>
+          <ForeName>Claudie</ForeName>
+          <Initials>C</Initials>
+          <AffiliationInfo>
+            <Affiliation>Neurology resident, CHU de Qu&#233;bec &#8211; Enfant-J&#233;sus, Laval University, Quebec City, Canada</Affiliation>
+          </AffiliationInfo>
+        </Author>
+        <Author ValidYN="Y">
+          <LastName>Brisson</LastName>
+          <ForeName>Jean-Denis</ForeName>
+          <Initials>JD</Initials>
+          <AffiliationInfo>
+            <Affiliation>Neurologist, Groupe de Recherche Interdisciplinaire sur les Maladies Neuromusculaires, Centre Int&#233;gr&#233; Universitaire de Sant&#233; et de Services Sociaux du Saguenay-Lac-Saint-Jean;, Sherbrooke University, Quebec, Canada</Affiliation>
+          </AffiliationInfo>
+        </Author>
+        <Author ValidYN="Y">
+          <LastName>Dupr&#233;</LastName>
+          <ForeName>Nicolas</ForeName>
+          <Initials>N</Initials>
+          <AffiliationInfo>
+            <Affiliation>Neurologist, Neurogenetics Clinic, Department of Neurological Sciences, CHA &#8211; Enfant-J&#233;sus, Quebec City, Canada</Affiliation>
+          </AffiliationInfo>
+        </Author>
+      </AuthorList>
+      <PublicationType UI="D016454">Review</PublicationType>
+      <Abstract>
+        <AbstractText Label="CLINICAL CHARACTERISTICS">Hereditary motor and sensory neuropathy with agenesis of the corpus callosum (HMSN/ACC), a neurodevelopmental and neurodegenerative disorder, is characterized by severe progressive sensorimotor neuropathy with resulting hypotonia, areflexia, and amyotrophy, and by variable degrees of dysgenesis of the corpus callosum. Mild-to-severe intellectual disability and "psychotic episodes" during adolescence are observed. Sensory modalities are moderately to severely affected beginning in infancy. The average age of onset of walking is 3.8 years; the average age of loss of walking is 13.8 years; the average age of death is 33 years.</AbstractText>
+        <AbstractText Label="DIAGNOSIS/TESTING">The diagnosis of HMSN/ACC is established in a proband with suggestive findings and biallelic pathogenic variants in <i>SLC12A6</i> identified by molecular genetic testing.</AbstractText>
+        <AbstractText Label="MANAGEMENT"><i>Treatment of manifestations:</i> Walking aids such as canes or walkers are required. As the disease progresses, orthoses for upper and lower limbs and physiotherapy are needed to prevent contractures. Early developmental/educational intervention addresses cognitive delays. Depending on severity, individuals with HMSN/ACC usually require corrective surgery for scoliosis. Neuroleptics may be used to treat psychiatric manifestations, usually during adolescence. <i>Surveillance:</i> Monitor in the early teens for scoliosis and in the late teens for psychiatric manifestations.</AbstractText>
+        <AbstractText Label="GENETIC COUNSELING">HMSN/ACC is inherited in an autosomal recessive manner. At conception, each sib of an affected individual has a 25% chance of being affected, a 50% chance of being an asymptomatic carrier, and a 25% chance of being unaffected and not a carrier. Heterozygotes (carriers) are asymptomatic. Once the <i>SLC12A6</i> pathogenic variants have been identified in an affected family member, carrier testing for at-risk family members and prenatal and preimplantation genetic testing are possible.</AbstractText>
+        <CopyrightInformation>Copyright &#169; 1993-2026, University of Washington, Seattle. GeneReviews is a registered trademark of the University of Washington, Seattle. All rights reserved. Test.</CopyrightInformation>
+      </Abstract>
+      <Sections>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Summary">Summary</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Diagnosis">Diagnosis</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Clinical_Characteristics">Clinical Characteristics</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Genetically_Related_Allelic_Disord">Genetically Related (Allelic) Disorders</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Differential_Diagnosis">Differential Diagnosis</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Management">Management</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Genetic_Counseling">Genetic Counseling</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Resources">Resources</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Molecular_Genetics">Molecular Genetics</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.Chapter_Notes">Chapter Notes</SectionTitle>
+        </Section>
+        <Section>
+          <SectionTitle book="gene" part="accpn" sec="accpn.References">References</SectionTitle>
+        </Section>
+      </Sections>
+      <KeywordList Owner="NLM">
+        <Keyword MajorTopicYN="N">Agenesis of Corpus Callosum with Peripheral Neuropathy (ACCPN)</Keyword>
+        <Keyword MajorTopicYN="N">Andermann Syndrome</Keyword>
+        <Keyword MajorTopicYN="N">Solute carrier family 12 member 6</Keyword>
+        <Keyword MajorTopicYN="N">SLC12A6</Keyword>
+        <Keyword MajorTopicYN="N">Hereditary Motor and Sensory Neuropathy with Agenesis of the Corpus Callosum</Keyword>
+        <Keyword MajorTopicYN="N">Agenesis of Corpus Callosum with Peripheral Neuropathy (ACCPN)</Keyword>
+        <Keyword MajorTopicYN="N">Andermann Syndrome</Keyword>
+      </KeywordList>
+      <ContributionDate>
+        <Year>2006</Year>
+        <Month>2</Month>
+        <Day>2</Day>
+      </ContributionDate>
+      <DateRevised>
+        <Year>2020</Year>
+        <Month>9</Month>
+        <Day>17</Day>
+      </DateRevised>
+      <ItemList ListType="Synonyms">
+        <Item>Agenesis of Corpus Callosum with Peripheral Neuropathy (ACCPN)</Item>
+        <Item>Andermann Syndrome</Item>
+      </ItemList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Antoniadi T, Buxton C, Dennis G, Forrester N, Smith D, Lunt P, Burton-Jones S. Application of targeted multi-gene panel testing for the diagnosis of inherited peripheral neuropathy provides a high diagnostic yield with unexpected phenotype-genotype variability. BMC Med Genet. 2015;16:84.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4578331</ArticleId>
+            <ArticleId IdType="pubmed">26392352</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Auer RN, Lagani&#232;re J, Robitaille Y, Richardson J, Dion PA, Rouleau GA, Shekarabi M. KCC3 axonopathy: neuropathological features in the central and peripheral nervous system. Mod Pathol. 2016;29:962-76.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">27230413</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Delpire E, Kahle KT. The KCC3 cotransporter as a therapeutic target for peripheral neuropathy. Expert Opin Ther Targets. 2017;21:113-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28019725</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dupr&#233; N, Howard HC, Mathieu J, Karpati G, Vanasse M, Bouchard JP, Carpenter S, Rouleau GA. Hereditary motor and sensory neuropathy with agenesis of the corpus callosum. Ann Neurol. 2003;54:9-18</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">12838516</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Flores B, Schornak CC, Delpire E. A role for kcc3 in maintaining cell volume of peripheral nerve fibers. Neurochemistry international. 2019;123:114-24.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6398598</ArticleId>
+            <ArticleId IdType="pubmed">29366908</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Howard HC, Mount DB, Rochefort D, Byun N, Dupr&#233; N, Lu J, Fan X, Song L, Rivi&#232;re JB, Pr&#233;vost C, Horst J, Simonati A, Lemcke B, Welch R, England R, Zhan FQ, Mercado A, Siesser WB, George AL Jr, McDonald MP, Bouchard JP, Mathieu J, Delpire E, Rouleau GA. The K-Cl cotransporter KCC3 is mutant in a severe peripheral neuropathy associated with agenesis of the corpus callosum. Nat Genet. 2002;32:384-92.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">12368912</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J&#243;nsson H, Sulem P, Kehr B, Kristmundsdottir S, Zink F, Hjartarson E, Hardarson MT, Hjorleifsson KE, Eggertsson HP, Gudjonsson SA, Ward LD, Arnadottir GA, Helgason EA, Helgason H, Gylfason A, Jonasdottir A, Jonasdottir A, Rafnar T, Frigge M, Stacey SN, Th Magnusson O, Thorsteinsdottir U, Masson G, Kong A, Halldorsson BV, Helgason A, Gudbjartsson DF, Stefansson K. Parental influence on human germline de novo mutations in 1,548 trios from Iceland. Nature. 2017;549:519-22.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28959963</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Larbrisseau L, Sarnat H. Andermann syndrome. In: Roos RP, ed. <i>MedLink Neurology</i>. San Diego: MedLink Corporation; 2017.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Larbrisseau A, Vanasse M, Brochu P, Jasmin G. The Andermann syndrome: agenesis of the corpus callosum associated with mental retardation and progressive sensorimotor neuronopathy. Can J Neurol Sci. 1984;11:257-61.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">6329500</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mathieu J, B&#233;dard F, Pr&#233;vost C, Langevin P. Motor and sensory neuropathies with or without agenesis of the corpus callosum: a radiological study of 64 cases. Can J Neurol Sci. 1990;17:103-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2357646</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Richards S, Aziz N, Bale S, Bick D, Das S, Gastier-Foster J, Grody WW, Hegde M, Lyon E, Spector E, Voelkerding K, Rehm HL; ACMG Laboratory Quality Assurance Committee. Standards and guidelines for the interpretation of sequence variants: a joint consensus recommendation of the American College of Medical Genetics and Genomics and the Association for Molecular Pathology. Genet Med. 2015;17:405-24.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4544753</ArticleId>
+            <ArticleId IdType="pubmed">25741868</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Salin-Cantegrel A, Rivi&#232;re JB, Dupr&#233; N, Charron FM, Shekarabi M, Kar&#233;m&#233;ra L, Gaspar C, Horst J, Tekin M, Deda G, Krause A, Lippert MM, Willemsen MA, Jarrar R, Lapointe JY, Rouleau GA. Distal truncation of KCC3 in non-French Canadian HMSN/ACC families. Neurology. 2007;69:1350-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">17893295</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shekarabi M, Moldrich RX, Rasheed S, Salin-Cantegrel A, Lagani&#232;re J, Rochefort D, Hince P, Huot K, Gaudet R, Kurniawan N, Sotocinal SG, Ritchie J, Dion PA, Mogil JS, Richards LJ, Rouleau GA. Loss of neuronal potassium/chloride cotransporter 3 (KCC3) is responsible for the degenerative phenotype in a conditional mouse model of hereditary motor and sensory neuropathy associated with agenesis of the corpus callosum. J Neurosci. 2012;32:3865-76.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6703451</ArticleId>
+            <ArticleId IdType="pubmed">22423107</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Stenson PD, Mort M, Ball EV, Chapman M, Evans K, Azevedo L, Hayden M, Heywood S, Millar DS, Phillips AD, Cooper DN. The Human Gene Mutation Database (HGMD&#174;): optimizing its use in a clinical diagnostic or research setting. Hum Genet. 2020;139:1197-207.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7497289</ArticleId>
+            <ArticleId IdType="pubmed">32596782</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sun YT, Tzeng SF, Lin TS, Hsu KS, Delpire E, Shen MR. Kcc3 deficiency-induced disruption of paranodal loops and impairment of axonal excitability in the peripheral nervous system. Neuroscience. 2016;335:91-102.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">27568057</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Uyanik G, Elcioglu N, Penzien J, Gross C, Yilmaz Y, Olmez A, Demir E, Wahl D, Scheglmann K, Winner B, Bogdahn U, Topaloglu H, Hehr U, Winkler J. Novel truncating and missense mutations of the KCC3 gene associated with Andermann syndrome. Neurology. 2006;66:1044-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">16606917</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </BookDocument>
+    <PubmedBookData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2020</Year>
+          <Month>9</Month>
+          <Day>17</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2020</Year>
+          <Month>9</Month>
+          <Day>17</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2020</Year>
+          <Month>9</Month>
+          <Day>17</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">20301546</ArticleId>
+      </ArticleIdList>
+    </PubmedBookData>
+  </PubmedBookArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/23435529.xml
+++ b/tests/fixtures/pmid_xml/23435529.xml
@@ -1,0 +1,655 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">23435529</PMID>
+      <DateCompleted>
+        <Year>2014</Year>
+        <Month>04</Month>
+        <Day>11</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2021</Year>
+        <Month>10</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print-Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1573-7330</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>30</Volume>
+            <Issue>4</Issue>
+            <PubDate>
+              <Year>2013</Year>
+              <Month>Apr</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Journal of assisted reproduction and genetics</Title>
+          <ISOAbbreviation>J Assist Reprod Genet</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Lower sperm DNA fragmentation after r-FSH administration in functional hypogonadotropic hypogonadism.</ArticleTitle>
+        <Pagination>
+          <StartPage>497</StartPage>
+          <EndPage>503</EndPage>
+          <MedlinePgn>497-503</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1007/s10815-013-9951-y</ELocationID>
+        <Abstract>
+          <AbstractText Label="PURPOSE" NlmCategory="OBJECTIVE">An observational clinical and molecular study was designed to evaluate the effects of the administration of recombinant human FSH on sperm DNA fragmentation in men with a non-classical form of hypogonadotropic hypogonadism and idiopathic oligoasthenoteratozoospermia.</AbstractText>
+          <AbstractText Label="METHODS" NlmCategory="METHODS">In the study were included 53 men with a non-classical form of hypogonadotropic hypogonadism and idiopathic oligoasthenoteratozoospermia. In all patients, sperm DNA fragmentation index (DFI), assessed by terminal deoxynucleotidyl transferase-mediated deoxyuridine triphosphate (dUTP) in situ DNA nick end-labelling (TUNEL) assay, was evaluated before starting the treatment with 150 IU of recombinant human FSH, given three times a week for at least 3 months. Patients' semen analysis and DNA fragmentation index were re-evaluated after the 3-month treatment period.</AbstractText>
+          <AbstractText Label="RESULTS" NlmCategory="RESULTS">After recombinant human FSH therapy, we did not find any differences in terms of sperm count, motility and morphology. The average DNA fragmentation index was significantly reduced (21.15 vs 15.2, p&lt;0.05), but we found a significant reduction in patients with high basal DFI values (&gt;15 %), while no significant variation occurred in the patients with DFI values &#8804; 15 %.</AbstractText>
+          <AbstractText Label="CONCLUSIONS" NlmCategory="CONCLUSIONS">Recombinant human FSH administration improves sperm DNA integrity in hypogonadotropic hypogonadism and idiopathic oligoasthenoteratozoospermia men with DNA fragmentation index value &gt;15 % .</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Ruvolo</LastName>
+            <ForeName>Giovanni</ForeName>
+            <Initials>G</Initials>
+            <AffiliationInfo>
+              <Affiliation>Centro di Biologia della Riproduzione, via V. Villareale 54, 90141, Palermo, Italy. ruvologi@hotmail.com</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Roccheri</LastName>
+            <ForeName>Maria Carmela</ForeName>
+            <Initials>MC</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Brucculeri</LastName>
+            <ForeName>Anna Maria</ForeName>
+            <Initials>AM</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Longobardi</LastName>
+            <ForeName>Salvatore</ForeName>
+            <Initials>S</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Cittadini</LastName>
+            <ForeName>Ettore</ForeName>
+            <Initials>E</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Bosco</LastName>
+            <ForeName>Liana</ForeName>
+            <Initials>L</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+        <ArticleDate DateType="Electronic">
+          <Year>2013</Year>
+          <Month>02</Month>
+          <Day>24</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Netherlands</Country>
+        <MedlineTA>J Assist Reprod Genet</MedlineTA>
+        <NlmUniqueID>9206495</NlmUniqueID>
+        <ISSNLinking>1058-0468</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D043373">Follicle Stimulating Hormone, Human</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D011994">Recombinant Proteins</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D053627" MajorTopicYN="N">Asthenozoospermia</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D053938" MajorTopicYN="Y">DNA Fragmentation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D043373" MajorTopicYN="N">Follicle Stimulating Hormone, Human</DescriptorName>
+          <QualifierName UI="Q000008" MajorTopicYN="Y">administration &amp; dosage</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007006" MajorTopicYN="N">Hypogonadism</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009845" MajorTopicYN="N">Oligospermia</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011994" MajorTopicYN="N">Recombinant Proteins</DescriptorName>
+          <QualifierName UI="Q000008" MajorTopicYN="N">administration &amp; dosage</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013076" MajorTopicYN="N">Sperm Count</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013094" MajorTopicYN="N">Spermatozoa</DescriptorName>
+          <QualifierName UI="Q000166" MajorTopicYN="N">cytology</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="received">
+          <Year>2012</Year>
+          <Month>11</Month>
+          <Day>6</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2013</Year>
+          <Month>1</Month>
+          <Day>28</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2013</Year>
+          <Month>2</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2013</Year>
+          <Month>2</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2014</Year>
+          <Month>4</Month>
+          <Day>12</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2014</Year>
+          <Month>4</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">23435529</ArticleId>
+        <ArticleId IdType="pmc">PMC3644128</ArticleId>
+        <ArticleId IdType="doi">10.1007/s10815-013-9951-y</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Adler ID. Spermatogenesis and mutagenicity of environmental hazards: extrapolation of genetic risk from mouse to man. Andrologia. 2000;32:233&#8211;237. doi: 10.1046/j.1439-0272.2000.00390.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1046/j.1439-0272.2000.00390.x</ArticleId>
+            <ArticleId IdType="pubmed">11021514</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Aitken RJ, De Iuliis GN. On the possible origins of DNA damage in human spermatozoa. Mol Hum Reprod. 2010;16:3&#8211;13. doi: 10.1093/molehr/gap059.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/molehr/gap059</ArticleId>
+            <ArticleId IdType="pubmed">19648152</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arnaldi G, Balercia G, Barbatelli G, Mantero F. Effects of long-term treatment with human pure follicle-stimulating hormone on semen parameters and sperm-cell ultrastructure in idiopathic oligoteratoasthenozoospermia. Andrologia. 2000;32:155&#8211;161. doi: 10.1046/j.1439-0272.2000.00358.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1046/j.1439-0272.2000.00358.x</ArticleId>
+            <ArticleId IdType="pubmed">10863970</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Attia AM, Al-Inany HG, Farquhar C, Proctor M: Gonadotrophins for idiopathic male factor subfertility. Cochrane Database Syst Rev 2007, CD005071.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">17943837</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ben-Rafael Z, Farhi J, Feldberg D, Bartoov B, Kovo M, Eltes F, et al. Follicle-stimulating hormone treatment for men with idiopathic oligoteratoasthenozoospermia before in vitro fertilization: the impact on sperm microstructure and fertilization potential. Fertil Steril. 2000;73:24&#8211;30. doi: 10.1016/S0015-0282(99)00461-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0015-0282(99)00461-6</ArticleId>
+            <ArticleId IdType="pubmed">10632407</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Berkovitz A, Eltes F, Ellenbogen A, Peer S, Feldberg D, Bartoov B. Does the presence of nuclear vacuoles in human sperm selected for ICSI affect pregnancy outcome? Hum Reprod. 2006;21:1787&#8211;1790. doi: 10.1093/humrep/del049.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/del049</ArticleId>
+            <ArticleId IdType="pubmed">16497697</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bungum M, Humaidan P, Axmon A, Spano M, Bungum L, Erenpreiss J, et al. Sperm DNA integrity assessment in prediction of assisted reproduction technology outcome. Hum Reprod. 2007;22:174&#8211;179. doi: 10.1093/humrep/del326.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/del326</ArticleId>
+            <ArticleId IdType="pubmed">16921163</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Calogero A, Polosa R, Perdichizzi A, Guarino F, La Vignera S, Scarfia A, et al. Cigarette smoke extract immobilizes human spermatozoa and induces sperm apoptosis. Reprod Biomed Online. 2009;19:564&#8211;571. doi: 10.1016/j.rbmo.2009.05.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.rbmo.2009.05.004</ArticleId>
+            <ArticleId IdType="pubmed">19909599</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Caroppo E, Niederberger C, Vizziello GM, D&#8217;Amato G. Recombinant human follicle-stimulating hormone as a pretreatment for idiopathic oligoasthenoteratozoospermic patients undergoing intracytoplasmic sperm injection. Fertil Steril. 2003;80:1398&#8211;1403. doi: 10.1016/S0015-0282(03)02202-7.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0015-0282(03)02202-7</ArticleId>
+            <ArticleId IdType="pubmed">14667875</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chemes EH, Rawe YV. Sperm pathology: a step beyond descriptive morphology. Origin, characterization and fertility potential of abnormal sperm phenotypes in infertile men. Hum Reprod Updat. 2003;9:405&#8211;428. doi: 10.1093/humupd/dmg034.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humupd/dmg034</ArticleId>
+            <ArticleId IdType="pubmed">14640375</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Colacurci N, Monti MG, Fornaro F, Izzo G, Izzo P, Trotta C, et al. Recombinant Human FSH Reduces Sperm DNA Fragmentation in Men with Idiopathic Oligoasthenoteratozoospermia. J Androl. 2012;33:588&#8211;593. doi: 10.2164/jandrol.111.013326.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2164/jandrol.111.013326</ArticleId>
+            <ArticleId IdType="pubmed">21868752</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Comhaire FH, Christophe AB, Zalata AA, Dhooge WS, Mahmoud AM, Depuydt CE. The effects of combined conventional treatment, oral antioxidants and essential fatty acids on sperm biology in subfertile men. Prostaglandins Leukot Essent Fatty Acids. 2000;63:159&#8211;165. doi: 10.1054/plef.2000.0174.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1054/plef.2000.0174</ArticleId>
+            <ArticleId IdType="pubmed">10991774</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Efesoy O, &#199;ayan S, Akbay E. The efficacy of recombinant human follicle-stimulating hormone in the treatment of various types of male-factor infertility at a single University Hospital. J Androl. 2009;30(6):679&#8211;684. doi: 10.2164/jandrol.108.007278.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2164/jandrol.108.007278</ArticleId>
+            <ArticleId IdType="pubmed">19478332</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Evenson DP, Jost LK, Marshall D, Zinaman MJ, Clegg E, Purvis K, et al. Utility of the sperm chromatin structure assay as a diagnostic and prognostic tool in the human fertility clinic. Hum Reprod. 1999;14:1039&#8211;1049. doi: 10.1093/humrep/14.4.1039.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/14.4.1039</ArticleId>
+            <ArticleId IdType="pubmed">10221239</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Foresta C, Bettella A, Garolla A, Ambrosini G, Ferlin A. Treatment of male idiopathic infertility with recombinant human follicle-stimulating hormone: a prospective, controlled, randomized clinical study. Fertil Steril. 2005;84:654&#8211;661. doi: 10.1016/j.fertnstert.2005.03.055.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2005.03.055</ArticleId>
+            <ArticleId IdType="pubmed">16169399</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Foresta C, Selice R, Garolla A, Ferlin A. Follicle-stimulating hormone treatment of male infertility. Curr Opin Urol. 2008;18:602&#8211;607. doi: 10.1097/MOU.0b013e328313647d.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/MOU.0b013e328313647d</ArticleId>
+            <ArticleId IdType="pubmed">18832946</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Frydman N, Prisant N, Hesters L, Frydman R, Tachdjian G, Cohen-Bacrie P, et al. Adequate ovarian follicular status does not prevent the decrease in pregnancy rates associated with high sperm DNA fragmentation. Fertil Steril. 2008;89:92&#8211;97. doi: 10.1016/j.fertnstert.2007.02.022.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2007.02.022</ArticleId>
+            <ArticleId IdType="pubmed">17482180</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gandini L, Lombardo F, Paoli D, Caponecchia L, Familiari G, Verlengia C, et al. Study of apoptotic DNA fragmentation in human spermatozoa. Hum Reprod. 2000;15:830&#8211;839. doi: 10.1093/humrep/15.4.830.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/15.4.830</ArticleId>
+            <ArticleId IdType="pubmed">10739828</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Greco E, Romano S, Iacobelli M, Ferrero S, Baroni E, Minasi MG, et al. ICSI in cases of sperm DNA damage: beneficial effect of oral antioxidant treatment. Hum Reprod. 2005;20:2590&#8211;2594. doi: 10.1093/humrep/dei091.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/dei091</ArticleId>
+            <ArticleId IdType="pubmed">15932912</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Grunewald S, Paasch U, Glander HJ. Enrichment of non-apoptotic human spermatozoa after cryopreservation by immunomagnetic cell sorting. Cell Tissue Bank. 2001;2:127&#8211;133. doi: 10.1023/A:1020188913551.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1023/A:1020188913551</ArticleId>
+            <ArticleId IdType="pubmed">15256910</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guzick DS, Overstreet JW, Factor-Litvak P, Brazil CK, Nakajima ST, Coutifaris C, et al. Sperm morphology, motility, and concentration in fertile and infertile men. N Engl J Med. 2001;345:1388&#8211;1393. doi: 10.1056/NEJMoa003005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa003005</ArticleId>
+            <ArticleId IdType="pubmed">11794171</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hikim AP, Wang C, Leung A, Swerdloff RS. Involvement of apoptosis in the induction of germ cell degeneration in adult rats after gonadotropin-releasing hormone antagonist treatment. Endocrinology. 1995;136:2770&#8211;2775. doi: 10.1210/en.136.6.2770.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/en.136.6.2770</ArticleId>
+            <ArticleId IdType="pubmed">7750502</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jakab A, Sakkas D, Delpiano E, Cayli S, Kovanci E, Ward D, et al. Intracytoplasmic sperm injection: a novel selection method for sperm with normal frequency of chromosomal aneuploidies. Fertil Steril. 2005;84:1665&#8211;1673. doi: 10.1016/j.fertnstert.2005.05.068.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2005.05.068</ArticleId>
+            <ArticleId IdType="pubmed">16359962</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jones R, Mann T, Sherins R. Peroxidative breakdown of phospholipids in human spermatozoa, spermicidal properties of fatty acid peroxides, and protective action of seminal plasma. Fertil Steril. 1979;31:531&#8211;537.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">446777</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jones R, Mann T, Sherins RJ. Adverse effects of peroxidized lipid on human spermatozoa. Proc R Soc Lond B Biol Sci. 1978;201:413&#8211;417. doi: 10.1098/rspb.1978.0053.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1098/rspb.1978.0053</ArticleId>
+            <ArticleId IdType="pubmed">27810</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ku WW, Wine RN, Chae BY, Ghanayem BI, Chapin RE. Spermatocyte toxicity of 2-methoxyethanol (ME) in rats and guinea pigs: evidence for the induction of apoptosis. Toxicol Appl Pharmacol. 1995;134:100&#8211;110. doi: 10.1006/taap.1995.1173.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1006/taap.1995.1173</ArticleId>
+            <ArticleId IdType="pubmed">7676444</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Leduc F, Nkoma GB, Boissonneault G. Spermiogenesis and DNA repair: a possible etiology of human infertility and genetic disorders. Syst Biol Reprod Med. 2008;54:3&#8211;10. doi: 10.1080/19396360701876823.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/19396360701876823</ArticleId>
+            <ArticleId IdType="pubmed">18543861</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lenzi A, Balercia G, Bellastella A, Colao A, Fabbri A, Foresta C, et al. Epidemiology, diagnosis, and treatment of male hypogonadotropic hypogonadism. J Endocrinol Invest. 2009;32:934&#8211;938.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">19955846</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lewis SE. Is sperm evaluation useful in predicting human fertility? Reproduction. 2007;134:31&#8211;40. doi: 10.1530/REP-07-0152.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1530/REP-07-0152</ArticleId>
+            <ArticleId IdType="pubmed">17641086</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lewis SE, Aitken RJ. DNA damage to spermatozoa has impacts on fertilization and pregnancy. Cell Tissue Res. 2005;322:33&#8211;41. doi: 10.1007/s00441-005-1097-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s00441-005-1097-5</ArticleId>
+            <ArticleId IdType="pubmed">15912407</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li LH, Wine RN, Chapin RE. 2-Methoxyacetic acid (MAA)-induced spermatocyte apoptosis in human and rat testes: an in vitro comparison. J Androl. 1996;17:538&#8211;549.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">8957698</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lin MH, Kuo-Kuang Lee R, Li SH, Lu CH, Sun FJ, Hwu YM. Sperm chromatin structure assay parameters are not related to fertilization rates, embryo quality, and pregnancy rates in in vitro fertilization and intracytoplasmic sperm injection, but might be related to spontaneous abortion rates. Fertil Steril. 2008;90:352&#8211;359. doi: 10.1016/j.fertnstert.2007.06.018.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2007.06.018</ArticleId>
+            <ArticleId IdType="pubmed">17904130</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lopes S, Sun JG, Jurisicova A, Meriano J, Casper RF. Sperm deoxyribonucleic acid fragmentation is increased in poor-quality semen samples and correlates with failed fertilization in intracytoplasmic sperm injection. Fertil Steril. 1998;69:528&#8211;532. doi: 10.1016/S0015-0282(97)00536-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0015-0282(97)00536-0</ArticleId>
+            <ArticleId IdType="pubmed">9531891</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lue TF. Topical and oral agents for erectile dysfunction. J Formos Med Assoc. 1999;98:233&#8211;241.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">10389366</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Marcon L, Boissonneault G. Transient DNA strand breaks during mouse and human spermiogenesis new insights in stage specificity and link to chromatin remodeling. Biol Reprod. 2004;70:910&#8211;918. doi: 10.1095/biolreprod.103.022541.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1095/biolreprod.103.022541</ArticleId>
+            <ArticleId IdType="pubmed">14645105</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Matsumoto AM, Snyder PJ, Bhasin S, Martin K, Weber T, Winters S, et al. Stimulation of spermatogenesis with recombinant human follicle-stimulating hormone (follitropin alfa; GONAL-f&#174;): long-term treatment in azoospermic men with hypogonadotropic hypogonadism. Fertil Steril. 2009;92:979&#8211;990. doi: 10.1016/j.fertnstert.2008.07.1742.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2008.07.1742</ArticleId>
+            <ArticleId IdType="pubmed">18930190</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Meistrich ML. Effects of chemotherapy and radiotherapy on spermatogenesis. Eur Urol. 1993;23:136&#8211;141.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">8477773</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Menezo YJ, Hazout A, Panteix G, Robert F, Rollet J, Cohen-Bacrie P, et al. Antioxidants to reduce sperm DNA fragmentation: an unexpected adverse effect. Reprod Biomed Online. 2007;14:418&#8211;421. doi: 10.1016/S1472-6483(10)60887-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1472-6483(10)60887-5</ArticleId>
+            <ArticleId IdType="pubmed">17425820</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Morris ID, Ilott S, Dixon L, Brison DR. The spectrum of DNA damage in human sperm assessed by single cell gel electrophoresis (Comet assay) and its relationship to fertilization and embryo development. Hum Reprod. 2002;17:990&#8211;998. doi: 10.1093/humrep/17.4.990.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/17.4.990</ArticleId>
+            <ArticleId IdType="pubmed">11925396</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Moustafa MH, Sharma RK, Thornton J, Mascha E, Abdel-Hafez MA, Thomas AJ, Jr, et al. Relationship between ROS production, apoptosis and DNA denaturation in spermatozoa from patients examined for infertility. Hum Reprod. 2004;19:129&#8211;138. doi: 10.1093/humrep/deh024.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/deh024</ArticleId>
+            <ArticleId IdType="pubmed">14688171</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Obasaju M, Kadam A, Sultan K, Fateh M, Munne S. Sperm quality may adversely affect the chromosome constitution of embryos that result from intracytoplasmic sperm injection. Fertil Steril. 1999;72:1113&#8211;1115. doi: 10.1016/S0015-0282(99)00391-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0015-0282(99)00391-X</ArticleId>
+            <ArticleId IdType="pubmed">10593391</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ozmen B, Caglar GS, Koster F, Schopper B, Diedrich K, Al-Hasani S. Relationship between sperm DNA damage, induced acrosome reaction and viability in ICSI patients. Reprod Biomed Online. 2007;15:208&#8211;214. doi: 10.1016/S1472-6483(10)60710-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1472-6483(10)60710-9</ArticleId>
+            <ArticleId IdType="pubmed">17697499</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Phillip M, Arbelle JE, Segev Y, Parvari R. Male hypogonadism due to a mutation in the gene for the beta-subunit of follicle-stimulating hormone. N Engl J Med. 1998;338:1729&#8211;1732. doi: 10.1056/NEJM199806113382404.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJM199806113382404</ArticleId>
+            <ArticleId IdType="pubmed">9624193</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Practice Committee of American Society for Reproductive Medicine The clinical utility of sperm DNA integrity testing. Fertil Steril. 2008;90(5 Suppl):S178&#8211;S180.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">19007622</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ruwanpura SM, McLachlan RI, Stanton PG, Loveland KL, Meachem SJ. Pathways involved in testicular germ cell apoptosis in immature rats after FSH suppression. J Endocrinol. 2008;197:35&#8211;43. doi: 10.1677/JOE-07-0637.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1677/JOE-07-0637</ArticleId>
+            <ArticleId IdType="pubmed">18372230</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Safarinejad MR, Shafiei N, Safarinejad S. Association of polymorphisms in the estrogen receptors alpha, and beta (ESR1, ESR2) with the occurrence of male infertility and semen parameters. J Steroid Biochem Mol Biol. 2010;122:193&#8211;203. doi: 10.1016/j.jsbmb.2010.06.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jsbmb.2010.06.011</ArticleId>
+            <ArticleId IdType="pubmed">20599614</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Safarinejad MR, Shafiei N, Safarinejad S. Evaluating the role of the FSH receptor gene Thr307-Ala and Asn680-Ser polymorphisms in male infertility and their association with semen quality and reproductive hormones. BJU Int. 2011;108:E117&#8211;E125. doi: 10.1111/j.1464-410X.2010.09890.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/j.1464-410X.2010.09890.x</ArticleId>
+            <ArticleId IdType="pubmed">21105990</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sakkas D, Urner F, Bianchi PG, Bizzaro D, Wagner I, Jaquenoud N, et al. Sperm chromatin anomalies can influence decondensation after intracytoplasmic sperm injection. Hum Reprod. 1996;11:837&#8211;843. doi: 10.1093/oxfordjournals.humrep.a019263.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/oxfordjournals.humrep.a019263</ArticleId>
+            <ArticleId IdType="pubmed">8671337</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sakkas D, Alvarez JG. Sperm DNA fragmentation: mechanisms of origin, impact on reproductive outcome, and analysis. Fertil Steril. 2010;93:1027&#8211;1036. doi: 10.1016/j.fertnstert.2009.10.046.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2009.10.046</ArticleId>
+            <ArticleId IdType="pubmed">20080235</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sakkas D, Mariethoz E, Manicardi G, Bizzaro D, Bianchi PG, Bianchi U. Origin of DNA damage in ejaculated human spermatozoa. Rev Reprod. 1999;4:31&#8211;37. doi: 10.1530/ror.0.0040031.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1530/ror.0.0040031</ArticleId>
+            <ArticleId IdType="pubmed">10051100</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sakkas D, Seli E, Bizzaro D, Tarozzi N, Manicardi GC. Abnormal spermatozoa in the ejaculate: abortive apoptosis and faulty nuclear remodelling during spermatogenesis. Reprod Biomed Online. 2003;7:428&#8211;432. doi: 10.1016/S1472-6483(10)61886-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1472-6483(10)61886-X</ArticleId>
+            <ArticleId IdType="pubmed">14656403</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sawyer DE, Roman SD, Aitken RJ. Relative susceptibilities of mitochondrial and nuclear DNA to damage induced by hydrogen peroxide in two mouse germ cell lines. Redox Rep. 2001;6:182&#8211;184. doi: 10.1179/135100001101536157.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1179/135100001101536157</ArticleId>
+            <ArticleId IdType="pubmed">11523594</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Selice R, Garolla A, Pengo M, Caretta N, Ferlin A, Foresta C. The response to FSH treatment in oligozoospermic men depends on FSH receptor gene polymorphisms. Int J Androl. 2011;34:306&#8211;312. doi: 10.1111/j.1365-2605.2010.01086.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/j.1365-2605.2010.01086.x</ArticleId>
+            <ArticleId IdType="pubmed">20569270</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Seminara SB, Crowley WF., Jr Perspective: the importance of genetic defects in humans in elucidating the complexities of the hypothalamic-pituitary-gonadal axis. Endocrinology. 2001;142:2173&#8211;2177. doi: 10.1210/en.142.6.2173.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/en.142.6.2173</ArticleId>
+            <ArticleId IdType="pubmed">11356659</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sinha Hikim AP, Rajavashisth TB, Sinha Hikim I, Lue Y, Bonavera JJ, Leung A, et al. Significance of apoptosis in the temporal and stage-specific loss of germ cells in the adult rat after gonadotropin deprivation. Biol Reprod. 1997;57:1193&#8211;1201. doi: 10.1095/biolreprod57.5.1193.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1095/biolreprod57.5.1193</ArticleId>
+            <ArticleId IdType="pubmed">9369187</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sinisi AA, Esposito D, Bellastella G, Maione L, Palumbo V, Gandini L, et al. Efficacy of recombinant human follicle stimulating hormone at low doses in inducing spermatogenesis and fertility in hypogonadotropic hypogonadism. J Endocrinol Invest. 2010;33:618&#8211;623.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">20436264</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Spano M, Bonde JP, Hjollund HI, Kolstad HA, Cordelli E, Leter G. Sperm chromatin damage impairs human fertility. The Danish First Pregnancy Planner Study Team. Fertil Steril. 2000;73:43&#8211;50. doi: 10.1016/S0015-0282(99)00462-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0015-0282(99)00462-8</ArticleId>
+            <ArticleId IdType="pubmed">10632410</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Strehler E, Sterzik K, De Santo M, Abt M, Wiedemann R, Bellati U, et al. The effect of follicle-stimulating hormone therapy on sperm quality: an ultrastructural mathematical evaluation. J Androl. 1997;18:439&#8211;447.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">9283958</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tapanainen JS, Aittomaki K, Min J, Vaskivuo T, Huhtaniemi IT. Men homozygous for an inactivating mutation of the follicle-stimulating hormone (FSH) receptor gene present variable suppression of spermatogenesis and fertility. Nat Genet. 1997;15:205&#8211;206. doi: 10.1038/ng0297-205.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/ng0297-205</ArticleId>
+            <ArticleId IdType="pubmed">9020851</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tarozzi N, Bizzaro D, Flamigni C, Borini A. Clinical relevance of sperm DNA damage in assisted reproduction. Reprod Biomed Online. 2007;14:746&#8211;757. doi: 10.1016/S1472-6483(10)60678-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1472-6483(10)60678-5</ArticleId>
+            <ArticleId IdType="pubmed">17579991</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tesarik J, Guido M, Mendoza C, Greco E. Human spermatogenesis in vitro: respective effects of follicle-stimulating hormone and testosterone on meiosis, spermiogenesis, and Sertoli cell apoptosis. J Clin Endocrinol Metab. 1998;83:4467&#8211;4473. doi: 10.1210/jc.83.12.4467.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.83.12.4467</ArticleId>
+            <ArticleId IdType="pubmed">9851795</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tesarik J, Martinez F, Rienzi L, Iacobelli M, Ubaldi F, Mendoza C, et al. In-vitro effects of FSH and testosterone withdrawal on caspase activation and DNA fragmentation in different cell types of human seminiferous epithelium. Hum Reprod. 2002;17:1811&#8211;1819. doi: 10.1093/humrep/17.7.1811.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/17.7.1811</ArticleId>
+            <ArticleId IdType="pubmed">12093844</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Walczak-Jedrzejowska R, Slowikowska-Hilczer J, Marchlewsk K, Oszukowska E, Kula K. During seminiferous tubule maturation testosterone and synergistic action of FSH with estradiol support germ cell survival while estradiol alone has pro-apoptotic effect. Folia Histochem Cytobiol. 2007;45(Suppl 1):S59&#8211;S64.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">18292837</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Warne DW, Decosterd G, Okada H, Yano Y, Koide N, Howles CM. A combined analysis of data to identify predictive factors for spermatogenesis in men with hypogonadotropic hypogonadism treated with recombinant human follicle-stimulating hormone and human chorionic gonadotropin. Fertil Steril. 2009;92:594&#8211;604. doi: 10.1016/j.fertnstert.2008.07.1720.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2008.07.1720</ArticleId>
+            <ArticleId IdType="pubmed">18930225</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>WHO laboratory manual for the examination of human semen and sperm-cervical mucus interaction. Cambridge: Cambridge Academic Press; 2010.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Zhang Y, Wang H, Wang L, Zhou Z, Sha J, Mao Y, et al. The clinical significance of sperm DNA damage detection combined with routine semen testing in assisted reproduction. Mol Med Rep. 2008;1:617&#8211;624.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">21479459</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zini A, Boman JM, Belzile E, Ciampi A. Sperm DNA damage is associated with an increased risk of pregnancy loss after IVF and ICSI: systematic review and meta-analysis. Hum Reprod. 2008;23:2663&#8211;2668. doi: 10.1093/humrep/den321.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/den321</ArticleId>
+            <ArticleId IdType="pubmed">18757447</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/2345678.xml
+++ b/tests/fixtures/pmid_xml/2345678.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">2345678</PMID>
+      <DateCompleted>
+        <Year>1990</Year>
+        <Month>06</Month>
+        <Day>29</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2016</Year>
+        <Month>11</Month>
+        <Day>23</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0031-3998</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>27</Volume>
+            <Issue>5</Issue>
+            <PubDate>
+              <Year>1990</Year>
+              <Month>May</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Pediatric research</Title>
+          <ISOAbbreviation>Pediatr Res</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>The enzymatic basis for the dehydrogenation of 3-phenylpropionic acid: in vitro reaction of 3-phenylpropionyl-CoA with various acyl-CoA dehydrogenases.</ArticleTitle>
+        <Pagination>
+          <StartPage>501</StartPage>
+          <EndPage>507</EndPage>
+          <MedlinePgn>501-7</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>3-Phenylpropionic acid is an end-product of the bacterial degradation of unabsorbed phenylalanine in the intestinal lumen. As CoA ester, this metabolite has been considered to be a specific substrate for medium chain acyl-CoA dehydrogenase (MCAD). Its glycine-conjugate, 3-phenylpropionylglycine, has now been established as a pathognomonic marker in urine from patients affected with MCAD deficiency. However, no systematic studies to evaluate the reactivity of 3-phenylpropionyl-CoA with other known acyl-CoA dehydrogenases have so far been carried out to establish the specificity of this substrate for MCAD. We studied the in vitro reactivity of 3-phenylpropionyl-CoA with five rat and human liver acyl-CoA dehydrogenases using purified preparations. we demonstrated that MCAD effectively dehydrogenated 3-phenylpropionyl-CoA, and that no other acyl-CoA dehydrogenase exhibited any significant activity with this substrate. In the steady state condition, the Km of 3-phenylpropionyl-CoA for human MCAD was 50 microM. Gas chromatography/mass spectrometry analysis of the assay mixture identified trans-cinnamoyl-CoA as the product of the reaction. Furthermore, we showed by determination of the reaction products using gas chromatography/mass spectrometry selected ion monitoring that, in absence of the primary electron acceptor, 3-phenylpropionyl-CoA was slowly but significantly dehydrogenated by MCAD under aerobic conditions. These data suggest that MCAD may oxidize 3-phenylpropionyl-CoA in vivo using an alternative electron acceptor, to produce trans-cinnamoyl-CoA. This mechanism provides an explanation for the normal 3-phenylpropionylglycine excretion observed in urine from patients affected with glutaric aciduria type II and ethylmalonic/adipic aciduria.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Rinaldo</LastName>
+            <ForeName>P</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>Yale University School of Medicine, Department of Human Genetics, New Haven, Connecticut 06510.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>O'Shea</LastName>
+            <ForeName>J J</ForeName>
+            <Initials>JJ</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Welch</LastName>
+            <ForeName>R D</ForeName>
+            <Initials>RD</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Tanaka</LastName>
+            <ForeName>K</ForeName>
+            <Initials>K</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>DK-17453</GrantID>
+            <Acronym>DK</Acronym>
+            <Agency>NIDDK NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>DK-29921</GrantID>
+            <Acronym>DK</Acronym>
+            <Agency>NIDDK NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>DK-38154</GrantID>
+            <Acronym>DK</Acronym>
+            <Agency>NIDDK NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+          <PublicationType UI="D013487">Research Support, U.S. Gov't, P.H.S.</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Pediatr Res</MedlineTA>
+        <NlmUniqueID>0100714</NlmUniqueID>
+        <ISSNLinking>0031-3998</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D010666">Phenylpropionates</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>5Q445IN5CU</RegistryNumber>
+          <NameOfSubstance UI="C035253">3-phenylpropionic acid</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 1.3.-</RegistryNumber>
+          <NameOfSubstance UI="D044944">Acyl-CoA Dehydrogenases</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D044944" MajorTopicYN="N">Acyl-CoA Dehydrogenases</DescriptorName>
+          <QualifierName UI="Q000172" MajorTopicYN="N">deficiency</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000818" MajorTopicYN="N">Animals</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004579" MajorTopicYN="N">Electron Transport</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D066298" MajorTopicYN="N">In Vitro Techniques</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008099" MajorTopicYN="N">Liver</DescriptorName>
+          <QualifierName UI="Q000201" MajorTopicYN="N">enzymology</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010666" MajorTopicYN="N">Phenylpropionates</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D051381" MajorTopicYN="N">Rats</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1990</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1990</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1990</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">2345678</ArticleId>
+        <ArticleId IdType="doi">10.1203/00006450-199005000-00017</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/23985001.xml
+++ b/tests/fixtures/pmid_xml/23985001.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">23985001</PMID>
+      <DateCompleted>
+        <Year>2014</Year>
+        <Month>03</Month>
+        <Day>21</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>04</Month>
+        <Day>19</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1747-4132</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>7</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>2013</Year>
+              <Month>Aug</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Expert review of gastroenterology &amp; hepatology</Title>
+          <ISOAbbreviation>Expert Rev Gastroenterol Hepatol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Diagnosis and treatment of hereditary hemochromatosis: an update.</ArticleTitle>
+        <Pagination>
+          <StartPage>517</StartPage>
+          <EndPage>530</EndPage>
+          <MedlinePgn>517-30</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1586/17474124.2013.816114</ELocationID>
+        <Abstract>
+          <AbstractText>Hereditary hemochromatosis is an inherited iron overload disorder caused by inappropriately low hepcidin secretion leading to increased duodenal absorption of dietary iron, most commonly in C282Y homozygous individuals. This can result in elevated serum ferritin, iron deposition in various organs and ultimately end-organ damage, although there is incomplete biochemical and clinical penetrance and variable phenotypic expression of the HFE mutation in hereditary hemochromatosis. An elevated SF &gt;1000 mg/l [corrected] is associated with an increased risk of cirrhosis and mortality in C282Y homozygotes.Conversely, a SF &lt;1000 &#181;g/l is associated with a very low likelihood of cirrhosis, making liver biopsy unnecessary among C282Y homozygotes in the absence of concomitant risk factors for liver disease. Phlebotomy remains the mainstay of treatment and new treatments being studied include erythrocytapheresis and 'mini-hepcidins'. Iron overload is being recognized to play a carcinogenic role in hepatocellular carcinoma and other cancers, possibly supporting iron depletion in these patients.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Kanwar</LastName>
+            <ForeName>Pushpjeet</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>Liver Center for Excellence, Digestive Disease Institute, Virginia Mason Medical Center, Seattle, WA, USA.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kowdley</LastName>
+            <ForeName>Kris V</ForeName>
+            <Initials>KV</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Expert Rev Gastroenterol Hepatol</MedlineTA>
+        <NlmUniqueID>101278199</NlmUniqueID>
+        <ISSNLinking>1747-4124</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D015415">Biomarkers</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="C103673">HFE protein, human</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000071020">Hemochromatosis Protein</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D064451">Hepcidins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D015395">Histocompatibility Antigens Class I</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D008565">Membrane Proteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9007-73-2</RegistryNumber>
+          <NameOfSubstance UI="D005293">Ferritins</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <CommentsCorrectionsList>
+        <CommentsCorrections RefType="ErratumIn">
+          <RefSource>Expert Rev Gastroenterol Hepatol. 2013 Nov;7(8):767</RefSource>
+        </CommentsCorrections>
+      </CommentsCorrectionsList>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D015415" MajorTopicYN="N">Biomarkers</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001706" MajorTopicYN="N">Biopsy</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019091" MajorTopicYN="N">Critical Pathways</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016238" MajorTopicYN="N">Cytapheresis</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004252" MajorTopicYN="N">DNA Mutational Analysis</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003663" MajorTopicYN="N">Decision Trees</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003952" MajorTopicYN="Y">Diagnostic Imaging</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005293" MajorTopicYN="N">Ferritins</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D020022" MajorTopicYN="N">Genetic Predisposition to Disease</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005820" MajorTopicYN="Y">Genetic Testing</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006432" MajorTopicYN="N">Hemochromatosis</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="Y">diagnosis</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="Y">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000071020" MajorTopicYN="N">Hemochromatosis Protein</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D064451" MajorTopicYN="N">Hepcidins</DescriptorName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D040941" MajorTopicYN="N">Heredity</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015395" MajorTopicYN="N">Histocompatibility Antigens Class I</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008565" MajorTopicYN="N">Membrane Proteins</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009154" MajorTopicYN="N">Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010375" MajorTopicYN="N">Pedigree</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010641" MajorTopicYN="N">Phenotype</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018962" MajorTopicYN="Y">Phlebotomy</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011237" MajorTopicYN="N">Predictive Value of Tests</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016896" MajorTopicYN="N">Treatment Outcome</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2013</Year>
+          <Month>8</Month>
+          <Day>30</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2013</Year>
+          <Month>8</Month>
+          <Day>30</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2014</Year>
+          <Month>3</Month>
+          <Day>22</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">23985001</ArticleId>
+        <ArticleId IdType="doi">10.1586/17474124.2013.816114</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/25532429.xml
+++ b/tests/fixtures/pmid_xml/25532429.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">25532429</PMID>
+      <DateCompleted>
+        <Year>2015</Year>
+        <Month>12</Month>
+        <Day>22</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2015</Year>
+        <Month>04</Month>
+        <Day>16</Day>
+      </DateRevised>
+      <Article PubModel="Print-Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1744-7631</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>19</Volume>
+            <Issue>5</Issue>
+            <PubDate>
+              <Year>2015</Year>
+              <Month>May</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Expert opinion on therapeutic targets</Title>
+          <ISOAbbreviation>Expert Opin Ther Targets</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Targeting the MET pathway for potential treatment of NSCLC.</ArticleTitle>
+        <Pagination>
+          <StartPage>663</StartPage>
+          <EndPage>674</EndPage>
+          <MedlinePgn>663-74</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1517/14728222.2014.995093</ELocationID>
+        <Abstract>
+          <AbstractText Label="INTRODUCTION" NlmCategory="BACKGROUND">The mesenchymal-epithelial transition (MET) protein is the only known receptor for hepatocyte growth factor and has recently been identified as a novel promising target in several human cancers, including NSCLC. Activation of the MET signaling pathway can occur via different mechanisms. A number of compounds targeting MET have been evaluated in clinical trials, and recent clinical data have begun to afford some insight into the tumor types and patient populations that might benefit from treatment with MET pathway inhibitors.</AbstractText>
+          <AbstractText Label="AREAS COVERED" NlmCategory="METHODS">We review recent publications and information disclosed at public conferences and summarize the epidemiology of dysregulation of MET signaling, and the associations thereof with other driver genes and therapeutic inhibitors useful to treat NSCLC.</AbstractText>
+          <AbstractText Label="EXPERT OPINION" NlmCategory="CONCLUSIONS">The MET pathway is emerging as a target for advanced NSCLC that is either resistant to EGFR tyrosine kinase inhibitors or that arises de novo. MET inhibitors currently being evaluated in clinical trials have yielded compelling evidence of clinical activities when used to treat various solid tumors, especially NSCLC. Remaining challenges are the identification of patient populations who might benefit from the use of MET inhibitors, and the most effective diagnostic methods for such patients.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Li</LastName>
+            <ForeName>Anna</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Guangdong Lung Cancer Institute, Guangdong General Hospital and Guangdong Academy of Medical Science , 106 Zhongshan 2nd Road, Guangzhou 510080 , PR China +86 20 83877855 ; +86 20 83827712 ; syylwu@live.cn.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Gao</LastName>
+            <ForeName>Hong-Fei</ForeName>
+            <Initials>HF</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wu</LastName>
+            <ForeName>Yi-Long</ForeName>
+            <Initials>YL</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <ArticleDate DateType="Electronic">
+          <Year>2014</Year>
+          <Month>12</Month>
+          <Day>23</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Expert Opin Ther Targets</MedlineTA>
+        <NlmUniqueID>101127833</NlmUniqueID>
+        <ISSNLinking>1472-8222</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000970">Antineoplastic Agents</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000970" MajorTopicYN="N">Antineoplastic Agents</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="Y">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002289" MajorTopicYN="N">Carcinoma, Non-Small-Cell Lung</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="Y">drug therapy</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D058750" MajorTopicYN="N">Epithelial-Mesenchymal Transition</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008175" MajorTopicYN="N">Lung Neoplasms</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="Y">drug therapy</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D058990" MajorTopicYN="N">Molecular Targeted Therapy</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011379" MajorTopicYN="N">Prognosis</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015398" MajorTopicYN="N">Signal Transduction</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">NSCLC</Keyword>
+        <Keyword MajorTopicYN="N">inhibitor</Keyword>
+        <Keyword MajorTopicYN="N">mesenchymal-epithelial transition protein</Keyword>
+        <Keyword MajorTopicYN="N">target treatment</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2014</Year>
+          <Month>12</Month>
+          <Day>24</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2014</Year>
+          <Month>12</Month>
+          <Day>24</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2015</Year>
+          <Month>12</Month>
+          <Day>23</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">25532429</ArticleId>
+        <ArticleId IdType="doi">10.1517/14728222.2014.995093</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/28139132.xml
+++ b/tests/fixtures/pmid_xml/28139132.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">28139132</PMID>
+      <DateCompleted>
+        <Year>2017</Year>
+        <Month>06</Month>
+        <Day>29</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2018</Year>
+        <Month>12</Month>
+        <Day>02</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0042-773X</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>62</Volume>
+            <Issue>12</Issue>
+            <PubDate>
+              <Year>2016</Year>
+              <Season>Winter</Season>
+            </PubDate>
+          </JournalIssue>
+          <Title>Vnitrni lekarstvi</Title>
+          <ISOAbbreviation>Vnitr Lek</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Takotsubo cardiomyopathy: incidence, etiology, complications, therapy and prognosis].</ArticleTitle>
+        <Pagination>
+          <StartPage>1021</StartPage>
+          <EndPage>1027</EndPage>
+          <MedlinePgn>1021-1027</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Takotsubo syndrome is presented by acute heart failure and looks like acute coronary syndrome and truly mimics its clinical and ECG features. It is characterised by transient contractility disorder of mostly apical part of left ventricle without any presence of occlusive coronary disease. It is found in 1-2 % patients admitted to the hospital care for acute coronary syndrome. Prognosis is very excellent within complete recovery of left ventricle in several weeks. The etiology is unknown and therapy just symptomatic. Transient dynamic obstruction of left ventricle output tract can be sometimes present as well as hemodynamic instability and arrhythmias. Death was rarely described. We introduce a case of takotsubo syndrome complicated by extreme high transient gradient in left ventricle output tract followed complete recovery in short time.Key words: complication - etiology - incidence - takotsubo syndrome - therapy.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Babick&#253;</LastName>
+            <ForeName>Milan</ForeName>
+            <Initials>M</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Holm</LastName>
+            <ForeName>Franti&#353;ek</ForeName>
+            <Initials>F</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Erbrt</LastName>
+            <ForeName>Miroslav</ForeName>
+            <Initials>M</Initials>
+          </Author>
+        </AuthorList>
+        <Language>cze</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D002363">Case Reports</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Takotsubo syndrom: incidence, etiologie, komplikace, l&#233;&#269;ba a progn&#243;za.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Czech Republic</Country>
+        <MedlineTA>Vnitr Lek</MedlineTA>
+        <NlmUniqueID>0413602</NlmUniqueID>
+        <ISSNLinking>0042-773X</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D001145" MajorTopicYN="N">Arrhythmias, Cardiac</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="Y">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004452" MajorTopicYN="N">Echocardiography</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011379" MajorTopicYN="N">Prognosis</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D054549" MajorTopicYN="N">Takotsubo Cardiomyopathy</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000000981" MajorTopicYN="Y">diagnostic imaging</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="Y">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016896" MajorTopicYN="N">Treatment Outcome</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014694" MajorTopicYN="N">Ventricular Outflow Obstruction</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="Y">complications</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2017</Year>
+          <Month>2</Month>
+          <Day>1</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2017</Year>
+          <Month>2</Month>
+          <Day>1</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2017</Year>
+          <Month>7</Month>
+          <Day>1</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">28139132</ArticleId>
+        <ArticleId IdType="pii">60149</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/3000000.xml
+++ b/tests/fixtures/pmid_xml/3000000.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">3000000</PMID>
+      <DateCompleted>
+        <Year>1986</Year>
+        <Month>01</Month>
+        <Day>14</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>10</Month>
+        <Day>22</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0740-7750</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>11</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>1985</Year>
+              <Month>Nov</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Somatic cell and molecular genetics</Title>
+          <ISOAbbreviation>Somat Cell Mol Genet</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Defective DNA topoisomerase I activity in a DNAts mutant of Balb/3T3 cells.</ArticleTitle>
+        <Pagination>
+          <StartPage>557</StartPage>
+          <EndPage>569</EndPage>
+          <MedlinePgn>557-69</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Cell and polyomavirus DNA synthesis in ts20, a temperature-sensitive mutant derived from Balb/3T3 cells, is inhibited at an early step in chain elongation in vivo and in vitro. Virus DNA synthesized under restrictive conditions, when analyzed by gel electrophoresis and fluorography, contained a series of equally spaced bands migrating between form I and form II. If restrictive conditions were prolonged, the relative amount of these less-supercoiled topoisomers increased while the overall amount of virus DNA decreased. DNA topoisomerase I activity was lower and more heat-labile when prepared from mutant cells compared to wild-type and revertant cells. An assay in which extracts from wild-type cells corrected defective cell DNA synthesis in lysed mutant cells was applied to purification of the active factor from such extracts. Salt fractionation and three cycles of column chromatography resulted in the isolation of the activity in a fraction containing 10 major polypeptides. The specific activity in the final preparation was increased fivefold and was accompanied by the activity of DNA topoisomerase I. Our results provide evidence that DNA topoisomerase I functions at an early step in chain elongation of cell and polyomavirus DNA synthesis and that the enzyme activity may be decreased as a result of the mutation in ts20.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Zeng</LastName>
+            <ForeName>G C</ForeName>
+            <Initials>GC</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Zannis-Hadjopoulos</LastName>
+            <ForeName>M</ForeName>
+            <Initials>M</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ozer</LastName>
+            <ForeName>H L</ForeName>
+            <Initials>HL</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Hand</LastName>
+            <ForeName>R</ForeName>
+            <Initials>R</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>CA 23002</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+          <PublicationType UI="D013487">Research Support, U.S. Gov't, P.H.S.</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Somat Cell Mol Genet</MedlineTA>
+        <NlmUniqueID>8403568</NlmUniqueID>
+        <ISSNLinking>0740-7750</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>EC 5.99.1.2</RegistryNumber>
+          <NameOfSubstance UI="D004264">DNA Topoisomerases, Type I</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000818" MajorTopicYN="N">Animals</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002417" MajorTopicYN="N">Cattle</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002471" MajorTopicYN="Y">Cell Transformation, Neoplastic</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002478" MajorTopicYN="N">Cells, Cultured</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004261" MajorTopicYN="Y">DNA Replication</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004264" MajorTopicYN="N">DNA Topoisomerases, Type I</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+          <QualifierName UI="Q000302" MajorTopicYN="N">isolation &amp; purification</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007700" MajorTopicYN="N">Kinetics</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D051379" MajorTopicYN="N">Mice</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008807" MajorTopicYN="N">Mice, Inbred BALB C</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009154" MajorTopicYN="Y">Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011120" MajorTopicYN="N">Polyomavirus</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013696" MajorTopicYN="N">Temperature</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013950" MajorTopicYN="N">Thymus Gland</DescriptorName>
+          <QualifierName UI="Q000201" MajorTopicYN="N">enzymology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014779" MajorTopicYN="N">Virus Replication</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1985</Year>
+          <Month>11</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1985</Year>
+          <Month>11</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1985</Year>
+          <Month>11</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">3000000</ArticleId>
+        <ArticleId IdType="doi">10.1007/BF01534721</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/30776274.xml
+++ b/tests/fixtures/pmid_xml/30776274.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">30776274</PMID>
+      <DateCompleted>
+        <Year>2020</Year>
+        <Month>03</Month>
+        <Day>11</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2020</Year>
+        <Month>03</Month>
+        <Day>11</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0025-7680</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>79</Volume>
+            <Issue>Suppl 1</Issue>
+            <PubDate>
+              <Year>2019</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Medicina</Title>
+          <ISOAbbreviation>Medicina (B Aires)</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Autism. Genetic and biological aspects].</ArticleTitle>
+        <Pagination>
+          <StartPage>16</StartPage>
+          <EndPage>21</EndPage>
+          <MedlinePgn>16-21</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Autism is a neurodevelopmental disorder characterized by commitment to social interaction and communication, associated with interests restricted and stereotyped behaviors with a high population prevalence, neurobiological bases and high heritability. Its etiology is heterogeneous, numerous genetic bases, environmental factors and epigenetic mechanisms have been recognized. Advances in molecular genetics, as well as epidemiological studies of large cohorts, have made it possible to identify specific medical entities, as well as genes and environmental factors partially or totally linked in their pathogenesis. This knowledge, according to the clinical characteristics, allows to guide the complementary studies, the therapeutic conducts, to infer a clinical prognosis and to propitiate the familiar genetic advice. In this work, the most prevalent clinical characteristics identified are described; the specific medical entities that are strongly related to autism are stated, as well as the recognized genes, the possible environmental factors and the epidemiological results that allow family counseling.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Arberas</LastName>
+            <ForeName>Claudia</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Secci&#243;n Gen&#233;tica M&#233;dica, Hospital de Ni&#241;os Dr. Ricardo Guti&#233;rrez, Buenos Aires, Argentina. E-mail: carberas@gmail.com.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ruggieri</LastName>
+            <ForeName>V&#237;ctor</ForeName>
+            <Initials>V</Initials>
+            <AffiliationInfo>
+              <Affiliation>Hospital de Pediatr&#237;a Prof. Dr. Juan P. Garrahan, Buenos Aires, Argentina.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>spa</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Autismo. Aspectos gen&#233;ticos y biol&#243;gicos.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Argentina</Country>
+        <MedlineTA>Medicina (B Aires)</MedlineTA>
+        <NlmUniqueID>0204271</NlmUniqueID>
+        <ISSNLinking>0025-7680</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000067877" MajorTopicYN="N">Autism Spectrum Disorder</DescriptorName>
+          <QualifierName UI="Q000209" MajorTopicYN="N">etiology</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000503" MajorTopicYN="N">physiopathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001321" MajorTopicYN="N">Autistic Disorder</DescriptorName>
+          <QualifierName UI="Q000209" MajorTopicYN="N">etiology</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+          <QualifierName UI="Q000503" MajorTopicYN="N">physiopathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004777" MajorTopicYN="N">Environment</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D044127" MajorTopicYN="N">Epigenesis, Genetic</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005817" MajorTopicYN="N">Genetic Counseling</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="spa">
+        <AbstractText>El autismo es un trastorno del neurodesarrollo caracterizado por compromiso en la interacci&#243;n social y la comunicaci&#243;n, asociado a intereses restringidos y conductas estereotipadas con gran prevalencia poblacional, bases neurobiol&#243;gicas y alta heredabilidad. Su etiolog&#237;a es heterog&#233;nea y se han reconocido numerosas bases gen&#233;ticas, factores ambientales y mecanismos epigen&#233;ticos. Los avances en la gen&#233;tica molecular, as&#237; como los estudios epidemiol&#243;gicos de grandes cohortes, han posibilitado identificar entidades m&#233;dicas espec&#237;ficas, as&#237; como genes y factores ambientales vinculados parcial o totalmente en su patogenia. Estos conocimientos, conforme las caracter&#237;sticas cl&#237;nicas, permiten orientar los estudios complementarios, las conductas terap&#233;uticas, inferir un pron&#243;stico cl&#237;nico y propiciar el asesoramiento gen&#233;tico familiar. En este trabajo analizamos las caracter&#237;sticas cl&#237;nicas de los trastornos del espectro del autismo, las entidades m&#233;dicas espec&#237;ficas que est&#225;n fuertemente relacionadas a los mismos, as&#237; como los genes reconocidos, los posibles factores ambientales y los resultados epidemiol&#243;gicos que permiten el adecuado asesoramiento familiar.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">autism</Keyword>
+        <Keyword MajorTopicYN="N">epigenetic</Keyword>
+        <Keyword MajorTopicYN="N">genes</Keyword>
+        <Keyword MajorTopicYN="N">genomic hybridization</Keyword>
+        <Keyword MajorTopicYN="N">heritability</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2019</Year>
+          <Month>2</Month>
+          <Day>19</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2019</Year>
+          <Month>2</Month>
+          <Day>19</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2020</Year>
+          <Month>3</Month>
+          <Day>12</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">30776274</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/31671389.xml
+++ b/tests/fixtures/pmid_xml/31671389.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">31671389</PMID>
+      <DateCompleted>
+        <Year>2019</Year>
+        <Month>12</Month>
+        <Day>17</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2020</Year>
+        <Month>01</Month>
+        <Day>08</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1669-9106</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>79</Volume>
+            <Issue>5</Issue>
+            <PubDate>
+              <Year>2019</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Medicina</Title>
+          <ISOAbbreviation>Medicina (B Aires)</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Hypervitaminosis B12. Our experience and a review].</ArticleTitle>
+        <Pagination>
+          <StartPage>391</StartPage>
+          <EndPage>396</EndPage>
+          <MedlinePgn>391-396</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>High serum levels of vitamin B12 or cobalamin, also called hypervitaminemia B12, is a frequently underestimated biological abnormality. According to the literature, some of the entities related to this finding are solid neoplasia (primary or metastatic) and acute or chronic hematological diseases. Other causes include liver disorders, monoclonal gammapathy of undetermined significance, renal failure and, less frequently, excess of vitamin B12 intake, inflammatory or autoimmune diseases, and transient hematological disorders (neutrophilia and secondary eosinophilia). This article reports on causes of hypervitaminosis B12, our experience and a review of the literature.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Zulfiqar</LastName>
+            <ForeName>Abrar-Ahmad</ForeName>
+            <Initials>AA</Initials>
+            <AffiliationInfo>
+              <Affiliation>Service de M&#233;decine Interne, Diab&#232;te et Maladies M&#233;taboliques, H&#244;pitaux Universitaires de Strasbourg, France.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Andres</LastName>
+            <ForeName>Emmanuel</ForeName>
+            <Initials>E</Initials>
+            <AffiliationInfo>
+              <Affiliation>Service de M&#233;decine Interne, Diab&#232;te et Maladies M&#233;taboliques, H&#244;pitaux Universitaires de Strasbourg, France.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lorenzo Villalba</LastName>
+            <ForeName>Noel</ForeName>
+            <Initials>N</Initials>
+            <AffiliationInfo>
+              <Affiliation>Service de M&#233;decine Interne, Diab&#232;te et Maladies M&#233;taboliques, H&#244;pitaux Universitaires de Strasbourg, France. E-mail: noellorenzo@gmail.com.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>spa</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Hipervitaminosis B12. Nuestra experiencia y una revisi&#243;n.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Argentina</Country>
+        <MedlineTA>Medicina (B Aires)</MedlineTA>
+        <NlmUniqueID>0204271</NlmUniqueID>
+        <ISSNLinking>0025-7680</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>P6YC3EG204</RegistryNumber>
+          <NameOfSubstance UI="D014805">Vitamin B 12</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D058186" MajorTopicYN="N">Acute Kidney Injury</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006402" MajorTopicYN="N">Hematologic Diseases</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008107" MajorTopicYN="N">Liver Diseases</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009369" MajorTopicYN="N">Neoplasms</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009748" MajorTopicYN="N">Nutrition Disorders</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+          <QualifierName UI="Q000209" MajorTopicYN="Y">etiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014805" MajorTopicYN="N">Vitamin B 12</DescriptorName>
+          <QualifierName UI="Q000009" MajorTopicYN="N">adverse effects</QualifierName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="spa">
+        <AbstractText>Los altos niveles de vitamina B12 o cobalamina, tambi&#233;n denominado hipervitaminosis B12 es una anormalidad anal&#237;tica frecuentemente subestimada. De acuerdo con la literatura algunas de las entidades relacionadas con este hallazgo son las neoplasias s&#243;lidas (primarias o metast&#225;sicas) y las enfermedades hematol&#243;gicas agudas o cr&#243;nicas. Otras causas incluyen la afecci&#243;n hep&#225;tica, la gammapat&#237;a monoclonal de significaci&#243;n indeterminada, la insuficiencia renal y, con menor frecuencia, un exceso de consumo de vitamina B12, enfermedades inflamatorias o autoinmunes y los trastornos hematol&#243;gicos transitorios (neutrofilia y eosinofilia secundaria). Este art&#237;culo informa sobre causas de hipervitaminosis B12, nuestra experiencia y hace una revisi&#243;n de la literatura.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">B12 hypervitaminemia</Keyword>
+        <Keyword MajorTopicYN="N">cobalamin</Keyword>
+        <Keyword MajorTopicYN="N">hematological malignant disease</Keyword>
+        <Keyword MajorTopicYN="N">neoplasia</Keyword>
+        <Keyword MajorTopicYN="N">transcobalamin</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2019</Year>
+          <Month>11</Month>
+          <Day>1</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2019</Year>
+          <Month>11</Month>
+          <Day>2</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2019</Year>
+          <Month>12</Month>
+          <Day>18</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">31671389</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/34558640.xml
+++ b/tests/fixtures/pmid_xml/34558640.xml
@@ -1,0 +1,1211 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">34558640</PMID>
+      <DateCompleted>
+        <Year>2022</Year>
+        <Month>01</Month>
+        <Day>28</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>01</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Print-Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1791-2423</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>59</Volume>
+            <Issue>5</Issue>
+            <PubDate>
+              <Year>2021</Year>
+              <Month>Nov</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>International journal of oncology</Title>
+          <ISOAbbreviation>Int J Oncol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Mechanisms and management of 3rd&#8209;generation EGFR&#8209;TKI resistance in advanced non&#8209;small cell lung cancer (Review).</ArticleTitle>
+        <ELocationID EIdType="pii" ValidYN="Y">90</ELocationID>
+        <ELocationID EIdType="doi" ValidYN="Y">10.3892/ijo.2021.5270</ELocationID>
+        <Abstract>
+          <AbstractText>Targeted therapy with epidermal growth factor receptor (EGFR)&#8209;tyrosine kinase inhibitors (TKIs) is a standard modality of the 1st&#8209;line treatments for patients with advanced <i>EGFR</i>&#8209;mutated non&#8209;small cell lung cancer (NSCLC), and substantially improves their prognosis. However, <i>EGFR</i> T790M mutation is the primary mechanism of 1st&#8209; and 2nd&#8209;generation EGFR&#8209;TKI resistance. Osimertinib is a representative of the 3rd&#8209;generation EGFR&#8209;TKIs that target T790M mutation, and has satisfactory efficacy in the treatment of T790M&#8209;positive NSCLC with disease progression following use of 1st&#8209; or 2nd&#8209;generation EGFR&#8209;TKIs. Other 3rd&#8209;generation EGFR&#8209;TKIs, such as abivertinib, rociletinib, nazartinib, olmutinib and alflutinib, are also at various stages of development. However, the occurrence of acquired resistance is inevitable, and the mechanisms of 3rd&#8209;generation EGFR&#8209;TKI resistance are complex and incompletely understood. Genomic studies in tissue and liquid biopsies of resistant patients reveal multiple candidate pathways. The present review summarizes the recent findings in mechanisms of resistance to 3rd&#8209;generation EGFR&#8209;TKIs in advanced NSCLC, and provides possible strategies to overcome this resistance. The mechanisms of acquired resistance mainly include an altered EGFR signaling pathway (<i>EGFR</i> tertiary mutations and amplification), activation of aberrant bypassing pathways (hepatocyte growth factor receptor amplification, human epidermal growth factor receptor&#160;2 amplification and aberrant insulin&#8209;like growth factor&#160;1 receptor activation), downstream pathway activation (RAS/RAF/MEK/ERK and PI3K/AKT/mTOR) and histological/phenotypic transformations (SCLC transformation and epithelial&#8209;mesenchymal transition). The combination of targeted therapies is a promising strategy to treat osimertinib&#8209;resistant patients, and multiple clinical studies on novel combined therapies are ongoing.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>He</LastName>
+            <ForeName>Jingyi</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Radiation and Medical Oncology, Zhongnan Hospital of Wuhan University, Wuhan, Hubei 430071, P.R.&#160;China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Huang</LastName>
+            <ForeName>Zhengrong</ForeName>
+            <Initials>Z</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Radiation and Medical Oncology, Zhongnan Hospital of Wuhan University, Wuhan, Hubei 430071, P.R.&#160;China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Han</LastName>
+            <ForeName>Linzhi</ForeName>
+            <Initials>L</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Radiation and Medical Oncology, Zhongnan Hospital of Wuhan University, Wuhan, Hubei 430071, P.R.&#160;China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Gong</LastName>
+            <ForeName>Yan</ForeName>
+            <Initials>Y</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Biological Repositories, Zhongnan Hospital of Wuhan University, Wuhan, Hubei 430071, P.R.&#160;China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Xie</LastName>
+            <ForeName>Conghua</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Radiation and Medical Oncology, Zhongnan Hospital of Wuhan University, Wuhan, Hubei 430071, P.R.&#160;China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <ArticleDate DateType="Electronic">
+          <Year>2021</Year>
+          <Month>09</Month>
+          <Day>24</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Greece</Country>
+        <MedlineTA>Int J Oncol</MedlineTA>
+        <NlmUniqueID>9306042</NlmUniqueID>
+        <ISSNLinking>1019-6439</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000072224">Bcl-2-Like Protein 11</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000082082">Immune Checkpoint Inhibitors</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D047428">Protein Kinase Inhibitors</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 2.7.10.1</RegistryNumber>
+          <NameOfSubstance UI="D066246">ErbB Receptors</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000072224" MajorTopicYN="N">Bcl-2-Like Protein 11</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002289" MajorTopicYN="N">Carcinoma, Non-Small-Cell Lung</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="Y">drug therapy</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019008" MajorTopicYN="N">Drug Resistance, Neoplasm</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D066246" MajorTopicYN="N">ErbB Receptors</DescriptorName>
+          <QualifierName UI="Q000037" MajorTopicYN="Y">antagonists &amp; inhibitors</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000082082" MajorTopicYN="N">Immune Checkpoint Inhibitors</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008175" MajorTopicYN="N">Lung Neoplasms</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="Y">drug therapy</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009154" MajorTopicYN="N">Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D047428" MajorTopicYN="N">Protein Kinase Inhibitors</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="Y">pharmacology</QualifierName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015398" MajorTopicYN="N">Signal Transduction</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+          <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">epidermal growth factor receptor&#8209;tyrosine kinase inhibitor</Keyword>
+        <Keyword MajorTopicYN="N">non&#8209;small cell lung cancer</Keyword>
+        <Keyword MajorTopicYN="N">osimertinib</Keyword>
+        <Keyword MajorTopicYN="N">resistance mechanism</Keyword>
+        <Keyword MajorTopicYN="N">targeted therapy</Keyword>
+      </KeywordList>
+      <CoiStatement>The authors declare that they have no competing interests.</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="received">
+          <Year>2021</Year>
+          <Month>6</Month>
+          <Day>25</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2021</Year>
+          <Month>9</Month>
+          <Day>9</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2021</Year>
+          <Month>9</Month>
+          <Day>24</Day>
+          <Hour>8</Hour>
+          <Minute>49</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2021</Year>
+          <Month>9</Month>
+          <Day>25</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2022</Year>
+          <Month>1</Month>
+          <Day>29</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2021</Year>
+          <Month>9</Month>
+          <Day>24</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">34558640</ArticleId>
+        <ArticleId IdType="pmc">PMC8562388</ArticleId>
+        <ArticleId IdType="doi">10.3892/ijo.2021.5270</ArticleId>
+        <ArticleId IdType="pii">90</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Siegel RL, Miller KD, Jemal A. Cancer statistics, 2020. CA Cancer J Clin. 2020;70:7&#8211;30. doi: 10.3322/caac.21590.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3322/caac.21590</ArticleId>
+            <ArticleId IdType="pubmed">31912902</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Testa U, Castelli G, Pelosi E. Lung cancers: Molecular characterization, clonal heterogeneity and evolution, and cancer stem cells. Cancers (Basel) 2018;10:248. doi: 10.3390/cancers10080248.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3390/cancers10080248</ArticleId>
+            <ArticleId IdType="pmc">PMC6116004</ArticleId>
+            <ArticleId IdType="pubmed">30060526</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rosell R, Moran T, Queralt C, Porta R, Cardenal F, Camps C, Majem M, Lopez-Vivanco G, Isla D, Provencio M, et al. Screening for epidermal growth factor receptor mutations in lung cancer. New Engl J Med. 2009;361:958&#8211;967. doi: 10.1056/NEJMoa0904554.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa0904554</ArticleId>
+            <ArticleId IdType="pubmed">19692684</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>da Cunha Santos G, Shepherd FA, Tsao MS. EGFR mutations and lung cancer. Annu Rev Pathol. 2011;6:49&#8211;69. doi: 10.1146/annurev-pathol-011110-130206.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1146/annurev-pathol-011110-130206</ArticleId>
+            <ArticleId IdType="pubmed">20887192</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Roskoski R., Jr Small molecule inhibitors targeting the EGFR/ErbB family of protein-tyrosine kinases in human cancers. Pharmacol Res. 2019;139:395&#8211;411. doi: 10.1016/j.phrs.2018.11.014.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.phrs.2018.11.014</ArticleId>
+            <ArticleId IdType="pubmed">30500458</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Huang L, Fu L. Mechanisms of resistance to EGFR tyrosine kinase inhibitors. Acta Pharm Sin B. 2015;5:390&#8211;401. doi: 10.1016/j.apsb.2015.07.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.apsb.2015.07.001</ArticleId>
+            <ArticleId IdType="pmc">PMC4629442</ArticleId>
+            <ArticleId IdType="pubmed">26579470</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mok TS, Wu YL, Thongprasert S, Yang CH, Chu DT, Saijo N, Sunpaweravong P, Han B, Margono B, Ichinose Y, et al. Gefitinib or carboplatin-paclitaxel in pulmonary adenocarcinoma. N Engl J Med. 2009;361:947&#8211;957. doi: 10.1056/NEJMoa0810699.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa0810699</ArticleId>
+            <ArticleId IdType="pubmed">19692680</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kazandjian D, Blumenthal GM, Yuan W, He K, Keegan P, Pazdur R. FDA approval of gefitinib for the treatment of patients with metastatic EGFR mutation-positive non-small cell lung cancer. Clin Cancer Res. 2016;22:1307&#8211;1312. doi: 10.1158/1078-0432.CCR-15-2266.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-15-2266</ArticleId>
+            <ArticleId IdType="pubmed">26980062</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rosell R, Carcereny E, Gervais R, Vergnenegre A, Massuti B, Felip E, Palmero R, Garcia-Gomez R, Pallares C, Sanchez JM, et al. Erlotinib versus standard chemotherapy as first-line treatment for European patients with advanced EGFR mutation-positive non-small-cell lung cancer (EURTAC): A multicentre, open-label, randomised phase 3 trial. Lancet Oncol. 2012;13:239&#8211;246. doi: 10.1016/S1470-2045(11)70393-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(11)70393-X</ArticleId>
+            <ArticleId IdType="pubmed">22285168</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shi YK, Wang L, Han BH, Li W, Yu P, Liu YP, Ding CM, Song X, Ma ZY, Ren XL, et al. First-line icotinib versus cisplatin/pemetrexed plus pemetrexed maintenance therapy for patients with advanced EGFR mutation-positive lung adenocarcinoma (CONVINCE): A phase 3, open-label, randomized study. Ann Oncol. 2017;28:2443&#8211;2450. doi: 10.1093/annonc/mdx359.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdx359</ArticleId>
+            <ArticleId IdType="pubmed">28945850</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Park K, Tan EH, O'Byrne K, Zhang L, Boyer M, Mok T, Hirsh V, Yang JC, Lee KH, Lu S, et al. Afatinib versus gefitinib as first-line treatment of patients with EGFR mutation-positive non-small-cell lung cancer (LUX-Lung 7): A phase 2B, open-label, randomised controlled trial. Lancet Oncol. 2016;17:577&#8211;589. doi: 10.1016/S1470-2045(16)30033-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(16)30033-X</ArticleId>
+            <ArticleId IdType="pubmed">27083334</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wu YL, Cheng Y, Zhou X, Lee KH, Nakagawa K, Niho S, Tsuji F, Linke R, Rosell R, Corral J, et al. Dacomitinib versus gefitinib as first-line treatment for patients with EGFR-mutation-positive non-small-cell lung cancer (ARCHER 1050): A randomised, open-label, phase 3 trial. Lancet Oncol. 2017;18:1454&#8211;1466. doi: 10.1016/S1470-2045(17)30608-3.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(17)30608-3</ArticleId>
+            <ArticleId IdType="pubmed">28958502</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Miller VA, Hirsh V, Cadranel J, Chen YM, Park K, Kim SW, Zhou C, Su WC, Wang M, Sun Y, et al. Afatinib versus placebo for patients with advanced, metastatic non-small-cell lung cancer after failure of erlotinib, gefitinib, or both, and one or two lines of chemotherapy (LUX-Lung 1): A phase 2b/3 randomised trial. Lancet Oncol. 2012;13:528&#8211;538. doi: 10.1016/S1470-2045(12)70087-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(12)70087-6</ArticleId>
+            <ArticleId IdType="pubmed">22452896</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ellis PM, Shepherd FA, Millward M, Perrone F, Seymour L, Liu G, Sun S, Cho BC, Morabito A, Leighl NB, et al. Dacomitinib compared with placebo in pretreated patients with advanced or metastatic non-small-cell lung cancer (NCIC CTG BR.26): A double-blind, randomised, phase 3 trial. Lancet Oncol. 2014;15:1379&#8211;1388. doi: 10.1016/S1470-2045(14)70472-3.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(14)70472-3</ArticleId>
+            <ArticleId IdType="pubmed">25439692</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Westover D, Zugazagoitia J, Cho BC, Lovly CM, Paz-Ares L. Mechanisms of acquired resistance to first- and second-generation EGFR tyrosine kinase inhibitors. Ann Oncol. 2018;29(Suppl-1):i10&#8211;i19. doi: 10.1093/annonc/mdx703.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdx703</ArticleId>
+            <ArticleId IdType="pmc">PMC6454547</ArticleId>
+            <ArticleId IdType="pubmed">29462254</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Passaro A, Guerini-Rocco E, Pochesci A, Vacirca D, Spitaleri G, Catania CM, Rappa A, Barberis M, de Marinis F. Targeting EGFR T790M mutation in NSCLC: From biology to evaluation and treatment. Pharmacol Res. 2017;117:406&#8211;415. doi: 10.1016/j.phrs.2017.01.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.phrs.2017.01.003</ArticleId>
+            <ArticleId IdType="pubmed">28089942</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mok TS, Wu YL, Ahn MJ, Garassino MC, Kim HR, Ramalingam SS, Shepherd FA, He Y, Akamatsu H, Theelen WS, et al. Osimertinib or platinum-pemetrexed in EGFR T790M-positive lung cancer. New Engl J Med. 2017;376:629&#8211;640. doi: 10.1056/NEJMoa1612674.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1612674</ArticleId>
+            <ArticleId IdType="pmc">PMC6762027</ArticleId>
+            <ArticleId IdType="pubmed">27959700</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cross DA, Ashton SE, Ghiorghiu S, Eberlein C, Nebhan CA, Spitzler PJ, Orme JP, Finlay MR, Ward RA, Mellor MJ, et al. AZD9291, an irreversible EGFR TKI, overcomes T790M-mediated resistance to EGFR inhibitors in lung cancer. Cancer Discov. 2014;4:1046&#8211;1061. doi: 10.1158/2159-8290.CD-14-0337.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/2159-8290.CD-14-0337</ArticleId>
+            <ArticleId IdType="pmc">PMC4315625</ArticleId>
+            <ArticleId IdType="pubmed">24893891</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Soria JC, Ohe Y, Vansteenkiste J, Reungwetwattana T, Chewaskulyong B, Lee KH, Dechaphunkul A, Imamura F, Nogami N, Kurata T, et al. Osimertinib in untreated EGFR-mutated advanced non-small-cell lung cancer. New Engl J Med. 2018;378:113&#8211;125. doi: 10.1056/NEJMoa1713137.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1713137</ArticleId>
+            <ArticleId IdType="pubmed">29151359</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sequist LV, Soria JC, Camidge DR. Update to rociletinib data with the RECIST confirmed response rate. New Engl J Med. 2016;374:2296&#8211;2297. doi: 10.1056/NEJMc1602688.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMc1602688</ArticleId>
+            <ArticleId IdType="pubmed">27195670</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yun J, Hong MH, Kim SY, Park CW, Kim S, Yun MR, Kang HN, Pyo KH, Lee SS, Koh JS, et al. YH25448, an irreversible EGFR-TKI with potent intracranial activity in EGFR mutant non-small cell lung cancer. Clin Cancer Res. 2019;25:2575&#8211;2587. doi: 10.1158/1078-0432.CCR-18-2906.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-18-2906</ArticleId>
+            <ArticleId IdType="pubmed">30670498</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Xu X, Mao L, Xu W, Tang W, Zhang X, Xi B, Xu R, Fang X, Liu J, Fang C, et al. AC0010, an irreversible EGFR inhibitor selectively targeting mutated EGFR and overcoming T790M-induced resistance in animal models and lung cancer patients. Mol Cancer Ther. 2016;15:2586&#8211;2597. doi: 10.1158/1535-7163.MCT-16-0281.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1535-7163.MCT-16-0281</ArticleId>
+            <ArticleId IdType="pubmed">27573423</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jia Y, Juarez J, Li J, Manuia M, Niederst MJ, Tompkins C, Timple N, Vaillancourt MT, Pferdekamper AC, Lockerman EL, et al. EGF816 exerts anticancer effects in non-small cell lung cancer by irreversibly and selectively targeting primary and acquired activating mutations in the EGF receptor. Cancer Res. 2016;76:1591&#8211;1602. doi: 10.1158/0008-5472.CAN-15-2581.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/0008-5472.CAN-15-2581</ArticleId>
+            <ArticleId IdType="pubmed">26825170</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yu HA, Spira A, Horn L, Weiss J, West H, Giaccone G, Evans T, Kelly RJ, Desai B, Krivoshik A, et al. A phase I, dose escalation study of oral ASP8273 in patients with non-small cell lung cancers with epidermal growth factor receptor mutations. Clin Cancer Res. 2017;23:7467&#8211;7473. doi: 10.1158/1078-0432.CCR-17-1447.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-17-1447</ArticleId>
+            <ArticleId IdType="pmc">PMC8788622</ArticleId>
+            <ArticleId IdType="pubmed">28954786</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Park K, Lee JS, Lee KH, Kim JH, Min YJ, Cho JY, Han JY, Kim BS, Kim JS, Lee DH, et al. Updated safety and efficacy results from phase I/II study of HM61713 in patients (pts) with EGFR mutation positive non-small cell lung cancer (NSCLC) who failed previous EGFR-tyrosine kinase inhibitor (TKI) J Clin Oncol. 2015;33(Suppl 15):S8084. doi: 10.1200/jco.2015.33.15_suppl.8084.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/jco.2015.33.15_suppl.8084</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sequist LV, Rolfe L, Allen AR. Rociletinib in EGFR-mutated non-small-cell lung cancer. New Engl J Med. 2015;373:578&#8211;579. doi: 10.1056/NEJMc1506831.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMc1506831</ArticleId>
+            <ArticleId IdType="pubmed">26244318</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang H, Pan R, Zhang X, Si X, Wang M, Zhang L. Abivertinib in patients with T790M-positive advanced NSCLC and its subsequent treatment with osimertinib. Thorac Cancer. 2020;11:594&#8211;602. doi: 10.1111/1759-7714.13302.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/1759-7714.13302</ArticleId>
+            <ArticleId IdType="pmc">PMC7049520</ArticleId>
+            <ArticleId IdType="pubmed">31943845</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tan DS, Leighl NB, Riely GJ, Yang JC, Sequist LV, Wolf J, Seto T, Felip E, Aix SP, Jonnaert M, et al. Safety and efficacy of nazartinib (EGF816) in adults with EGFR-mutant non-small-cell lung carcinoma: A multicentre, open-label, phase 1 study. Lancet Resp Med. 2020;8:561&#8211;572. doi: 10.1016/S2213-2600(19)30267-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S2213-2600(19)30267-X</ArticleId>
+            <ArticleId IdType="pubmed">31954624</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim DW, Lee DH, Han JY, Lee J, Cho BC, Kang JH, Lee KH, Cho EK, Kim JS, Min YJ, et al. Safety, tolerability, and anti-tumor activity of olmutinib in non-small cell lung cancer with T790M mutation: A single arm, open label, phase 1/2 trial. Lung Cancer. 2019;135:66&#8211;72. doi: 10.1016/j.lungcan.2019.07.007.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2019.07.007</ArticleId>
+            <ArticleId IdType="pubmed">31447004</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shi Y, Zhang S, Hu X, Feng J, Ma Z, Zhou J, Yang N, Wu L, Liao W, Zhong D, et al. Safety, clinical activity, and pharmacokinetics of alflutinib (AST2818) in patients with advanced NSCLC With EGFR T790M mutation. J Thorac Oncol. 2020;15:1015&#8211;1026. doi: 10.1016/j.jtho.2020.01.010.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2020.01.010</ArticleId>
+            <ArticleId IdType="pubmed">32007598</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang JC, Camidge DR, Yang CT, Zhou J, Guo R, Chiu CH, Chang GC, Shiah HS, Chen Y, Wang CC, et al. Safety, efficacy, and pharmacokinetics of almonertinib (HS-10296) in pretreated patients with EGFR-mutated advanced NSCLC: A multicenter, open-label, phase 1 Trial. J Thorac Oncol. 2020;15:1907&#8211;1918. doi: 10.1016/j.jtho.2020.09.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2020.09.001</ArticleId>
+            <ArticleId IdType="pubmed">32916310</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ahn MJ, Han JY, Lee KH, Kim SW, Kim DW, Lee YG, Cho EK, Kim JH, Lee GW, Lee JS, et al. Lazertinib in patients with EGFR mutation-positive advanced non-small-cell lung cancer: Results from the dose escalation and dose expansion parts of a first-in-human, open-label, multicentre, phase 1-2 study. Lancet Oncol. 2019;20:1681&#8211;1690. doi: 10.1016/S1470-2045(19)30504-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(19)30504-2</ArticleId>
+            <ArticleId IdType="pubmed">31587882</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kelly RJ, Shepherd FA, Krivoshik A, Jie F, Horn L. A phase III, randomized, open-label study of ASP8273 versus erlotinib or gefitinib in patients with advanced stage IIIB/IV non-small-cell lung cancer. Ann Oncol. 2019;30:1127&#8211;1133. doi: 10.1093/annonc/mdz128.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdz128</ArticleId>
+            <ArticleId IdType="pmc">PMC6736319</ArticleId>
+            <ArticleId IdType="pubmed">31070709</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mezquita L, Varga A, Planchard D. Safety of osimertinib in EGFR-mutated non-small cell lung cancer. Expert Opin Drug Saf. 2018;17:1239&#8211;1248. doi: 10.1080/14740338.2018.1549222.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/14740338.2018.1549222</ArticleId>
+            <ArticleId IdType="pubmed">30457891</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ramalingam SS, Vansteenkiste J, Planchard D, Cho BC, Gray JE, Ohe Y, Zhou C, Reungwetwattana T, Cheng Y, Chewaskulyong B, et al. Overall Survival with Osimertinib in Untreated, -Mutated Advanced NSCLC. New Engl J Med. 2020;382:41&#8211;50. doi: 10.1056/NEJMoa1913662.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1913662</ArticleId>
+            <ArticleId IdType="pubmed">31751012</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Reungwetwattana T, Nakagawa K, Cho BC, Cobo M, Cho EK, Bertolini A, Bohnet S, Zhou C, Lee KH, Nogami N, et al. CNS response to osimertinib versus standard epidermal growth factor receptor tyrosine kinase inhibitors in patients with untreated EGFR-mutated advanced non-small-cell lung cancer. J Clin Oncol. 2018 Aug 28; doi: 10.1200/JCO.2018.78.3118. Epub ahead of print.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2018.78.3118</ArticleId>
+            <ArticleId IdType="pubmed">30153097</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Saito H, Fukuhara T, Furuya N, Watanabe K, Sugawara S, Iwasawa S, Tsunezuka Y, Yamaguchi O, Okada M, Yoshimori K, et al. Erlotinib plus bevacizumab versus erlotinib alone in patients with EGFR-positive advanced non-squamous non-small-cell lung cancer (NEJ026): Interim analysis of an open-label, randomised, multicentre, phase 3 trial. Lancet Oncol. 2019;20:625&#8211;635. doi: 10.1016/S1470-2045(19)30035-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(19)30035-X</ArticleId>
+            <ArticleId IdType="pubmed">30975627</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Goldberg SB, Redman MW, Lilenbaum R, Politi K, Stinchcombe TE, Horn L, Chen EH, Mashru SH, Gettinger SN, Melnick MA, et al. Randomized trial of afatinib plus cetuximab versus afatinib alone for first-line treatment of -mutant non-small-cell lung cancer: Final results from SWOG S1403. J Clin Oncol. 2020;38:4076&#8211;4085. doi: 10.1200/JCO.20.01149.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.20.01149</ArticleId>
+            <ArticleId IdType="pmc">PMC7768342</ArticleId>
+            <ArticleId IdType="pubmed">33021871</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oxnard GR, Yang JC, Yu H, Kim SW, Saka H, Horn L, Goto K, Ohe Y, Mann H, Thress KS, et al. TATTON: A multi-arm, phase Ib trial of osimertinib combined with selumetinib, savolitinib, or durvalumab in EGFR-mutant lung cancer. Ann Oncol. 2020;31:507&#8211;516. doi: 10.1016/j.annonc.2020.01.013.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annonc.2020.01.013</ArticleId>
+            <ArticleId IdType="pubmed">32139298</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sequist LV, Piotrowska Z, Niederst MJ, Heist RS, Digumarthy S, Shaw AT, Engelman JA. Osimertinib responses after disease progression in patients who had been receiving rociletinib. JAMA Oncol. 2016;2:541&#8211;543. doi: 10.1001/jamaoncol.2015.5009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamaoncol.2015.5009</ArticleId>
+            <ArticleId IdType="pubmed">26720284</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nagasaka M, Zhu VW, Lim SM, Greco M, Wu F, Ou SI. Beyond osimertinib: The development of third-generation EGFR tyrosine kinase inhibitors for advanced EGFR+ NSCLC. J Thorac Oncol. 2021;16:740&#8211;763. doi: 10.1016/j.jtho.2020.11.028.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2020.11.028</ArticleId>
+            <ArticleId IdType="pubmed">33338652</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ma Y, Zheng X, Zhao H, Fang W, Zhang Y, Ge J, Wang L, Wang W, Jiang J, Chuai S, et al. First-in-human phase I study of AC0010, a mutant-selective EGFR inhibitor in non-small cell lung cancer: Safety, efficacy, and potential mechanism of resistance. J Thorac Oncol. 2018;13:968&#8211;977. doi: 10.1016/j.jtho.2018.03.025.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2018.03.025</ArticleId>
+            <ArticleId IdType="pubmed">29626621</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang H, Zhang L, Hu P, Zheng X, Si X, Zhang X, Wang M. Penetration of the blood-brain barrier by avitinib and its control of intra/extra-cranial disease in non-small cell lung cancer harboring the T790M mutation. Lung Cancer. 2018;122:1&#8211;6. doi: 10.1016/j.lungcan.2018.05.010.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2018.05.010</ArticleId>
+            <ArticleId IdType="pubmed">30032814</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim ES. Olmutinib: First global approval. Drugs. 2016;76:1153&#8211;1157. doi: 10.1007/s40265-016-0606-z.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s40265-016-0606-z</ArticleId>
+            <ArticleId IdType="pubmed">27357069</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arcila ME, Nafa K, Chaft JE, Rekhtman N, Lau C, Reva BA, Zakowski MF, Kris MG, Ladanyi M. EGFR exon 20 insertion mutations in lung adenocarcinomas: Prevalence, molecular heterogeneity, and clinicopathologic characteristics. Mol Cancer Ther. 2013;12:220&#8211;229. doi: 10.1158/1535-7163.MCT-12-0620.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1535-7163.MCT-12-0620</ArticleId>
+            <ArticleId IdType="pmc">PMC3714231</ArticleId>
+            <ArticleId IdType="pubmed">23371856</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Robichaux JP, Elamin YY, Tan Z, Carter BW, Zhang S, Liu S, Li S, Chen T, Poteete A, Estrada-Bernal A, et al. Mechanisms and clinical activity of an EGFR and HER2 exon 20-selective kinase inhibitor in non-small cell lung cancer. Nat Med. 2018;24:638&#8211;646. doi: 10.1038/s41591-018-0007-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41591-018-0007-9</ArticleId>
+            <ArticleId IdType="pmc">PMC5964608</ArticleId>
+            <ArticleId IdType="pubmed">29686424</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Qin Y, Jian H, Tong X, Wu X, Wang F, Shao YW, Zhao X. Variability of EGFR exon 20 insertions in 24 468 Chinese lung cancer patients and their divergent responses to EGFR inhibitors. Mol Oncol. 2020;14:1695&#8211;1704. doi: 10.1002/1878-0261.12710.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/1878-0261.12710</ArticleId>
+            <ArticleId IdType="pmc">PMC7400778</ArticleId>
+            <ArticleId IdType="pubmed">32412152</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>van Veggel B, Madeira R, Santos JFV, Hashemi SMS, Paats MS, Monkhorst K, Heideman DAM, Groves M, Radonic T, Smit EF, et al. Osimertinib treatment for patients with EGFR exon 20 mutation positive non-small cell lung cancer. Lung Cancer. 2020;141:9&#8211;13. doi: 10.1016/j.lungcan.2019.12.013.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2019.12.013</ArticleId>
+            <ArticleId IdType="pubmed">31926441</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li X, Wang S, Li B, Wang Z, Shang S, Shao Y, Sun X, Wang L. BIM deletion polymorphism confers resistance to osimertinib in EGFR T790M lung cancer: A case report and literature review. Target Oncol. 2018;13:517&#8211;523. doi: 10.1007/s11523-018-0573-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11523-018-0573-2</ArticleId>
+            <ArticleId IdType="pubmed">29907952</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhao M, Zhang Y, Cai W, Li J, Zhou F, Cheng N, Ren R, Zhao C, Li X, Ren S, et al. The Bim deletion polymorphism clinical profile and its relation with tyrosine kinase inhibitor resistance in Chinese patients with non-small cell lung cancer. Cancer. 2014;120:2299&#8211;2307. doi: 10.1002/cncr.28725.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/cncr.28725</ArticleId>
+            <ArticleId IdType="pubmed">24737648</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tanimoto A, Takeuchi S, Arai S, Fukuda K, Yamada T, Roca X, Ong ST, Yano S. Histone deacetylase 3 inhibition overcomes BIM deletion polymorphism-mediated osimertinib resistance in EGFR-mutant lung cancer. Clin Cancer Res. 2017;23:3139&#8211;3149. doi: 10.1158/1078-0432.CCR-16-2271.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-16-2271</ArticleId>
+            <ArticleId IdType="pubmed">27986747</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Isobe K, Hata Y, Tochigi N, Kaburaki K, Kobayashi H, Makino T, Otsuka H, Sato F, Ishida F, Kikuchi N, et al. Clinical significance of BIM deletion polymorphism in non-small-cell lung cancer with epidermal growth factor receptor mutation. J Thorac Oncol. 2014;9:483&#8211;487. doi: 10.1097/JTO.0000000000000125.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/JTO.0000000000000125</ArticleId>
+            <ArticleId IdType="pmc">PMC4132037</ArticleId>
+            <ArticleId IdType="pubmed">24736070</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu SY, Zhou JY, Li WF, Sun H, Zhang YC, Yan HH, Chen ZH, Chen CX, Ye JY, Yang JJ, et al. Concomitant genetic alterations having greater impact on the clinical benefit of EGFR-TKIs in EGFR-mutant advanced NSCLC than BIM deletion polymorphism. Clin Transl Med. 2020;10:337&#8211;345. doi: 10.1002/ctm2.12.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ctm2.12</ArticleId>
+            <ArticleId IdType="pmc">PMC7240862</ArticleId>
+            <ArticleId IdType="pubmed">32508032</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Papadimitrakopoulou VA, Wu YL, Han JY, Ahn MJ, Ramalingam SS, John T, Okamoto I, Yang JCH, Bulusu KC, Laus G, et al. Analysis of resistance mechanisms to osimertinib in patients with EGFR T790M advanced NSCLC from the AURA3 study. Ann Oncol. 2018;29(Suppl 8):VIII741. doi: 10.1093/annonc/mdy424.064.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdy424.064</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang Z, Yang N, Ou Q, Xiang Y, Jiang T, Wu X, Bao H, Tong X, Wang X, Shao YW, et al. Investigating novel resistance mechanisms to third-generation EGFR tyrosine kinase inhibitor osimertinib in non-small cell lung cancer patients. Clin Cancer Res. 2018;24:3097&#8211;3107. doi: 10.1158/1078-0432.CCR-17-2310.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-17-2310</ArticleId>
+            <ArticleId IdType="pubmed">29506987</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Le X, Puri S, Negrao MV, Nilsson MB, Robichaux J, Boyle T, Hicks JK, Lovinger KL, Roarty E, Rinsurongkawong W, et al. Landscape of EGFR-dependent and -independent resistance mechanisms to osimertinib and continuation therapy beyond progression in -mutant NSCLC. Clin Cancer Res. 2018;24:6195&#8211;6203. doi: 10.1158/1078-0432.CCR-18-1542.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-18-1542</ArticleId>
+            <ArticleId IdType="pmc">PMC6295279</ArticleId>
+            <ArticleId IdType="pubmed">30228210</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oxnard GR, Hu Y, Mileham KF, Husain H, Costa DB, Tracy P, Feeney N, Sholl LM, Dahlberg SE, Redig AJ, et al. Assessment of resistance mechanisms and clinical implications in patients with EGFR T790M-positive lung cancer and acquired resistance to osimertinib. JAMA Oncol. 2018;4:1527&#8211;1534. doi: 10.1001/jamaoncol.2018.2969.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamaoncol.2018.2969</ArticleId>
+            <ArticleId IdType="pmc">PMC6240476</ArticleId>
+            <ArticleId IdType="pubmed">30073261</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lin CC, Shih JY, Yu CJ, Ho CC, Liao WY, Lee JH, Tsai TH, Su KY, Hsieh MS, Chang YL, et al. Outcomes in patients with non-small-cell lung cancer and acquired Thr790Met mutation treated with osimertinib: A genomic study. Lancet Resp Med. 2018;6:107&#8211;116. doi: 10.1016/S2213-2600(17)30480-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S2213-2600(17)30480-0</ArticleId>
+            <ArticleId IdType="pubmed">29249325</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ramalingam SS, Cheng Y, Zhou C, Ohe Y, Imamura F, Cho BC, Lin MC, Majem M, Shah R, Rukazenkov Y, et al. Mechanisms of acquired resistance to first-line osimertinib: Preliminary data from the phase III FLAURA study. Ann Oncol. 2018;29(Suppl 8):viii740. doi: 10.1093/annonc/mdy424.063.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdy424.063</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ramalingam SS, Yang JC, Lee CK, Kurata T, Kim DW, John T, Nogami N, Ohe Y, Mann H, Rukazenkov Y, et al. Osimertinib as first-line treatment of EGFR mutation-positive advanced non-small-cell lung cancer. J Clin Oncol. 2018;36:841&#8211;849. doi: 10.1200/JCO.2017.74.7576.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2017.74.7576</ArticleId>
+            <ArticleId IdType="pubmed">28841389</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang YC, Chen ZH, Zhang XC, Xu CR, Yan HH, Xie Z, Chuai SK, Ye JY, Han-Zhang H, Zhang Z, et al. Analysis of resistance mechanisms to abivertinib, a third-generation EGFR tyrosine kinase inhibitor, in patients with EGFR T790M-positive non-small cell lung cancer from a phase I trial. EBioMedicine. 2019;43:180&#8211;187. doi: 10.1016/j.ebiom.2019.04.030.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ebiom.2019.04.030</ArticleId>
+            <ArticleId IdType="pmc">PMC6558024</ArticleId>
+            <ArticleId IdType="pubmed">31027916</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chabon JJ, Simmons AD, Lovejoy AF, Esfahani MS, Newman AM, Haringsma HJ, Kurtz DM, Stehr H, Scherer F, Karlovich CA, et al. Circulating tumour DNA profiling reveals heterogeneity of EGFR inhibitor resistance mechanisms in lung cancer patients. Nat Commun. 2016;7:11815. doi: 10.1038/ncomms11815.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/ncomms11815</ArticleId>
+            <ArticleId IdType="pmc">PMC4906406</ArticleId>
+            <ArticleId IdType="pubmed">27283993</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Helman E, Nguyen M, Karlovich CA, Despain D, Choquette AK, Spira AI, Yu HA, Camidge DR, Harding TC, Lanman RB, Simmons AD. Cell-Free DNA next-generation sequencing prediction of response and resistance to third-generation EGFR inhibitor. Clin Lung Cancer. 2018;19:530.e7. doi: 10.1016/j.cllc.2018.07.008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.cllc.2018.07.008</ArticleId>
+            <ArticleId IdType="pubmed">30279111</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ercan D, Choi HG, Yun CH, Capelletti M, Xie T, Eck MJ, Gray NS, J&#228;nne PA. EGFR mutations and resistance to irreversible pyrimidine-based EGFR inhibitors. Clin Cancer Res. 2015;21:3913&#8211;3923. doi: 10.1158/1078-0432.CCR-14-2789.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-14-2789</ArticleId>
+            <ArticleId IdType="pmc">PMC4791951</ArticleId>
+            <ArticleId IdType="pubmed">25948633</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Song HN, Jung KS, Yoo KH, Cho J, Lee JY, Lim SH, Kim HS, Sun JM, Lee SH, Ahn JS, et al. Acquired C797S mutation upon treatment with a T790M-specific third-generation EGFR inhibitor (HM61713) in non-small cell lung cancer. J Thorac Oncol. 2016;11:e45&#8211;e47. doi: 10.1016/j.jtho.2015.12.093.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2015.12.093</ArticleId>
+            <ArticleId IdType="pubmed">26749488</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Park S, Ku BM, Jung HA, Sun JM, Ahn JS, Lee SH, Park K, Ahn MJ. EGFR C797S as a resistance mechanism of lazertinib in non-small cell lung cancer with EGFR T790M mutation. Cancer Res Treat. 2020;52:1288&#8211;1290.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7577810</ArticleId>
+            <ArticleId IdType="pubmed">32599977</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oztan A, Fischer S, Schrock AB, Erlich RL, Lovly CM, Stephens PJ, Ross JS, Miller V, Ali SM, Ou SI, Raez LE. Emergence of EGFR G724S mutation in EGFR-mutant lung adenocarcinoma post progression on osimertinib. Lung Cancer. 2017;111:84&#8211;87. doi: 10.1016/j.lungcan.2017.07.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2017.07.002</ArticleId>
+            <ArticleId IdType="pubmed">28838405</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Fassunke J, Muller F, Keul M, Michels S, Dammert MA, Schmitt A, Plenker D, Lategahn J, Heydt C, Bragelmann J, et al. Overcoming EGFRG724S-mediated osimertinib resistance through unique binding characteristics of second-generation EGFR inhibitors. Nat Commun. 2018;9:4655. doi: 10.1038/s41467-018-07078-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41467-018-07078-0</ArticleId>
+            <ArticleId IdType="pmc">PMC6220297</ArticleId>
+            <ArticleId IdType="pubmed">30405134</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bersanelli M, Minari R, Bordi P, Gnetti L, Bozzetti C, Squadrilli A, Lagrasta CA, Bottarelli L, Osipova G, Capelletto E, et al. L718Q mutation as new mechanism of acquired resistance to AZD9291 in EGFR-Mutated NSCLC. J Thorac Oncol 11: e121-e123, 2016</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">27257132</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhao S, Li X, Zhao C, Jiang T, Jia Y, Shi J, He Y, Li J, Zhou F, Gao G, et al. Loss of T790M mutation is associated with early progression to osimertinib in Chinese patients with advanced NSCLC who are harboring EGFR T790M. Lung Cancer. 2019;128:33&#8211;39. doi: 10.1016/j.lungcan.2018.12.010.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2018.12.010</ArticleId>
+            <ArticleId IdType="pubmed">30642450</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Piotrowska Z, Niederst MJ, Karlovich CA, Wakelee HA, Neal JW, Mino-Kenudson M, Fulton L, Hata AN, Lockerman EL, Kalsy A, et al. Heterogeneity underlies the emergence of EGFRT790 wild-type clones following treatment of T790M-positive cancers with a third-generation EGFR inhibitor. Cancer Discov. 2015;5:713&#8211;722. doi: 10.1158/2159-8290.CD-15-0399.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/2159-8290.CD-15-0399</ArticleId>
+            <ArticleId IdType="pmc">PMC4497836</ArticleId>
+            <ArticleId IdType="pubmed">25934077</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Knebel FH, Bettoni F, Shimada AK, Cruz M, Alessi JV, Negr&#227;o MV, Reis LFL, Katz A, Camargo AA. Sequential liquid biopsies reveal dynamic alterations of EGFR driver mutations and indicate EGFR amplification as a new mechanism of resistance to osimertinib in NSCLC. Lung Cancer. 2017;108:238&#8211;241. doi: 10.1016/j.lungcan.2017.04.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2017.04.004</ArticleId>
+            <ArticleId IdType="pubmed">28625643</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang Q, Yang S, Wang K, Sun SY. MET inhibitors for targeted therapy of EGFR TKI-resistant lung cancer. J Hematol Oncol. 2019;12:63. doi: 10.1186/s13045-019-0759-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13045-019-0759-9</ArticleId>
+            <ArticleId IdType="pmc">PMC6588884</ArticleId>
+            <ArticleId IdType="pubmed">31227004</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Drilon A, Cappuzzo F, Ou SI, Camidge DR. Targeting MET in lung cancer: Will expectations finally Be MET? J Thorac Oncol. 2017;12:15&#8211;26. doi: 10.1016/j.jtho.2016.10.014.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2016.10.014</ArticleId>
+            <ArticleId IdType="pmc">PMC5603268</ArticleId>
+            <ArticleId IdType="pubmed">27794501</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hsu CC, Liao BC, Liao WY, Markovets A, Stetson D, Thress K, Yang JC. Exon 16-Skipping HER2 as a Novel Mechanism of Osimertinib Resistance in EGFR L858R/T790M-positive non-small cell lung cancer. J Thorac Oncol. 2020;15:50&#8211;61. doi: 10.1016/j.jtho.2019.09.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2019.09.006</ArticleId>
+            <ArticleId IdType="pubmed">31557536</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Desai A, Adjei AA. FGFR signaling as a target for lung cancer therapy. J Thorac Oncol. 2016;11:9&#8211;20. doi: 10.1016/j.jtho.2015.08.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2015.08.003</ArticleId>
+            <ArticleId IdType="pubmed">26762735</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim TM, Song A, Kim DW, Kim S, Ahn YO, Keam B, Jeon YK, Lee SH, Chung DH, Heo DS. Mechanisms of acquired resistance to AZD9291: A mutation-selective, irreversible EGFR inhibitor. J Thorac Oncol. 2015;10:1736&#8211;1744. doi: 10.1097/JTO.0000000000000688.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/JTO.0000000000000688</ArticleId>
+            <ArticleId IdType="pubmed">26473643</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ou SI, Horn L, Cruz M, Vafai D, Lovly CM, Spradlin A, Williamson MJ, Dagogo-Jack I, Johnson A, Miller VA, et al. Emergence of FGFR3-TACC3 fusions as a potential by-pass resistance mechanism to EGFR tyrosine kinase inhibitors in EGFR mutated NSCLC patients. Lung Cancer. 2017;111:61&#8211;64. doi: 10.1016/j.lungcan.2017.07.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2017.07.006</ArticleId>
+            <ArticleId IdType="pmc">PMC10203818</ArticleId>
+            <ArticleId IdType="pubmed">28838400</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hayakawa D, Takahashi F, Mitsuishi Y, Tajima K, Hidayat M, Winardi W, Ihara H, Kanamori K, Matsumoto N, Asao T, et al. Activation of insulin-like growth factor-1 receptor confers acquired resistance to osimertinib in non-small cell lung cancer with EGFR T790M mutation. Thorac Cancer. 2020;11:140&#8211;149. doi: 10.1111/1759-7714.13255.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/1759-7714.13255</ArticleId>
+            <ArticleId IdType="pmc">PMC6938756</ArticleId>
+            <ArticleId IdType="pubmed">31758670</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Manabe T, Yasuda H, Terai H, Kagiwada H, Hamamoto J, Ebisudani T, Kobayashi K, Masuzawa K, Ikemura S, Kawada I, et al. IGF2 Autocrine-Mediated IGF1R activation is a clinically relevant mechanism of osimertinib resistance in lung cancer. Mol Cancer Res. 2020;18:549&#8211;559. doi: 10.1158/1541-7786.MCR-19-0956.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1541-7786.MCR-19-0956</ArticleId>
+            <ArticleId IdType="pubmed">31941753</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Taniguchi H, Yamada T, Wang R, Tanimura K, Adachi Y, Nishiyama A, Tanimoto A, Takeuchi S, Araujo LH, Boroni M, et al. AXL confers intrinsic resistance to osimertinib and advances the emergence of tolerant cells. Nat Commun. 2019;10:259. doi: 10.1038/s41467-018-08074-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41467-018-08074-0</ArticleId>
+            <ArticleId IdType="pmc">PMC6335418</ArticleId>
+            <ArticleId IdType="pubmed">30651547</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Namba K, Shien K, Takahashi Y, Torigoe H, Sato H, Yoshioka T, Takeda T, Kurihara E, Ogoshi Y, Yamamoto H, et al. Activation of AXL as a preclinical acquired resistance mechanism against osimertinib treatment in EGFR-mutant non-small cell lung cancer cells. Mol Cancer Res. 2019;17:499&#8211;507. doi: 10.1158/1541-7786.MCR-18-0628.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1541-7786.MCR-18-0628</ArticleId>
+            <ArticleId IdType="pubmed">30463991</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nakatani K, Yamaoka T, Ohba M, Fujita KI, Arata S, Kusumoto S, Taki-Takemoto I, Kamei D, Iwai S, Tsurutani J, Ohmori T. KRAS and EGFR amplifications mediate resistance to rociletinib and osimertinib in acquired afatinib-resistant NSCLC harboring exon 19 deletion/T790M in. Mol Cancer Ther. 2019;18:112&#8211;126. doi: 10.1158/1535-7163.MCT-18-0591.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1535-7163.MCT-18-0591</ArticleId>
+            <ArticleId IdType="pubmed">30322949</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Marcoux N, Gettinger SN, O'Kane G, Arbour KC, Neal JW, Husain H, Evans TL, Brahmer JR, Muzikansky A, Bonomi PD, et al. EGFR-mutant adenocarcinomas that transform to small-cell lung cancer and other neuroendocrine carcinomas: Clinical outcomes. J Clin Oncol. 2019;37:278&#8211;285. doi: 10.1200/JCO.18.01585.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.18.01585</ArticleId>
+            <ArticleId IdType="pmc">PMC7001776</ArticleId>
+            <ArticleId IdType="pubmed">30550363</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schoenfeld AJ, Chan JM, Kubota D, Sato H, Rizvi H, Daneshbod Y, Chang JC, Paik PK, Offin M, Arcila ME, et al. Tumor analyses reveal squamous transformation and off-target alterations as early resistance mechanisms to first-line osimertinib in EGFR-mutant lung cancer. Clin Cancer Res. 2020;26:2654&#8211;2663. doi: 10.1158/1078-0432.CCR-19-3563.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-19-3563</ArticleId>
+            <ArticleId IdType="pmc">PMC7448565</ArticleId>
+            <ArticleId IdType="pubmed">31911548</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dongre A, Weinberg RA. New insights into the mechanisms of epithelial-mesenchymal transition and implications for cancer. Nat Rev Mol Cell Biol. 2019;20:69&#8211;84. doi: 10.1038/s41580-018-0080-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41580-018-0080-4</ArticleId>
+            <ArticleId IdType="pubmed">30459476</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nukaga S, Yasuda H, Tsuchihara K, Hamamoto J, Masuzawa K, Kawada I, Naoki K, Matsumoto S, Mimaki S, Ikemura S, et al. Amplification of EGFR wild-type alleles in non-small cell lung cancer cells confers acquired resistance to mutation-selective EGFR tyrosine kinase inhibitors. Cancer Res. 2017;77:2078&#8211;2089. doi: 10.1158/0008-5472.CAN-16-2359.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/0008-5472.CAN-16-2359</ArticleId>
+            <ArticleId IdType="pubmed">28202511</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weng CH, Chen LY, Lin YC, Shih JY, Lin YC, Tseng RY, Chiu AC, Yeh YH, Liu C, Lin YT, et al. Epithelial-mesenchymal transition (EMT) beyond EGFR mutations per se is a common mechanism for acquired resistance to EGFR TKI. Oncogene. 2019;38:455&#8211;468. doi: 10.1038/s41388-018-0454-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41388-018-0454-2</ArticleId>
+            <ArticleId IdType="pubmed">30111817</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schrock AB, Zhu VW, Hsieh WS, Madison R, Creelan B, Silberberg J, Costin D, Bharne A, Bonta I, Bosemani T, et al. Receptor tyrosine kinase fusions and BRAF kinase fusions are rare but actionable resistance mechanisms to EGFR tyrosine kinase inhibitors. J Thorac Oncol. 2018;13:1312&#8211;1323. doi: 10.1016/j.jtho.2018.05.027.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2018.05.027</ArticleId>
+            <ArticleId IdType="pubmed">29883838</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Batra U, Sharma M, Amrith BP, Mehta A, Jain P. EML4-ALK fusion as a resistance mechanism to osimertinib and its successful management with osimertinib and alectinib: Case report and review of the literature. Clin Lung Cancer. 2020;21:e597&#8211;e600. doi: 10.1016/j.cllc.2020.05.016.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.cllc.2020.05.016</ArticleId>
+            <ArticleId IdType="pubmed">32620470</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jia Y, Yun CH, Park E, Ercan D, Manuia M, Juarez J, Xu C, Rhee K, Chen T, Zhang H, et al. Overcoming EGFR(T790M) and EGFR(C797S) resistance with mutant-selective allosteric inhibitors. Nature. 2016;534:129&#8211;132. doi: 10.1038/nature17960.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/nature17960</ArticleId>
+            <ArticleId IdType="pmc">PMC4929832</ArticleId>
+            <ArticleId IdType="pubmed">27251290</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Uchibori K, Inase N, Araki M, Kamada M, Sato S, Okuno Y, Fujita N, Katayama R. Brigatinib combined with anti-EGFR antibody overcomes osimertinib resistance in EGFR-mutated non-small-cell lung cancer. Nat Commun. 2017;8:14768. doi: 10.1038/ncomms14768.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/ncomms14768</ArticleId>
+            <ArticleId IdType="pmc">PMC5355811</ArticleId>
+            <ArticleId IdType="pubmed">28287083</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schalm SS, Dineen T, Lim SM, Park CW, Hsieh J, Woessner R, Zhang Z, Wilson K, Eno M, Wilson D, et al. 1296P BLU-945, a highly potent and selective 4th generation EGFR TKI for the treatment of EGFR T790M/C797S resistant NSCLC. Ann Oncol. 2020;31(Suppl 6):S1386&#8211;S1406.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Liu X, Zhang X, Yang L, Tian X, Dong T, Ding CZ, Hu L, Wu L, Zhao L, Mao J, et al. Abstract 1320: Preclinical evaluation of TQB3804, a potent EGFR C797S inhibitor. 2019;79(Suppl 13):S1320.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kim DW, Tiseo M, Ahn MJ, Reckamp KL, Hansen KH, Kim SW, Huber RM, West HL, Groen HJ, Hochmair MJ, et al. Brigatinib in patients with crizotinib-refractory anaplastic lymphoma kinase-positive non-small-cell lung cancer: A randomized, multicenter phase II trial. J Clin Oncol. 2017;35:2490&#8211;2498. doi: 10.1200/JCO.2016.71.5904.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2016.71.5904</ArticleId>
+            <ArticleId IdType="pubmed">28475456</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang Y, Yang N, Zhang Y, Li L, Han R, Zhu M, Feng M, Chen H, Lizaso A, Qin T, et al. Effective treatment of lung adenocarcinoma harboring EGFR-activating mutation, T790M, and cis-C797S triple mutations by brigatinib and cetuximab combination therapy. J Thorac Oncol. 2020;15:1369&#8211;1375. doi: 10.1016/j.jtho.2020.04.014.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2020.04.014</ArticleId>
+            <ArticleId IdType="pubmed">32353596</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhao J, Zou M, Lv J, Han Y, Wang G, Wang G. Effective treatment of pulmonary adenocarcinoma harboring triple EGFR mutations of L858R, T790M, and -C797S by osimertinib, bevacizumab, and brigatinib combination therapy: A case report. Onco Targets Ther. 2018;11:5545&#8211;5550. doi: 10.2147/OTT.S170358.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2147/OTT.S170358</ArticleId>
+            <ArticleId IdType="pmc">PMC6134962</ArticleId>
+            <ArticleId IdType="pubmed">30233215</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arulananda S, Do H, Musafer A, Mitchell P, Dobrovic A, John T. Combination osimertinib and gefitinib in C797S and T790M EGFR-mutated non-small cell lung cancer. J Thorac Oncol. 2017;12:1728&#8211;1732. doi: 10.1016/j.jtho.2017.08.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2017.08.006</ArticleId>
+            <ArticleId IdType="pubmed">28843359</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Giroux-Leprieur E, Dumenil C, Chinet T. Combination of crizotinib and osimertinib or erlotinib might overcome MET-mediated resistance to EGFR Tyrosine kinase inhibitor in EGFR-mutated adenocarcinoma. J Thorac Oncol. 2018;13:e232&#8211;e234. doi: 10.1016/j.jtho.2018.07.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2018.07.012</ArticleId>
+            <ArticleId IdType="pubmed">30368417</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sequist LV, Han JY, Ahn MJ, Cho BC, Yu H, Kim SW, Yang JC, Lee JS, Su WC, Kowalski D, et al. Osimertinib plus savolitinib in patients with EGFR mutation-positive, MET-amplified, non-small-cell lung cancer after progression on EGFR tyrosine kinase inhibitors: Interim results from a multicentre, open-label, phase 1b study. Lancet Oncol. 2020;21:373&#8211;386. doi: 10.1016/S1470-2045(19)30785-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1470-2045(19)30785-5</ArticleId>
+            <ArticleId IdType="pubmed">32027846</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Odogwu L, Mathieu L, Blumenthal G, Larkins E, Goldberg KB, Griffin N, Bijwaard K, Lee EY, Philip R, Jiang X, et al. FDA approval summary: Dabrafenib and trametinib for the treatment of metastatic non-small cell lung cancers harboring BRAF V600E mutations. Oncologist. 2018;23:740&#8211;745. doi: 10.1634/theoncologist.2017-0642.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1634/theoncologist.2017-0642</ArticleId>
+            <ArticleId IdType="pmc">PMC6067947</ArticleId>
+            <ArticleId IdType="pubmed">29438093</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oh DK, Ji WJ, Kim WS, Choi CM, Yoon SK, Rho JK, Lee JC. Efficacy, safety, and resistance profile of osimertinib in T790M mutation-positive non-small cell lung cancer in real-world practice. PLoS One. 2019;14:e0210225. doi: 10.1371/journal.pone.0210225.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1371/journal.pone.0210225</ArticleId>
+            <ArticleId IdType="pmc">PMC6326493</ArticleId>
+            <ArticleId IdType="pubmed">30625213</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Piotrowska Z, Isozaki H, Lennerz JK, Gainor JF, Lennes IT, Zhu VW, Marcoux N, Banwait MK, Digumarthy SR, Su W, et al. Landscape of acquired resistance to osimertinib in EGFR-Mutant NSCLC and clinical validation of combined EGFR and RET inhibition with osimertinib and BLU-667 for acquired fusion. Cancer Discov. 2018;8:1529&#8211;1539. doi: 10.1158/2159-8290.CD-18-1022.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/2159-8290.CD-18-1022</ArticleId>
+            <ArticleId IdType="pmc">PMC6279502</ArticleId>
+            <ArticleId IdType="pubmed">30257958</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Han R, Hao S, Lu C, Zhang C, Lin C, Li L, Wang Y, Hu C, He Y. Aspirin sensitizes osimertinib-resistant NSCLC cells in vitro and in vivo via Bim-dependent apoptosis induction. Mol Oncol. 2020;14:1152&#8211;1169. doi: 10.1002/1878-0261.12682.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/1878-0261.12682</ArticleId>
+            <ArticleId IdType="pmc">PMC7266273</ArticleId>
+            <ArticleId IdType="pubmed">32239624</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Niederst MJ, Hu H, Mulvey HE, Lockerman EL, Garcia AR, Piotrowska Z, Sequist LV, Engelman JA. The allelic context of the C797S mutation acquired upon treatment with third-generation EGFR inhibitors impacts sensitivity to subsequent treatment strategies. Clin Cancer Res. 2015;21:3924&#8211;3933. doi: 10.1158/1078-0432.CCR-15-0560.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-15-0560</ArticleId>
+            <ArticleId IdType="pmc">PMC4587765</ArticleId>
+            <ArticleId IdType="pubmed">25964297</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang Z, Yang JJ, Huang J, Ye JY, Zhang XC, Tu HY, Han-Zhang H, Wu YL. Lung Adenocarcinoma Harboring EGFR T790M and in trans C797S responds to combination therapy of first- and third-generation EGFR TKIs and shifts allelic configuration at resistance. J Thorac Oncol. 2017;12:1723&#8211;1727. doi: 10.1016/j.jtho.2017.06.017.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2017.06.017</ArticleId>
+            <ArticleId IdType="pubmed">28662863</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rotow JK, Costa DB, Paweletz CP, Awad MM, Marcoux P, Rangachari D, Barbie DA, Sands J, Cheng ML, Johnson BE, et al. Concurrent osimertinib plus gefitinib for first-line treatment of EGFR-mutated non-small cell lung cancer (NSCLC) J Clin Oncol. 2020;38:9507. doi: 10.1200/JCO.2020.38.15_suppl.9507.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2020.38.15_suppl.9507</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chic N, Mayo-de-Las-Casas C, Reguart N. Successful treatment with gefitinib in advanced non-small cell lung cancer after acquired resistance to osimertinib. J Thorac Oncol. 2017;12:e78&#8211;e80. doi: 10.1016/j.jtho.2017.02.014.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2017.02.014</ArticleId>
+            <ArticleId IdType="pubmed">28532569</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rangachari D, To C, Shpilsky JE, VanderLaan PA, Kobayashi SS, Mushajiang M, Lau CJ, Paweletz CP, Oxnard GR, J&#228;nne PA, Costa DB. EGFR-mutated lung cancers resistant to osimertinib through EGFR C797S respond to first-generation reversible EGFR inhibitors but eventually acquire EGFR T790M/C797S in preclinical models and clinical samples. J Thorac Oncol. 2019;14:1995&#8211;2002. doi: 10.1016/j.jtho.2019.07.016.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2019.07.016</ArticleId>
+            <ArticleId IdType="pmc">PMC6823139</ArticleId>
+            <ArticleId IdType="pubmed">31377341</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang X, Huang C, Chen R, Zhao J. Resolving resistance to osimertinib therapy with afatinib in an NSCLC patient with EGFR L718Q mutation. Clin Lung Cancer. 2020;21:e258&#8211;e260. doi: 10.1016/j.cllc.2019.12.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.cllc.2019.12.002</ArticleId>
+            <ArticleId IdType="pubmed">32146032</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Romaniello D, Mazzeo L, Mancini M, Marrocco I, Noronha A, Kreitman M, Srivastava S, Ghosh S, Lindzen M, Salame TM, et al. A combination of approved antibodies overcomes resistance of lung cancer to osimertinib by blocking bypass pathways. Clin Cancer Res. 2018;24:5610&#8211;5621. doi: 10.1158/1078-0432.CCR-18-0450.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-18-0450</ArticleId>
+            <ArticleId IdType="pubmed">29967248</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yu HA, Baik CS, Gold K, Hayashi H, Johnson M, Koczywas M, Murakami H, Nishio M, Steuer C, Su WC, et al. LBA62 Efficacy and safety of patritumab deruxtecan (U3-1402), a novel HER3 directed antibody drug conjugate, in patients (pts) with EGFR-mutated (EGFRm) NSCLC. Ann Oncol. 2020;31:S1189&#8211;S1190. doi: 10.1016/j.annonc.2020.08.2295.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annonc.2020.08.2295</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cho BC, Lee KH, Cho EK, Kim DW, Lee JS, Han JY, Kim SW, Spira A, Haura EB, Sabari JK, et al. 1258O Amivantamab (JNJ-61186372), an EGFR-MET bispecific antibody, in combination with lazertinib, a 3rd-generation tyrosine kinase inhibitor (TKI), in advanced EGFR NSCLC. Ann Oncol. 2020;31(Suppl 4):S813. doi: 10.1016/j.annonc.2020.08.1572.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annonc.2020.08.1572</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Okura N, Nishioka N, Yamada T, Taniguchi H, Tanimura K, Katayama Y, Yoshimura A, Watanabe S, Kikuchi T, Shiotsu S, et al. ONO-7475, a Novel AXL inhibitor, suppresses the adaptive resistance to initial EGFR-TKI treatment in -mutated non-small cell lung cancer. Clin Cancer Res. 2020;26:2244&#8211;2256. doi: 10.1158/1078-0432.CCR-19-2321.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-19-2321</ArticleId>
+            <ArticleId IdType="pubmed">31953310</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim D, Bach DH, Fan YH, Luu TT, Hong JY, Park HJ, Lee SK. AXL degradation in combination with EGFR-TKI can delay and overcome acquired resistance in human non-small cell lung cancer cells. Cell Death Dis. 2019;10:361. doi: 10.1038/s41419-019-1601-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41419-019-1601-6</ArticleId>
+            <ArticleId IdType="pmc">PMC6494839</ArticleId>
+            <ArticleId IdType="pubmed">31043587</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang YM, Jang Y, Lee SH, Kang B, Lim SM. AXL/MET dual inhibitor, CB469, has activity in non-small cell lung cancer with acquired resistance to EGFR TKI with AXL or MET activation. Lung Cancer. 2020;46:70&#8211;77. doi: 10.1016/j.lungcan.2020.05.031.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2020.05.031</ArticleId>
+            <ArticleId IdType="pubmed">32521387</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shi P, Oh YT, Deng L, Zhang G, Qian G, Zhang S, Ren H, Wu G, Legendre B, Jr, Anderson E, et al. Overcoming acquired resistance to AZD9291, A third-generation EGFR inhibitor, through modulation of MEK/ERK-dependent Bim and Mcl-1 Degradation. Clin Cancer Res. 2017;23:6567&#8211;6579. doi: 10.1158/1078-0432.CCR-17-1574.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/1078-0432.CCR-17-1574</ArticleId>
+            <ArticleId IdType="pmc">PMC5668147</ArticleId>
+            <ArticleId IdType="pubmed">28765329</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gu J, Yao W, Shi P, Zhang G, Owonikoko TK, Ramalingam SS, Sun SY. MEK or ERK inhibition effectively abrogates emergence of acquired osimertinib resistance in the treatment of epidermal growth factor receptor-mutant lung cancers. Cancer. 2020;126:3788&#8211;3799. doi: 10.1002/cncr.32996.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/cncr.32996</ArticleId>
+            <ArticleId IdType="pmc">PMC7381372</ArticleId>
+            <ArticleId IdType="pubmed">32497272</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Xie Z, Gu Y, Xie X, Lin X, Ouyang M, Qin Y, Zhang J, Lizaso A, Chen S, Zhou C. Lung adenocarcinoma harboring concomitant EGFR mutations and BRAF V600E responds to a combination of osimertinib and vemurafenib to overcome osimertinib resistance. Clin Lung Cancer. 2021;22:e390&#8211;e394. doi: 10.1016/j.cllc.2020.06.008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.cllc.2020.06.008</ArticleId>
+            <ArticleId IdType="pubmed">32693944</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Raoof S, Mulford IJ, Frisco-Cabanos H, Nangia V, Timonina D, Labrot E, Hafeez N, Bilton SJ, Drier Y, Ji F, et al. Targeting FGFR overcomes EMT-mediated resistance in EGFR mutant non-small cell lung cancer. Oncogene. 2019;38:6399&#8211;6413. doi: 10.1038/s41388-019-0887-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41388-019-0887-2</ArticleId>
+            <ArticleId IdType="pmc">PMC6742540</ArticleId>
+            <ArticleId IdType="pubmed">31324888</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yochum ZA, Cades J, Wang H, Chatterjee S, Simons BW, O'Brien JP, Khetarpal SK, Lemtiri-Chlieh G, Myers KV, Huang EH, et al. Targeting the EMT transcription factor TWIST1 overcomes resistance to EGFR inhibitors in EGFR-mutant non-small-cell lung cancer. Oncogene. 2019;38:656&#8211;670. doi: 10.1038/s41388-018-0482-y.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41388-018-0482-y</ArticleId>
+            <ArticleId IdType="pmc">PMC6358506</ArticleId>
+            <ArticleId IdType="pubmed">30171258</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang JC, Schuler M, Popat S, Miura S, Heeke S, Park K, M&#228;rten A, Kim ES. Afatinib for the treatment of NSCLC harboring uncommon EGFR mutations: A database of 693 cases. J Thorac Oncol. 2020;15:803&#8211;815. doi: 10.1016/j.jtho.2019.12.126.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2019.12.126</ArticleId>
+            <ArticleId IdType="pubmed">31931137</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Fang W, Huang Y, Gan J, Shao YW, Zhang L. Durable response of low-dose afatinib plus cetuximab in an adenocarcinoma patient with a novel EGFR exon 20 insertion mutation. J Thorac Oncol. 2019;14:e220&#8211;e221. doi: 10.1016/j.jtho.2019.05.023.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2019.05.023</ArticleId>
+            <ArticleId IdType="pubmed">31558231</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hasegawa H, Yasuda H, Hamamoto J, Masuzawa K, Tani T, Nukaga S, Hirano T, Kobayashi K, Manabe T, Terai H, et al. Efficacy of afatinib or osimertinib plus cetuximab combination therapy for non-small-cell lung cancer with EGFR exon 20 insertion mutations. Lung Cancer. 2019;127:146&#8211;152. doi: 10.1016/j.lungcan.2018.11.039.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.lungcan.2018.11.039</ArticleId>
+            <ArticleId IdType="pubmed">30642543</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>van Veggel B, de Langen AJ, Hashemi SMS, Monkhorst K, Heideman DAM, Thunnissen E, Smit EF. Afatinib and cetuximab in four patients with EGFR exon 20 insertion-positive advanced NSCLC. J Thorac Oncol. 2018;13:1222&#8211;1226. doi: 10.1016/j.jtho.2018.04.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2018.04.012</ArticleId>
+            <ArticleId IdType="pubmed">29702285</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yun J, Lee SH, Kim SY, Jeong SY, Kim JH, Pyo KH, Park CW, Heo SG, Yun MR, Lim S, et al. Antitumor activity of amivantamab (JNJ-61186372), an EGFR-MET bispecific antibody, in diverse models of exon 20 insertion-driven NSCLC. Cancer Discov. 2020;10:1194&#8211;1209.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">32414908</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Riely GJ, Neal JW, Camidge DR, Spira A, Piotrowska Z, Horn L, Costa DB, Tsao A, Patel J, Gadgeel S, et al. 1261MO Updated results from a phase I/II study of mobocertinib (TAK-788) in NSCLC with EGFR exon 20 insertions (exon20ins) Ann Oncol. 2020;31:S815&#8211;S816. doi: 10.1016/j.annonc.2020.08.1575.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annonc.2020.08.1575</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nakahara Y, Kato T, Isomura R, Seki N, Furuya N, Naoki K, Yamanaka T, Okamoto H. A multicenter, open label, randomized phase II study of osimertinib plus ramucirumab versus osimertinib alone as initial chemotherapy for EGFR mutation-positive non-squamous non-small cell lung cancer: TORG1833. J Clin Oncol. 2019;37:TPS9120. doi: 10.1200/JCO.2019.37.15_suppl.TPS9120.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2019.37.15_suppl.TPS9120</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yu HA, Schoenfeld AJ, Makhnin A, Kim R, Rizvi H, Tsui D, Falcon C, Houck-Loomis B, Meng F, Yang JL, et al. Effect of osimertinib and bevacizumab on progression-free survival for patients with metastatic EGFR-mutant lung cancers: A Phase 1/2 single-group open-label trial. JAMA Oncol. 2020;6:1048&#8211;1054. doi: 10.1001/jamaoncol.2020.1260.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamaoncol.2020.1260</ArticleId>
+            <ArticleId IdType="pmc">PMC7256866</ArticleId>
+            <ArticleId IdType="pubmed">32463456</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kobayashi N, Hashimoto H, Kamimaki C, Nagasawa R, Tanaka K, Kubo S, Katakura S, Chen H, Hirama N, Ushio R, et al. Afatinib + bevacizumab combination therapy in EGFR-mutant NSCLC patients with osimertinib resistance: Protocol of an open-label, phase II, multicenter, single-arm trial. Thorac Cancer. 2020;11:2125&#8211;2129. doi: 10.1111/1759-7714.13503.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/1759-7714.13503</ArticleId>
+            <ArticleId IdType="pmc">PMC7396380</ArticleId>
+            <ArticleId IdType="pubmed">32495514</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lisberg A, Cummings A, Goldman JW, Bornazyan K, Reese N, Wang T, Coluzzi P, Ledezma B, Mendenhall M, Hunt J, et al. A phase II study of pembrolizumab in EGFR-Mutant, PD-L1+, tyrosine kinase inhibitor na&#239;ve patients with advanced NSCLC. J Thorac Oncol. 2018;13:1138&#8211;1145. doi: 10.1016/j.jtho.2018.03.035.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jtho.2018.03.035</ArticleId>
+            <ArticleId IdType="pmc">PMC6063769</ArticleId>
+            <ArticleId IdType="pubmed">29874546</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ahn MJ, Yang J, Yu H, Saka H, Ramalingam S, Goto K, Kim SW, Yang L, Walding A, Oxnard GR. 136O: Osimertinib combined with durvalumab in EGFR-mutant non-small cell lung cancer: Results from the TATTON phase Ib trial. J Thorac Oncol. 2016;11:S115. doi: 10.1016/S1556-0864(16)30246-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1556-0864(16)30246-5</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhou J, Zhou F, Xie H, Wu Y, Zhao J, Su C. An advanced non-small cell lung cancer patient with epidermal growth factor receptor sensitizing mutation responded to toripalimab in combination with chemotherapy after resistance to osimertinib: A case report. Transl Lung Cancer Res. 2020;9:354&#8211;359. doi: 10.21037/tlcr.2020.02.09.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.21037/tlcr.2020.02.09</ArticleId>
+            <ArticleId IdType="pmc">PMC7225156</ArticleId>
+            <ArticleId IdType="pubmed">32420075</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang YC, Zhou Q, Wu YL. Clinical management of third-generation EGFR inhibitor-resistant patients with advanced non-small cell lung cancer: Current status and future perspectives. Cancer Lett. 2019;459:240&#8211;247. doi: 10.1016/j.canlet.2019.05.044.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.canlet.2019.05.044</ArticleId>
+            <ArticleId IdType="pubmed">31201840</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wu YL, Planchard D, Lu S, Sun H, Yamamoto N, Kim DW, Tan DSW, Yang JC, Azrif M, Mitsudomi T, et al. Pan-Asian adapted clinical practice guidelines for the management of patients with metastatic non-small-cell lung cancer: A CSCO-ESMO initiative endorsed by JSMO, KSMO, MOS, SSO and TOS. Ann Oncol. 2019;30:171&#8211;210. doi: 10.1093/annonc/mdy554.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/annonc/mdy554</ArticleId>
+            <ArticleId IdType="pubmed">30596843</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Non-Small Cell Lung Cancer Version 4. NCCN Clinical Practice Guidelines in Oncology. 2021.   https://www.nccn.org. Accessed at 25 Jun 2021.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Jang J, To C, De Clercq DJH, Park E, Ponthier CM, Shin BH, Mushajiang M, Nowak RP, Fischer ES, Eck MJ, et al. Mutant-selective allosteric EGFR degraders are effective against a broad range of drug-resistant mutations. Angew Chem Int Ed Engl. 2020;59:14481&#8211;14489. doi: 10.1002/anie.202003500.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/anie.202003500</ArticleId>
+            <ArticleId IdType="pmc">PMC7686272</ArticleId>
+            <ArticleId IdType="pubmed">32510788</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>To C, Jang J, Chen T, Park E, Mushajiang M, De Clercq DJH, Xu M, Wang S, Cameron MD, Heppner DE, et al. Single and dual targeting of mutant EGFR with an allosteric inhibitor. Cancer Discov. 2019;9:926&#8211;943. doi: 10.1158/2159-8290.CD-18-0903.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1158/2159-8290.CD-18-0903</ArticleId>
+            <ArticleId IdType="pmc">PMC6664433</ArticleId>
+            <ArticleId IdType="pubmed">31092401</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/3456789.xml
+++ b/tests/fixtures/pmid_xml/3456789.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">3456789</PMID>
+      <DateCompleted>
+        <Year>1986</Year>
+        <Month>05</Month>
+        <Day>02</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>07</Month>
+        <Day>04</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0007-1048</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>62</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>1986</Year>
+              <Month>Mar</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>British journal of haematology</Title>
+          <ISOAbbreviation>Br J Haematol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Changes in the granulocyte membrane following chemotherapy for chronic myelogenous leukaemia.</ArticleTitle>
+        <Pagination>
+          <StartPage>431</StartPage>
+          <EndPage>438</EndPage>
+          <MedlinePgn>431-8</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Granulocytes from patients with chronic myelogenous leukaemia (CML) have been previously shown to have aberrant sialylation of membrane glycoproteins. We have examined the granulocytes from CML patients receiving intermittent chemotherapy to determine the relationship of the oligosaccharide changes to treatment. Compared to cells from non-leukaemic patients, granulocytes from untreated CML patients showed less adherence to nylon wool, decreased reactivity with peanut lectin, and decreased binding of the synthetic chemotactic peptide formyl-methionine-leucine-phenylalanine (FMLP). Granulocytes from CML patients treated with chemotherapy showed nylon wool adherence, peanut lectin reactivity and FMLP binding comparable to non-leukaemic cells. Chemotherapeutic agents may interfere with oligosaccharide synthesis with a resulting change in the composition of cell surface glycoconjugates.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Baker</LastName>
+            <ForeName>M A</ForeName>
+            <Initials>MA</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kanani</LastName>
+            <ForeName>A</ForeName>
+            <Initials>A</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Hindenburg</LastName>
+            <ForeName>A</ForeName>
+            <Initials>A</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Taub</LastName>
+            <ForeName>R N</ForeName>
+            <Initials>RN</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>CA 31761-03</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>CA 31762-03</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+          <PublicationType UI="D013487">Research Support, U.S. Gov't, P.H.S.</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Br J Haematol</MedlineTA>
+        <NlmUniqueID>0372544</NlmUniqueID>
+        <ISSNLinking>0007-1048</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D037102">Lectins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D019887">Peanut Agglutinin</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>59880-97-6</RegistryNumber>
+          <NameOfSubstance UI="D009240">N-Formylmethionine Leucyl-Phenylalanine</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000372" MajorTopicYN="N">Agglutination Tests</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002448" MajorTopicYN="N">Cell Adhesion</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002449" MajorTopicYN="N">Cell Aggregation</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002462" MajorTopicYN="N">Cell Membrane</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006098" MajorTopicYN="N">Granulocytes</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="Y">drug effects</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D037102" MajorTopicYN="N">Lectins</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007951" MajorTopicYN="N">Leukemia, Myeloid</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+          <QualifierName UI="Q000188" MajorTopicYN="Y">drug therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009240" MajorTopicYN="N">N-Formylmethionine Leucyl-Phenylalanine</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019887" MajorTopicYN="N">Peanut Agglutinin</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1986</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1986</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1986</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">3456789</ArticleId>
+        <ArticleId IdType="doi">10.1111/j.1365-2141.1986.tb02954.x</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/34690539.xml
+++ b/tests/fixtures/pmid_xml/34690539.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+      <PMID Version="1">34690539</PMID>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>05</Month>
+        <Day>30</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">2591-1783</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>31</Volume>
+            <Issue>1</Issue>
+            <PubDate>
+              <Year>2021</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Annales. Series historia naturalis : anali za istrske in mediteranske studije = annali di studi istriani e mediterranei = annals of Istrian and Mediterranean studies</Title>
+          <ISOAbbreviation>Ann Ser Hist Nat</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Using Citizen Science to Detect Rare and Endangered Species: New Records of the Great White Shark <i>Carcharodon Carcharias</i> off the Libyan Coast.</ArticleTitle>
+        <Pagination>
+          <StartPage>51</StartPage>
+          <EndPage>57</EndPage>
+          <MedlinePgn>51-57</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.19233/ASHN.2021.08</ELocationID>
+        <Abstract>
+          <AbstractText>The presence of the great white shark (Carcharodon carcharias) in the Mediterranean Sea is well documented, but encounters with this species are rare and all assumptions about its spatial and temporal distribution are heavily relying on anecdotal observations. To date, only one record off the Libyan coast has been reported, raising the question if this species is underreported in these waters or simply represents a rare occasional transient. We utilised citizen science-sourced data to document the presence of the great white shark off the Libyan coast, and found six additional records for this species from the period between 2017 and 2020. Our study points out the need for scientific monitoring of this species along the Libyan coast to facilitate the establishment of effective conservation plans to protect this critically endangered species.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Jambura</LastName>
+            <ForeName>Patrick L</ForeName>
+            <Initials>PL</Initials>
+            <AffiliationInfo>
+              <Affiliation>University of Vienna, Department of Palaeontology, Vienna 1090, Austria.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>T&#252;rtscher</LastName>
+            <ForeName>Julia</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>University of Vienna, Department of Palaeontology, Vienna 1090, Austria.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>De Maddalena</LastName>
+            <ForeName>Alessandro</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Shark Museum, Cape Town 7995, South Africa.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Giovos</LastName>
+            <ForeName>Ioannis</ForeName>
+            <Initials>I</Initials>
+            <AffiliationInfo>
+              <Affiliation>iSea, Environmental Organization for the Preservation of the Aquatic Ecosystems, Thessaloniki 54645, Greece.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kriwet</LastName>
+            <ForeName>J&#252;rgen</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>University of Vienna, Department of Palaeontology, Vienna 1090, Austria.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rizgalla</LastName>
+            <ForeName>Jamila</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>University of Tripoli, Faculty of Agriculture, Department of Aquaculture, Tripoli, Libya.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Al Mabruk</LastName>
+            <ForeName>Sara A A</ForeName>
+            <Initials>SAA</Initials>
+            <AffiliationInfo>
+              <Affiliation>Higher institute of Science and Technology, Department of General Nursing Technology, Cyrene, Libya Marine Biology in Libya Society, El Bayda, Libya.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>P 33820</GrantID>
+            <Acronym>FWF_</Acronym>
+            <Agency>Austrian Science Fund FWF</Agency>
+            <Country>Austria</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Slovenia</Country>
+        <MedlineTA>Ann Ser Hist Nat</MedlineTA>
+        <NlmUniqueID>9918266186406676</NlmUniqueID>
+        <ISSNLinking>1408-533X</ISSNLinking>
+      </MedlineJournalInfo>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">Elasmobranchii</Keyword>
+        <Keyword MajorTopicYN="N">cartilaginous fish</Keyword>
+        <Keyword MajorTopicYN="N">conservation biology</Keyword>
+        <Keyword MajorTopicYN="N">fisheries</Keyword>
+        <Keyword MajorTopicYN="N">social media</Keyword>
+        <Keyword MajorTopicYN="N">threatened species</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2021</Year>
+          <Month>10</Month>
+          <Day>25</Day>
+          <Hour>6</Hour>
+          <Minute>21</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2021</Year>
+          <Month>10</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2021</Year>
+          <Month>10</Month>
+          <Day>26</Day>
+          <Hour>6</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2021</Year>
+          <Month>10</Month>
+          <Day>21</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">34690539</ArticleId>
+        <ArticleId IdType="mid">EMS135982</ArticleId>
+        <ArticleId IdType="pmc">PMC7611865</ArticleId>
+        <ArticleId IdType="doi">10.19233/ASHN.2021.08</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Boldrocchi G, Kiszka J, Purkis S, Storai T, Zinzula L, Burkholder D. Distribution, ecology, and status of the white shark, Carcharodon carcharias in the Mediterranean Sea. Rev Fish Biol Fish. 2017;27(3):515&#8211;534.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Brada&#239; MN, Sa&#239;di B. On the occurrence of the great white shark (Carcharodon carcharias) in Tunisian coasts. Rapp Comm Int Mer M&#233;dit. 2013;40:489.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Ben Amor MM, Bdioui M, Ounifi-Ben Amor K, Capap&#233; C. Captures of large shark species from the northeastern Tunisian coast (Central Mediterranean) Ann Ser Hist Nat. 2020;30(1):15&#8211;24.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Cashion MS, Bailly N, Pauly D. Official catch data underrepresent shark and ray taxa caught in Mediterranean and Black Sea fisheries. Mar Policy. 2019;105:1&#8211;9.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Castro JI. In: Global Perspectives on the Biology and Life History of the White Shark. Domeier ML, editor. CRC Press; Boca Raton: 2012. A summary of observations on the maximum size attained by the white shark Carcharodon carcharias; pp. 85&#8211;90.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Compagno LJV. Sharks of the world: an annotated and illustrated catalogue of shark species known to date, vol 2 Bullhead, mackerel and carpet sharks (Heterodontiformes, Lamniformes and Orectolobiformes) FAO Species Catalogue for Fishery Purposes; Rome: 2001. p. 269.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Damalas D, Megalofonou P. Occurrences of large sharks in the open waters of the southeastern Mediterranean Sea. J Nat Hist. 2012;46(43-44):2701&#8211;2723.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>De Maddalena A. Historical and contemporary presence of the great white shark, Carcharodon carcharias (Linnaeus, 1758), in the Northern and Central Adriatic Sea. Ann Ser Hist Nat. 2000;10(1):3&#8211;18.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>De Maddalena A, Heim W. Mediterranean Great White Sharks: a Comprehensive Study Including All Recorded Sightings. McFarland, Jefferson; 2012. p. 256.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>De Maddalena A, Zuffa M. Historical and contemporary presence of the great white shark, Carcharodon carcharias (Linnaeus, 1758), along the Mediterranean coast of France. Boll Mus Civico Storia Nat Venezia. 2008;59:81&#8211;94.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Ebert DA, Fowler SL, Compagno LJV. Sharks of the World: a Fully Illustrated Guide. Wild Nature Press; Plymouth: 2013. p. 528.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Fergusson IK. In: Great White Sharks: the Biology of Carcharodon carcharias. Klimley AP, Ainley DG, editors. Academic Press; London: 1996. Distribution and autecology of the white shark in the eastern North Atlantic Ocean and the Mediterranean Sea; pp. 321&#8211;345.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Galaz T, De Maddalena A. On a Great White Shark, Carcharodon carcharias (Linnaeus, 1758), trapped in a tuna cage off Libya, Mediterranean Sea. Ann Ser Hist Nat. 2004;14(2):159&#8211;164.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Gardiner MM, Allee LL, Brown PM, Losey JE, Roy HE, Smyth RR. Lessons from lady beetles: accuracy of monitoring data from US and UK citizen-science programs. Front Ecol Environ. 2012;10(9):471&#8211;476.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Giovos I, Stoilas VO, Al-Mabruk SAA, Doumpas N, Marakis P, Maximiadi M, Moutopoulos D, Kleitou P, Keramidas I, Tiralongo F, De Maddalena A. Integrating local ecological knowledge, citizen science and long-term historical data for endangered species conservation: Additional records of angel sharks (Chondrichthyes: Squatinidae) in the Mediterranean Sea. Aquat Conserv. 2019;29(6):881&#8211;890.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Gubili C, Bilgin R, Kalkan E, Karhan S&#220;, Jones CS, Sims DW, Kabasakal H, Martin AP, Noble LR. Antipodean white sharks on a Mediterranean walkabout? Historical dispersal leads to genetic discontinuity and an endangered anomalous population. Proc Royal Soc B. 2011;278(1712):1679&#8211;1686.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3081765</ArticleId>
+            <ArticleId IdType="pubmed">21084352</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gubili C, Robinson CE, Cliff G, Wintner SP, de Sabata E, De Innocentiis S, Canese S, Sims DW, Martin AP, Noble LR, Jones CS. DNA from historical and trophy samples provides insights into white shark population origins and genetic diversity. Endangered Species Res. 2015;27(3):233&#8211;241.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Jambura PL, &#262;etkovi&#263; I, Kriwet J, T&#252;rtscher J. Using historical and citizen science data to improve knowledge about the occurrence of the elusive sandbar shark Carcharhinus plumbeus (Chondrichthyes &#8211; Carcharhinidae) in the Adriatic Sea. Mediterr Mar Sci. 2021;22(1):169&#8211;179.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7611800</ArticleId>
+            <ArticleId IdType="pubmed">34642564</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jeffries E. Sharks in crisis: a call to action for the Mediterranean. World Wide Fund For Nature (WWF); 2019.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Leone A, Puncher GN, Ferretti F, Sperone E, Tripepi S, Micarelli P, Gambarelli A, Sar&#224; M, Arculeo M, Doria G, Garibaldi F. Pliocene colonization of the Mediterranean by Great White Shark inferred from fossil records, historical jaws, phylogeographic and divergence time analyses. J Biogeogr. 2020;47(5):1119&#8211;1129.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. Historical and contemporary records of sharks from the Sea of Marmara, Turkey. Ann Ser Hist Nat. 2003;13(1):1&#8211;12.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. The status of the great white shark Carcharodon carcharias in Turkey&#8217;s waters. Mar Biodivers Rec. 2014;7(e109):1&#8211;8.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. Historical dispersal of the great white shark, Carcharodon carcharias and bluefin tuna, Thunnus thynnus in Turkish waters: decline of a predator in response to the loss of its prey. Ann Ser Hist Nat. 2016;26(2):213&#8211;218.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. A review of shark research in Turkish waters. Ann Ser Hist Nat. 2019;29(1):1&#8211;16.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. Exploring a possible nursery ground of white shark Carcharodon carcharias in Edremit Bay (northeastern Aegean Sea, Turkey) J Black Sea/Medit Environ. 2020a;26(2):176&#8211;189.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H. Agreement with the Monster - Lessons we learned from the Great White Shark in Turkish waters. TUDAV Turkish Marine Research Foundation; Istanbul: 2020b. p. 74.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kabasakal H, Bileceno&#287;lu MB. Shark infested internet: an analysis of internet-based media reports on rare and large sharks of Turkey. FishTaxa. 2020;16:8&#8211;18.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Morey G, Mart&#237;nez M, Massut&#237; E, Moranta J. The occurrence of white sharks, Carcharodon carcharias around the Balearic Islands (western Mediterranean Sea) Environ Biol Fishes. 2003;68(4):425&#8211;432.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Monkman GG, Kaiser M, Hyder K. The ethics of using social media in fisheries research. Rev Fish Sci Aquac. 2018;26(2):235&#8211;242.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Moro S, Jona-Lasinio G, Block B, Micheli F, De Leo G, Serena F, Bottaro M, Scacco U, Ferretti F. Abundance and distribution of the white shark in the Mediterranean Sea. Fish Fish. 2020;21(2):338&#8211;349.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Papaconstantinou C. Fauna Graeciae. An updated checklist of the fishes in the Hellenic Seas, Monographs on Marine Sciences. Vol. 7 HCMR; 2014.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Randall JE. Size of the great white shark Carcharodon . Science. 1973;181(4095):169&#8211;170.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">17746627</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rigby CL, Barreto R, Carlson J, Fernando D, Fordham S, Francis MP, Herman K, Jabado RW, Liu KM, Lowe CG, Marshall A, et al. The IUCN Red List of Threatened Species 2019; 2019. [Accessed 18 March 2021]. Carcharodon carcharias. e.T3855A2878674.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2305/IUCN.UK.2019-3.RLTS.T3855A2878674.en</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sa&#239;di B, Brada&#239; MN, Bouain A, Guelorget O, Capap&#233; C. Capture of a pregnant female white shark, Carcharodon carcharias (Lamnidae) in the Gulf of Gabes (southern Tunisia, central Mediterranean) with comments on oophagy in sharks. Cybium. 2005;29(3):303&#8211;307.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Soldo A, Jardas I. Occurrence of great white shark, Carcharodon carcharias (Linnaeus, 1758) and basking shark, Cetorhinus maximus (Gunnerus, 1758) in the Eastern Adriatic and their protection. Period Biol. 2002;104(2):195&#8211;201.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Soldo A, Bradai MN, Walls RHL.  Carcharodon carcharias. The IUCN Red List of Threatened Species 2016; 2016.  [Accessed 18 March 2021].  e.T3855A16527829.  https://www.iucnredlist.org/species/3855/16527829.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Span&#242; N, De Domenico E. In: Mediterranean Identities: Environment, Society, Culture. Fuerst-Bjelis B, editor. IntechOpen Limited; London: 2017. Biodiversity in Central Mediterranean Sea; pp. 129&#8211;148.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Storai T, Mojetta A, Zuffa M, Giuliani S. Nuove segnalazioni di Carcharodon carcharias (L.) nel Mediterraneo centrale. Atti Soc Tosc Sci Nat Pisa, Mem. 2000;107:139&#8211;142.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Tiralongo F, Monaco C, De Maddalena A. Report on a great white shark Carcharodon carcharias observed off Lampedusa, Italy. Ann Ser Hist Nat. 2020;30(2):181&#8211;186.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Weng KC, O&#8217;Sullivan JB, Lowe CG, Winkler CE, Dewar H, Block BA. Movements, behavior and habitat preferences of juvenile white sharks Carcharodon carcharias in the eastern Pacific. Mar Ecol Prog Ser. 2007;338:211&#8211;224.</Citation>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/34889398.xml
+++ b/tests/fixtures/pmid_xml/34889398.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">34889398</PMID>
+      <DateCompleted>
+        <Year>2022</Year>
+        <Month>02</Month>
+        <Day>21</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>02</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1520-4383</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>2021</Volume>
+            <Issue>1</Issue>
+            <PubDate>
+              <Year>2021</Year>
+              <Month>Dec</Month>
+              <Day>10</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Hematology. American Society of Hematology. Education Program</Title>
+          <ISOAbbreviation>Hematology Am Soc Hematol Educ Program</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Hereditary hemorrhagic telangiectasia (HHT): a practical guide to management.</ArticleTitle>
+        <Pagination>
+          <StartPage>469</StartPage>
+          <EndPage>477</EndPage>
+          <MedlinePgn>469-477</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1182/hematology.2021000281</ELocationID>
+        <Abstract>
+          <AbstractText>Hereditary hemorrhagic telangiectasia (HHT), the second most common inherited bleeding disorder, is associated with the development of malformed blood vessels. Abnormal blood vessels may be small and cutaneous or mucosal (telangiectasia), with frequent complications of bleeding, or large and visceral (arteriovenous malformations [AVMs]), with additional risks that can lead to significant morbidity and even mortality. HHT can present in many different ways and can be difficult to recognize, particularly in younger patients in the absence of a known family history of disease or epistaxis, its most common manifestation. HHT is commonly diagnosed using the established Cura&#231;ao clinical criteria, which include (1) family history, (2) recurrent epistaxis, (3) telangiectasia, and (4) visceral AVMs. Fulfillment of 3 or more criteria provides a definite diagnosis of HHT, whereas 2 criteria constitute a possible diagnosis of HHT. However, these criteria are insufficient in children to rule out disease due to the age-dependent development of some of these criteria. Genetic testing, when positive, can provide definitive diagnosis of HHT in all age groups. Clinical course is often complicated by significant epistaxis and/or gastrointestinal bleeding, leading to anemia in half of adult patients with HHT. The management paradigm has recently shifted from surgical approaches to medical treatments aimed at control of chronic bleeding, such as antifibrinolytic and antiangiogenic agents, combined with aggressive iron replacement with intravenous iron. Guidelines for management of HHT, including screening and treatment, were determined by expert consensus and originally published in 2009 with updates and new guidelines in 2020.</AbstractText>
+          <CopyrightInformation>Copyright &#169; 2021 by The American Society of Hematology.</CopyrightInformation>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Hammill</LastName>
+            <ForeName>Adrienne M</ForeName>
+            <Initials>AM</Initials>
+            <AffiliationInfo>
+              <Affiliation>Cancer and Blood Diseases Institute, Division of Hematology, Cincinnati Children's Hospital Medical Center, and Department of Pediatrics, University of Cincinnati College of Medicine, Cincinnati, OH.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wusik</LastName>
+            <ForeName>Katie</ForeName>
+            <Initials>K</Initials>
+            <AffiliationInfo>
+              <Affiliation>Division of Human Genetics, Cincinnati Children's Hospital Medical Center, Cincinnati, OH.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kasthuri</LastName>
+            <ForeName>Raj S</ForeName>
+            <Initials>RS</Initials>
+            <AffiliationInfo>
+              <Affiliation>Division of Hematology, Department of Medicine, University of North Carolina School of Medicine, Chapel Hill, NC.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D002363">Case Reports</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Hematology Am Soc Hematol Educ Program</MedlineTA>
+        <NlmUniqueID>100890099</NlmUniqueID>
+        <ISSNLinking>1520-4383</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000740" MajorTopicYN="N">Anemia</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019468" MajorTopicYN="N">Disease Management</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004844" MajorTopicYN="N">Epistaxis</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006471" MajorTopicYN="N">Gastrointestinal Hemorrhage</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011247" MajorTopicYN="N">Pregnancy</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011250" MajorTopicYN="N">Pregnancy Complications, Hematologic</DescriptorName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013683" MajorTopicYN="N">Telangiectasia, Hereditary Hemorrhagic</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="Y">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="Y">therapy</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <CoiStatement>Adrienne M. Hammill: none related to this paper. But AH has clinical trials (for other diseases) with novartis, cerecor, Venthera, Merck; had study drug provided by Pfizer; serves as a consultant for Novartis. Katie Wusik: none reported. Raj S. Kasthuri: none reported.</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2021</Year>
+          <Month>12</Month>
+          <Day>10</Day>
+          <Hour>8</Hour>
+          <Minute>45</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2021</Year>
+          <Month>12</Month>
+          <Day>11</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2022</Year>
+          <Month>2</Month>
+          <Day>22</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2021</Year>
+          <Month>12</Month>
+          <Day>10</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">34889398</ArticleId>
+        <ArticleId IdType="pmc">PMC8791148</ArticleId>
+        <ArticleId IdType="doi">10.1182/hematology.2021000281</ArticleId>
+        <ArticleId IdType="pii">482972</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Faughnan ME, Mager JJ, Hetts SW, et al.. Second International Guidelines for the Diagnosis and Management of Hereditary Hemorrhagic Telangiectasia. Ann Intern Med. 2020;173(12):989-1001. doi: 10.7326/M20-1443.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/M20-1443</ArticleId>
+            <ArticleId IdType="pubmed">32894695</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ginon I, Decullier E, Finet G, et al.. Hereditary hemorrhagic telangiectasia, liver vascular malformations and cardiac consequences. Eur J Intern Med. 2013;24(3):e35-e39. doi: 10.1016/j.ejim.2012.12.013.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ejim.2012.12.013</ArticleId>
+            <ArticleId IdType="pubmed">23312966</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weber LM, McDonald J, Whitehead K. Vitamin D levels are associated with epistaxis severity and bleeding duration in hereditary hemorrhagic telangiectasia. Biomark Med. 2018;12(4):365-371. doi: 10.2217/bmm-2017-0229.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2217/bmm-2017-0229</ArticleId>
+            <ArticleId IdType="pmc">PMC6367804</ArticleId>
+            <ArticleId IdType="pubmed">29537299</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ratjen A, Au J, Carpenter S, John P, Ratjen F. Growth of pulmonary arteriovenous malformations in pediatric patients with hereditary hemorrhagic telangiectasia. J Pediatr. 2019;208:279-281. doi: 10.1016/j.jpeds.2018.12.069.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jpeds.2018.12.069</ArticleId>
+            <ArticleId IdType="pubmed">30853205</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>McDonald J, Stevenson DA, Whitehead K. Incidence of epistaxis and telangiectases in the general population. Angiogenesis. 2017;18:531.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kjeldsen AD, Vase P, Green A. Hereditary haemorrhagic telangiectasia: a population-based study of prevalence and mortality in Danish patients. J Intern Med. 1999;245(1):31-39. doi: 10.1046/j.1365-2796.1999.00398.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1046/j.1365-2796.1999.00398.x</ArticleId>
+            <ArticleId IdType="pubmed">10095814</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>McDonald J, Wooderchak-Donahue WL, Henderson K, Paul E, Morris A, Bayrak-Toydemir P. Tissue-specific mosaicism in hereditary hemorrhagic telangiectasia: implications for genetic testing in families. Am J Med Genet A. 2018;176(7):1618-1621. doi: 10.1002/ajmg.a.38695.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ajmg.a.38695</ArticleId>
+            <ArticleId IdType="pubmed">29736967</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>T&#248;rring PM, Kjeldsen AD, Ousager LB, Brusgaard K. ENG mutational mosaicism in a family with hereditary hemorrhagic telangiectasia. Mol Genet Genomic Med. 2018;6(1):121-125. doi: 10.1002/mgg3.361.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/mgg3.361</ArticleId>
+            <ArticleId IdType="pmc">PMC5823686</ArticleId>
+            <ArticleId IdType="pubmed">29243366</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Best DH, Vaughn C, McDonald J, et al.. Mosaic ACVRL1 and ENG mutations in hereditary haemorrhagic telangiectasia patients. J Med Genet. 2011;48(5):358-360. doi: 10.1136/jmg.2010.088286.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/jmg.2010.088286</ArticleId>
+            <ArticleId IdType="pubmed">21378382</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lee NP, Matevski D, Dumitru D, Piovesan B, Rushlow D, Gallie BL. Identification of clinically relevant mosaicism in type I hereditary haemorrhagic telangiectasia. J Med Genet. 2011;48(5):353-357. doi: 10.1136/jmg.2010.088112.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/jmg.2010.088112</ArticleId>
+            <ArticleId IdType="pubmed">21415079</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gedge F, McDonald J, Phansalkar A, et al.. Clinical and analytical sensitivities in hereditary hemorrhagic telangiectasia testing and a report of de novo mutations. J Mol Diagn. 2007;9(2):258-265. doi: 10.2353/jmoldx.2007.060117.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2353/jmoldx.2007.060117</ArticleId>
+            <ArticleId IdType="pmc">PMC1867450</ArticleId>
+            <ArticleId IdType="pubmed">17384219</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shovlin CL, Guttmacher AE, Buscarini E, et al.. Diagnostic criteria for hereditary hemorrhagic telangiectasia (Rendu-Osler-Weber syndrome). Am J Med Genet. 2000;91(1):66-67. doi: 10.1002/(sici)1096-8628(20000306)91:1&lt;66::aid-ajmg12&gt;3.0.co;2-p.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/(sici)1096-8628(20000306)91:1&lt;66::aid-ajmg12&gt;3.0.co;2-p</ArticleId>
+            <ArticleId IdType="pubmed">10751092</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pierucci P, Lenato GM, Suppressa P, et al.. A long diagnostic delay in patients with hereditary haemorrhagic telangiectasia: a questionnaire-based retrospective study. Orphanet J Rare Dis. 2012;7:33. doi: 10.1186/1750-1172-7-33.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/1750-1172-7-33</ArticleId>
+            <ArticleId IdType="pmc">PMC3458963</ArticleId>
+            <ArticleId IdType="pubmed">22676497</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pahl KS, Choudhury A, Wusik K, et al.. Applicability of the Cura&#231;ao criteria for the diagnosis of hereditary hemorrhagic telangiectasia in the pediatric population. J Pediatr. 2018;197:207-213. doi: 10.1016/j.jpeds.2018.01.079.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jpeds.2018.01.079</ArticleId>
+            <ArticleId IdType="pubmed">29655863</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Faughnan ME, Palda VA, Garcia-Tsao G, et al; HHT Foundation International&#8212; Guidelines Working Group. International guidelines for the diagnosis and management of hereditary haemorrhagic telangiectasia. J Med Genet. 2011;48(2):73-87. doi: 10.1136/jmg.2009.069013.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/jmg.2009.069013</ArticleId>
+            <ArticleId IdType="pubmed">19553198</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>McDonald J, Bayrak-Toydemir P, DeMille D, Wooderchak-Donahue W, Whitehead K. Cura&#231;ao diagnostic criteria for hereditary hemorrhagic telangiectasia is highly predictive of a pathogenic variant in ENG or ACVRL1 (HHT1 and HHT2). Genet Med. 2020;22(7):1201-1205. doi: 10.1038/s41436-020-0775-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41436-020-0775-8</ArticleId>
+            <ArticleId IdType="pubmed">32300199</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gallione CJ, Richards JA, Letteboer TG, et al.. SMAD4 mutations found in unselected HHT patients. J Med Genet. 2006;43(10):793-797. doi: 10.1136/jmg.2006.041517.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/jmg.2006.041517</ArticleId>
+            <ArticleId IdType="pmc">PMC2563178</ArticleId>
+            <ArticleId IdType="pubmed">16613914</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gallione C, Aylsworth AS, Beis J, et al.. Overlapping spectra of SMAD4 mutations in juvenile polyposis (JP) and JP-HHT syndrome. Am J Med Genet A. 2010;152A(2):333-339. doi: 10.1002/ajmg.a.33206.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ajmg.a.33206</ArticleId>
+            <ArticleId IdType="pubmed">20101697</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Heald B, Rigelsky C, Moran R, et al.. Prevalence of thoracic aortopathy in patients with juvenile polyposis syndrome&#8211;hereditary hemorrhagic telangiectasia due to SMAD4. Am J Med Genet A. 2015;167(8):1758-1762. doi: 10.1002/ajmg.a.37093.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ajmg.a.37093</ArticleId>
+            <ArticleId IdType="pubmed">25931195</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hernandez F, Huether R, Carter L, et al.. Mutations in RASA1 and GDF2 identified in patients with clinical features of hereditary hemorrhagic telangiectasia. Hum Genome Var. 2015;2:15040. doi: 10.1038/hgv.2015.40.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/hgv.2015.40</ArticleId>
+            <ArticleId IdType="pmc">PMC4785548</ArticleId>
+            <ArticleId IdType="pubmed">27081547</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wooderchak-Donahue WL, Akay G, Whitehead K, et al.. Phenotype of CM-AVM2 caused by variants in EPHB4: how much overlap with hereditary hemorrhagic telangiectasia (HHT)? Genet Med. 2019;21(9):2007-2014. doi: 10.1038/s41436-019-0443-z.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41436-019-0443-z</ArticleId>
+            <ArticleId IdType="pubmed">30760892</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hoag JB, Terry P, Mitchell S, Reh D, Merlo CA. An epistaxis severity score for hereditary hemorrhagic telangiectasia. Laryngoscope. 2010;120(4):838-843. doi: 10.1002/lary.20818.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/lary.20818</ArticleId>
+            <ArticleId IdType="pubmed">20087969</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gaillard S, Dupuis-Girod S, Boutitie F, et al; ATERO Study Group. Tranexamic acid for epistaxis in hereditary hemorrhagic telangiectasia patients: a European cross-over controlled trial in a rare disease. J Thromb Haemost. 2014;12(9):1494-1502. doi: 10.1111/jth.12654.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/jth.12654</ArticleId>
+            <ArticleId IdType="pubmed">25040799</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Geisthoff UW, Seyfert UT, K&#252;bler M, Bieg B, Plinkert PK, K&#246;nig J. Treatment of epistaxis in hereditary hemorrhagic telangiectasia with tranexamic acid&#8212;a double-blind placebo-controlled cross-over phase IIIB study. Thromb Res. 2014;134(3):565-571. doi: 10.1016/j.thromres.2014.06.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.thromres.2014.06.012</ArticleId>
+            <ArticleId IdType="pubmed">25005464</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Canzonieri C, Centenara L, Ornati F, et al.. Endoscopic evaluation of gastrointestinal tract in patients with hereditary hemorrhagic telangiectasia and correlation with their genotypes. Genet Med. 2014;16(1):3-10. doi: 10.1038/gim.2013.62.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/gim.2013.62</ArticleId>
+            <ArticleId IdType="pubmed">23722869</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kasthuri RS, Montifar M, Nelson J, et al; Brain Vascular Malformation Consortium HHT Investigator Group. Prevalence and predictors of anemia in hereditary hemorrhagic telangiectasia. Am J Hematol. 2017;92(10):e591-e593. doi: 10.1002/ajh.24832.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ajh.24832</ArticleId>
+            <ArticleId IdType="pmc">PMC5997494</ArticleId>
+            <ArticleId IdType="pubmed">28639385</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Serra MM, Besada CH, Cabana Cal A, et al.. Central nervous system manganese induced lesions and clinical consequences in patients with hereditary hemorrhagic telangiectasia. Orphanet J Rare Dis. 2017;12(1):92. doi: 10.1186/s13023-017-0632-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13023-017-0632-2</ArticleId>
+            <ArticleId IdType="pmc">PMC5437640</ArticleId>
+            <ArticleId IdType="pubmed">28521822</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Livesey JA, Manning RA, Meek JH, et al.. Low serum iron levels are associated with elevated plasma levels of coagulation factor VIII and pulmonary emboli/deep venous thromboses in replicate cohorts of patients with hereditary haemorrhagic telangiectasia. Thorax. 2012;67(4):328-333. doi: 10.1136/thoraxjnl-2011-201076.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/thoraxjnl-2011-201076</ArticleId>
+            <ArticleId IdType="pubmed">22169361</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Iyer VN, Apala DR, Pannu BS, et al.. Intravenous bevacizumab for refractory hereditary hemorrhagic telangiectasia-related epistaxis and gastrointestinal bleeding. Mayo Clin Proc. 2018;93(2):155-166. doi: 10.1016/j.mayocp.2017.11.013.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mayocp.2017.11.013</ArticleId>
+            <ArticleId IdType="pubmed">29395350</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Al-Samkari H, Kasthuri RS, Parambil JG, et al.. An international, multicenter study of intravenous bevacizumab for bleeding in hereditary hemorrhagic telangiectasia: the InHIBIT-Bleed study. Haematologica. 2020;106(8):2161-2169. doi: 10.3324/haematol.2020.261859.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3324/haematol.2020.261859</ArticleId>
+            <ArticleId IdType="pmc">PMC8327711</ArticleId>
+            <ArticleId IdType="pubmed">32675221</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>McCrae K, Swaidani S, Samour M, Silver B, Parambil J, Thomas S. Pomalidomide in HHT: results of a pilot study. Angiogenesis. 2019;22(4):624. doi: 10.1007/s10456-019-09686-w.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s10456-019-09686-w</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Faughnan ME, Gossage JR, Chakinala MM, et al.. Pazopanib may reduce bleeding in hereditary hemorrhagic telangiectasia. Angiogenesis. 2019;22(1):145-155. doi: 10.1007/s10456-018-9646-1.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s10456-018-9646-1</ArticleId>
+            <ArticleId IdType="pmc">PMC6510884</ArticleId>
+            <ArticleId IdType="pubmed">30191360</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Meek M, Womble P, Jordan A, Kanaan A, Meek J. Oral doxycycline for the treatment of epistaxis in patients with hereditary hemorrhagic telangiectasia. Angiogenesis. 2015;18(4):530-530.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>de Gussem EM, Edwards CP, Hosman AE, et al.. Life expectancy of parents with hereditary haemorrhagic telangiectasia. Orphanet J Rare Dis. 2016;11:46. doi: 10.1186/s13023-016-0427-x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13023-016-0427-x</ArticleId>
+            <ArticleId IdType="pmc">PMC4841052</ArticleId>
+            <ArticleId IdType="pubmed">27102204</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Iyer VN, Brinjikji W, Pannu BS, et al.. Effect of center volume on outcomes in hospitalized patients with hereditary hemorrhagic telangiectasia. Mayo Clin Proc. 2016;91(12):1753-1760. doi: 10.1016/j.mayocp.2016.07.005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mayocp.2016.07.005</ArticleId>
+            <ArticleId IdType="pubmed">27814895</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dupuis O, Delagrange L, Dupuis-Girod S. Hereditary haemorrhagic telangiectasia and pregnancy: a review of the literature. Orphanet J Rare Dis. 2020;15(1):5. doi: 10.1186/s13023-019-1286-z.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13023-019-1286-z</ArticleId>
+            <ArticleId IdType="pmc">PMC6947864</ArticleId>
+            <ArticleId IdType="pubmed">31910869</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>de Gussem EM, Lausman AY, Beder AJ, et al.. Outcomes of pregnancy in women with hereditary hemorrhagic telangiectasia. Obstet Gynecol. 2014;123(3):514-520. doi: 10.1097/AOG.0000000000000120.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/AOG.0000000000000120</ArticleId>
+            <ArticleId IdType="pubmed">24499751</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shovlin CL, Sodhi V, McCarthy A, Lasjaunias P, Jackson JE, Sheppard MN. Estimates of maternal risks of pregnancy for women with hereditary haemorrhagic telangiectasia (Osler-Weber-Rendu syndrome): suggested approach for obstetric services. BJOG. 2008;115(9):1108-1115. doi: 10.1111/j.1471-0528.2008.01786.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/j.1471-0528.2008.01786.x</ArticleId>
+            <ArticleId IdType="pubmed">18518871</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Al-Samkari H. Hereditary hemorrhagic telangiectasia: systemic therapies, guidelines, and an evolving standard of care. Blood. 2021;137(7):888-895. doi: 10.1182/blood.2020008739.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1182/blood.2020008739</ArticleId>
+            <ArticleId IdType="pubmed">33171488</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/36043633.xml
+++ b/tests/fixtures/pmid_xml/36043633.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">36043633</PMID>
+      <DateCompleted>
+        <Year>2022</Year>
+        <Month>09</Month>
+        <Day>02</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>07</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Electronic-eCollection">
+        <Journal>
+          <ISSN IssnType="Electronic">1678-4464</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>38Suppl 2</Volume>
+            <Issue>Suppl 2</Issue>
+            <PubDate>
+              <Year>2022</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Cadernos de saude publica</Title>
+          <ISOAbbreviation>Cad Saude Publica</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Funding in health.</ArticleTitle>
+        <Pagination>
+          <StartPage>e00119722</StartPage>
+          <MedlinePgn>e00119722</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1590/0102-311XPT119722</ELocationID>
+        <ELocationID EIdType="pii" ValidYN="Y">S0102-311X2022001400101</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Bahia</LastName>
+            <ForeName>Ligia</ForeName>
+            <Initials>L</Initials>
+            <Identifier Source="ORCID">0000-0001-8730-2244</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Instituto de Estudos em Sa&#250;de Coletiva, Universidade Federal do Rio de Janeiro, Rio de Janeiro, Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Scheffer</LastName>
+            <ForeName>M&#225;rio</ForeName>
+            <Initials>M</Initials>
+            <Identifier Source="ORCID">0000-0001-8931-6471</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade de Medicina, Universidade de S&#227;o Paulo, S&#227;o Paulo, Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <Language>por</Language>
+        <Language>spa</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Financeiriza&#231;&#227;o na sa&#250;de.</VernacularTitle>
+        <ArticleDate DateType="Electronic">
+          <Year>2022</Year>
+          <Month>08</Month>
+          <Day>26</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Brazil</Country>
+        <MedlineTA>Cad Saude Publica</MedlineTA>
+        <NlmUniqueID>8901573</NlmUniqueID>
+        <ISSNLinking>0102-311X</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D001938" MajorTopicYN="N" Type="Geographic">Brazil</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005380" MajorTopicYN="Y">Financing, Government</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="received">
+          <Year>2022</Year>
+          <Month>6</Month>
+          <Day>28</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2022</Year>
+          <Month>6</Month>
+          <Day>29</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2022</Year>
+          <Month>8</Month>
+          <Day>31</Day>
+          <Hour>7</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>1</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>3</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>epublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">36043633</ArticleId>
+        <ArticleId IdType="doi">10.1590/0102-311XPT119722</ArticleId>
+        <ArticleId IdType="pii">S0102-311X2022001400101</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/36054861.xml
+++ b/tests/fixtures/pmid_xml/36054861.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">36054861</PMID>
+      <DateCompleted>
+        <Year>2022</Year>
+        <Month>09</Month>
+        <Day>07</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>12</Month>
+        <Day>12</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1669-9106</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>82 Suppl 3</Volume>
+            <PubDate>
+              <Year>2022</Year>
+              <Month>Aug</Month>
+              <Day>30</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Medicina</Title>
+          <ISOAbbreviation>Medicina (B Aires)</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Autism spectrum disorder and attention-deficit/hyperactivity disorder: challenge in diagnosis and treatment].</ArticleTitle>
+        <Pagination>
+          <StartPage>67</StartPage>
+          <EndPage>70</EndPage>
+          <MedlinePgn>67-70</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>The coexistence of autism spectrum disorder (ASD) and attention deficit hyperactivity disorder (ADHD) definitely poses new challenges, such as making an early diagnosis, considering that the former is usually diagnosed 2 years later in children with ADHD comorbid with autism compared to those with ASD alone; this is a problem at a personal, family and social level, since they must receive timely intervention. This coexistence raises questions about the efficacy of treatment in ADHD in people with autism, genetic, anatomical and functional concordances, among others; these are the challenges that are currently posed. In this review, we present some responses to the challenges posed by such coexistence, and we highlight some pending issues to be solved, being these of great importance for their better understanding and management. In all patients with ADHD or ASD, a coexistence between them should be sought. There are shared functional brain alterations in both disorders identified by functional brain magnetic resonance imaging; the treatment established for ADHD is also effective in this comorbidity.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Velarde</LastName>
+            <ForeName>Myriam</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Servicio de Neurolog&#237;a, Instituto M&#233;dico de Lenguaje y Aprendizaje, Lima, Per&#250;. E-mail: mvelardei@unmsm.edu.pe.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Facultad de Medicina, Universidad Nacional Mayor de San Marcos UNMSM, Lima, Per&#250;.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>C&#225;rdenas</LastName>
+            <ForeName>Aland</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Servicio de Neurolog&#237;a, Hospital Aplao, Arequipa, Per&#250;.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Facultad de Medicina, Universidad Nacional Mayor de San Marcos UNMSM, Lima, Per&#250;.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>spa</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Trastornos del espectro autista y trastornos por d&#233;ficit de atenci&#243;n con hiperactividad: desaf&#237;os en el diagn&#243;stico y tratamiento.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Argentina</Country>
+        <MedlineTA>Medicina (B Aires)</MedlineTA>
+        <NlmUniqueID>0204271</NlmUniqueID>
+        <ISSNLinking>0025-7680</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D001289" MajorTopicYN="Y">Attention Deficit Disorder with Hyperactivity</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000067877" MajorTopicYN="Y">Autism Spectrum Disorder</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001321" MajorTopicYN="Y">Autistic Disorder</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001921" MajorTopicYN="N">Brain</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015897" MajorTopicYN="N">Comorbidity</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="spa">
+        <AbstractText>La coexistencia del trastorno del espectro autista (TEA) y trastorno por d&#233;ficit de atenci&#243;n con hiperactividad (TDAH) definitivamente plantea nuevos desaf&#237;os, como la realizaci&#243;n de un diagn&#243;stico temprano teniendo en cuenta que el primero generalmente es diagnosticado 2 a&#241;os despu&#233;s en los ni&#241;os con TDAH com&#243;rbidos; esto es un problema a nivel personal, familiar y social, ya que deben recibir intervenci&#243;n oportuna. Esta coexistencia genera interrogantes sobre la eficacia del tratamiento en TDAH en personas con autismo, concordancias gen&#233;ticas, anat&#243;micas y funcionales entre otros; y son los retos que se plantean en la actualidad. En la presente revisi&#243;n exponemos algunas respuestas a los desaf&#237;os dados por tal coexistencia y resaltamos algunos temas pendientes a resolver, siendo estos de gran importancia para su mejor entendimiento y manejo. En todos los pacientes con TDAH o TEA se debe buscar una coexistencia entre ellos. Existen alteraciones funcionales cerebrales compartidas en ambos trastornos identificadas por resonancia magn&#233;tica funcional cerebral; el tratamiento establecido para el TDAH es tambi&#233;n eficaz en esta comorbilidad.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">attention deficit hyperactivity disorder</Keyword>
+        <Keyword MajorTopicYN="N">autism spectrum disorder</Keyword>
+        <Keyword MajorTopicYN="N">comorbidity</Keyword>
+        <Keyword MajorTopicYN="N">neurodevelopmental disorder</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>2</Day>
+          <Hour>16</Hour>
+          <Minute>2</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>3</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>8</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">36054861</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/36168687.xml
+++ b/tests/fixtures/pmid_xml/36168687.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">36168687</PMID>
+      <DateCompleted>
+        <Year>2022</Year>
+        <Month>09</Month>
+        <Day>29</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>09</Month>
+        <Day>29</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1997-7298</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>122</Volume>
+            <Issue>9</Issue>
+            <PubDate>
+              <Year>2022</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Zhurnal nevrologii i psikhiatrii imeni S.S. Korsakova</Title>
+          <ISOAbbreviation>Zh Nevrol Psikhiatr Im S S Korsakova</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Mitochondrial dysfunction].</ArticleTitle>
+        <Pagination>
+          <StartPage>48</StartPage>
+          <EndPage>53</EndPage>
+          <MedlinePgn>48-53</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.17116/jnevro202212209148</ELocationID>
+        <Abstract>
+          <AbstractText>Hypoergos-energy deficiency, i.e., a mismatch between the body's (tissue, organ, cell) need for energy and the limited amount of macroergs (ATP) that can currently be used to maintain the structural integrity and functional activity of a tissue or organ. The main role in the development of hypoergoses is played by damage to mitochondria, therefore, in recent years, this term has been replaced by mitochondrial dysfunction. Over the past 50 years, drugs have been actively studied and developed that have the ability to influence mitochondrial disorders, both primary and secondary mitochondrial diseases. In this context, Cytochrome C, an original antioxidant/antihypoxant with a dual mechanism of action, deserves attention.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Putilina</LastName>
+            <ForeName>M V</ForeName>
+            <Initials>MV</Initials>
+            <Identifier Source="ORCID">0000-0002-8655-8501</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Pirogov Russian National Research Medical University, Moscow, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>rus</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Mitokhondrial'naya disfunktsiya.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Russia (Federation)</Country>
+        <MedlineTA>Zh Nevrol Psikhiatr Im S S Korsakova</MedlineTA>
+        <NlmUniqueID>9712194</NlmUniqueID>
+        <ISSNLinking>1997-7298</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000975">Antioxidants</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>8L70Q75FXE</RegistryNumber>
+          <NameOfSubstance UI="D000255">Adenosine Triphosphate</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9007-43-6</RegistryNumber>
+          <NameOfSubstance UI="D045304">Cytochromes c</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000255" MajorTopicYN="N">Adenosine Triphosphate</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000975" MajorTopicYN="Y">Antioxidants</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D045304" MajorTopicYN="N">Cytochromes c</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004734" MajorTopicYN="N">Energy Metabolism</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008928" MajorTopicYN="N">Mitochondria</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D028361" MajorTopicYN="Y">Mitochondrial Diseases</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="N">drug therapy</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018384" MajorTopicYN="N">Oxidative Stress</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="rus">
+        <AbstractText>&#1069;&#1085;&#1077;&#1088;&#1075;&#1077;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1072;&#1103; &#1085;&#1077;&#1076;&#1086;&#1089;&#1090;&#1072;&#1090;&#1086;&#1095;&#1085;&#1086;&#1089;&#1090;&#1100; &#8212; &#1085;&#1077;&#1089;&#1086;&#1086;&#1090;&#1074;&#1077;&#1090;&#1089;&#1090;&#1074;&#1080;&#1077; &#1084;&#1077;&#1078;&#1076;&#1091; &#1087;&#1086;&#1090;&#1088;&#1077;&#1073;&#1085;&#1086;&#1089;&#1090;&#1100;&#1102; &#1086;&#1088;&#1075;&#1072;&#1085;&#1080;&#1079;&#1084;&#1072; &#1074; &#1101;&#1085;&#1077;&#1088;&#1075;&#1080;&#1080; &#1080; &#1090;&#1077;&#1084; &#1086;&#1075;&#1088;&#1072;&#1085;&#1080;&#1095;&#1077;&#1085;&#1085;&#1099;&#1084; &#1082;&#1086;&#1083;&#1080;&#1095;&#1077;&#1089;&#1090;&#1074;&#1086;&#1084; &#1084;&#1072;&#1082;&#1088;&#1086;&#1101;&#1088;&#1075;&#1086;&#1074; (&#1040;&#1058;&#1060;), &#1082;&#1086;&#1090;&#1086;&#1088;&#1086;&#1077; &#1084;&#1086;&#1078;&#1077;&#1090; &#1074; &#1076;&#1072;&#1085;&#1085;&#1099;&#1081; &#1084;&#1086;&#1084;&#1077;&#1085;&#1090; &#1080;&#1089;&#1087;&#1086;&#1083;&#1100;&#1079;&#1086;&#1074;&#1072;&#1090;&#1100;&#1089;&#1103; &#1076;&#1083;&#1103; &#1087;&#1086;&#1076;&#1076;&#1077;&#1088;&#1078;&#1072;&#1085;&#1080;&#1103; &#1077;&#1075;&#1086; &#1089;&#1090;&#1088;&#1091;&#1082;&#1090;&#1091;&#1088;&#1085;&#1086;&#1081; &#1094;&#1077;&#1083;&#1086;&#1089;&#1090;&#1085;&#1086;&#1089;&#1090;&#1080; &#1080; &#1092;&#1091;&#1085;&#1082;&#1094;&#1080;&#1086;&#1085;&#1072;&#1083;&#1100;&#1085;&#1086;&#1081; &#1072;&#1082;&#1090;&#1080;&#1074;&#1085;&#1086;&#1089;&#1090;&#1080; &#1090;&#1082;&#1072;&#1085;&#1080;. &#1043;&#1083;&#1072;&#1074;&#1085;&#1091;&#1102; &#1088;&#1086;&#1083;&#1100; &#1074; &#1088;&#1072;&#1079;&#1074;&#1080;&#1090;&#1080;&#1080; &#1101;&#1085;&#1077;&#1088;&#1075;&#1077;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1085;&#1077;&#1076;&#1086;&#1089;&#1090;&#1072;&#1090;&#1086;&#1095;&#1085;&#1086;&#1089;&#1090;&#1080; &#1080;&#1075;&#1088;&#1072;&#1077;&#1090; &#1087;&#1086;&#1074;&#1088;&#1077;&#1078;&#1076;&#1077;&#1085;&#1080;&#1077; &#1084;&#1080;&#1090;&#1086;&#1093;&#1086;&#1085;&#1076;&#1088;&#1080;&#1081;, &#1087;&#1086;&#1101;&#1090;&#1086;&#1084;&#1091; &#1074; &#1087;&#1086;&#1089;&#1083;&#1077;&#1076;&#1085;&#1080;&#1077; &#1075;&#1086;&#1076;&#1099; &#1101;&#1090;&#1086;&#1090; &#1090;&#1077;&#1088;&#1084;&#1080;&#1085; &#1079;&#1072;&#1084;&#1077;&#1085;&#1077;&#1085; &#1085;&#1072; &#1084;&#1080;&#1090;&#1086;&#1093;&#1086;&#1085;&#1076;&#1088;&#1080;&#1072;&#1083;&#1100;&#1085;&#1091;&#1102; &#1076;&#1080;&#1089;&#1092;&#1091;&#1085;&#1082;&#1094;&#1080;&#1102;. &#1055;&#1086;&#1089;&#1083;&#1077;&#1076;&#1085;&#1080;&#1077; 50 &#1083;&#1077;&#1090; &#1072;&#1082;&#1090;&#1080;&#1074;&#1085;&#1086; &#1080;&#1079;&#1091;&#1095;&#1072;&#1102;&#1090;&#1089;&#1103; &#1080; &#1088;&#1072;&#1079;&#1088;&#1072;&#1073;&#1072;&#1090;&#1099;&#1074;&#1072;&#1102;&#1090;&#1089;&#1103; &#1083;&#1077;&#1082;&#1072;&#1088;&#1089;&#1090;&#1074;&#1077;&#1085;&#1085;&#1099;&#1077; &#1089;&#1088;&#1077;&#1076;&#1089;&#1090;&#1074;&#1072;, &#1089;&#1087;&#1086;&#1089;&#1086;&#1073;&#1085;&#1099;&#1077; &#1086;&#1082;&#1072;&#1079;&#1099;&#1074;&#1072;&#1090;&#1100; &#1074;&#1086;&#1079;&#1076;&#1077;&#1081;&#1089;&#1090;&#1074;&#1080;&#1077; &#1082;&#1072;&#1082; &#1085;&#1072; &#1087;&#1077;&#1088;&#1074;&#1080;&#1095;&#1085;&#1099;&#1077;, &#1090;&#1072;&#1082; &#1080; &#1085;&#1072; &#1074;&#1090;&#1086;&#1088;&#1080;&#1095;&#1085;&#1099;&#1077; &#1084;&#1080;&#1090;&#1086;&#1093;&#1086;&#1085;&#1076;&#1088;&#1080;&#1072;&#1083;&#1100;&#1085;&#1099;&#1077; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1103;. &#1042; &#1101;&#1090;&#1086;&#1084; &#1082;&#1086;&#1085;&#1090;&#1077;&#1082;&#1089;&#1090;&#1077; &#1079;&#1072;&#1089;&#1083;&#1091;&#1078;&#1080;&#1074;&#1072;&#1077;&#1090; &#1074;&#1085;&#1080;&#1084;&#1072;&#1085;&#1080;&#1103; &#1087;&#1088;&#1077;&#1087;&#1072;&#1088;&#1072;&#1090; &#1062;&#1080;&#1090;&#1086;&#1093;&#1088;&#1086;&#1084; &#1057; &#8212; &#1086;&#1088;&#1080;&#1075;&#1080;&#1085;&#1072;&#1083;&#1100;&#1085;&#1099;&#1081; &#1072;&#1085;&#1090;&#1080;&#1086;&#1082;&#1089;&#1080;&#1076;&#1072;&#1085;&#1090;/&#1072;&#1085;&#1090;&#1080;&#1075;&#1080;&#1087;&#1086;&#1082;&#1089;&#1072;&#1085;&#1090;.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">ATP</Keyword>
+        <Keyword MajorTopicYN="N">Cytochrome C</Keyword>
+        <Keyword MajorTopicYN="N">antihypoxants</Keyword>
+        <Keyword MajorTopicYN="N">antioxidants</Keyword>
+        <Keyword MajorTopicYN="N">energy deficiency</Keyword>
+        <Keyword MajorTopicYN="N">mitochondrial diseases</Keyword>
+        <Keyword MajorTopicYN="N">mitochondrial dysfunction</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>28</Day>
+          <Hour>2</Hour>
+          <Minute>28</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>29</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2022</Year>
+          <Month>9</Month>
+          <Day>30</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">36168687</ArticleId>
+        <ArticleId IdType="doi">10.17116/jnevro202212209148</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/36890755.xml
+++ b/tests/fixtures/pmid_xml/36890755.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">36890755</PMID>
+      <DateCompleted>
+        <Year>2023</Year>
+        <Month>03</Month>
+        <Day>10</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2023</Year>
+        <Month>03</Month>
+        <Day>10</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1881-6096</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>75</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>2023</Year>
+              <Month>Mar</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Brain and nerve = Shinkei kenkyu no shinpo</Title>
+          <ISOAbbreviation>Brain Nerve</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Chronic Pain: Definition/Conception/Classification of Pain].</ArticleTitle>
+        <Pagination>
+          <StartPage>201</StartPage>
+          <EndPage>205</EndPage>
+          <MedlinePgn>201-205</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.11477/mf.1416202309</ELocationID>
+        <Abstract>
+          <AbstractText>Understanding what pain is necessary to understand the pathomechanisms of chronic pain. The International Association for the Study of Pain (IASP) defines pain as "An unpleasant sensory and emotional experience associated with, or resembling that associated with, actual or potential tissue damage" and its further states that pain is a personal experience, influenced to varying degrees by biological, psychological, and social factors. It also mentions that person learn the concept of the pain through life experiences, and that it does not always play an adaptive role and has a negative impact on our physical, social, and psychological health. In order to classify chronic pain, IASP created a coding system in ICD11 that focuses on chronic secondary pain, which has clear organic factors, and chronic primary pain, which is difficult to explain from the organic aspect alone. When considering pain treatment, it is necessary to consider three pain mechanisms, including nociceptive pain, neuropathic pain, and nociplastic pain, which is a condition in which the patient feels strong pain due to sensitization of the nervous system.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Ushida</LastName>
+            <ForeName>Takahiro</ForeName>
+            <Initials>T</Initials>
+            <AffiliationInfo>
+              <Affiliation>Pain Relief Surgery and Multidisciplinary Pain Center, Aichi Medical University Hospital.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>jpn</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Japan</Country>
+        <MedlineTA>Brain Nerve</MedlineTA>
+        <NlmUniqueID>101299709</NlmUniqueID>
+        <ISSNLinking>1881-6096</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D059350" MajorTopicYN="Y">Chronic Pain</DescriptorName>
+          <QualifierName UI="Q000145" MajorTopicYN="N">classification</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2023</Year>
+          <Month>3</Month>
+          <Day>9</Day>
+          <Hour>1</Hour>
+          <Minute>53</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2023</Year>
+          <Month>3</Month>
+          <Day>10</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2023</Year>
+          <Month>3</Month>
+          <Day>11</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">36890755</ArticleId>
+        <ArticleId IdType="doi">10.11477/mf.1416202309</ArticleId>
+        <ArticleId IdType="pii">1416202309</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/37070066.xml
+++ b/tests/fixtures/pmid_xml/37070066.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+      <PMID Version="1">37070066</PMID>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>05</Month>
+        <Day>31</Day>
+      </DateRevised>
+      <Article PubModel="Electronic-eCollection">
+        <Journal>
+          <ISSN IssnType="Electronic">2283-5733</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>10</Volume>
+            <PubDate>
+              <Year>2023</Year>
+              <Season>Jan-Dec</Season>
+            </PubDate>
+          </JournalIssue>
+          <Title>Global &amp; regional health technology assessment</Title>
+          <ISOAbbreviation>Glob Reg Health Technol Assess</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>29</StartPage>
+          <EndPage>39</EndPage>
+          <MedlinePgn>29-39</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.33393/grhta.2023.2507</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Fiorentino</LastName>
+            <ForeName>Francesca</ForeName>
+            <Initials>F</Initials>
+            <AffiliationInfo>
+              <Affiliation>IQVIA Italia, Milano - Italy.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Di Rienzo</LastName>
+            <ForeName>Paolo</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>Astellas Pharma S.p.A. Italia, Milano - Italy.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ita</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Analisi di impatto sul budget sanitario italiano di enzalutamide per il trattamento del carcinoma prostatico metastatico ormono-sensibile.</VernacularTitle>
+        <ArticleDate DateType="Electronic">
+          <Year>2023</Year>
+          <Month>04</Month>
+          <Day>11</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Italy</Country>
+        <MedlineTA>Glob Reg Health Technol Assess</MedlineTA>
+        <NlmUniqueID>9918417986506676</NlmUniqueID>
+        <ISSNLinking>2284-2403</ISSNLinking>
+      </MedlineJournalInfo>
+      <CoiStatement>Conflict of interest: FF, during the preparation of this article was an employee of IQVIA Italia, who receives honoraria for professional services from several pharma companies. PDR is an employee of Astellas Pharma S.p.A. Italia.</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="received">
+          <Year>2022</Year>
+          <Month>10</Month>
+          <Day>19</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2023</Year>
+          <Month>3</Month>
+          <Day>8</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2023</Year>
+          <Month>4</Month>
+          <Day>19</Day>
+          <Hour>6</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2023</Year>
+          <Month>4</Month>
+          <Day>18</Day>
+          <Hour>1</Hour>
+          <Minute>46</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2023</Year>
+          <Month>4</Month>
+          <Day>19</Day>
+          <Hour>6</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>epublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">37070066</ArticleId>
+        <ArticleId IdType="doi">10.33393/grhta.2023.2507</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/37530005.xml
+++ b/tests/fixtures/pmid_xml/37530005.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+      <PMID Version="1">37530005</PMID>
+      <DateCompleted>
+        <Year>2023</Year>
+        <Month>08</Month>
+        <Day>04</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2023</Year>
+        <Month>08</Month>
+        <Day>22</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">2038-1840</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>114</Volume>
+            <Issue>9</Issue>
+            <PubDate>
+              <Year>2023</Year>
+              <Month>Sep</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Recenti progressi in medicina</Title>
+          <ISOAbbreviation>Recenti Prog Med</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>529</StartPage>
+          <EndPage>530</EndPage>
+          <MedlinePgn>529-530</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1701/4088.40798</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Sementilli</LastName>
+            <ForeName>Andrea</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere Coordinatore, Centro salute mentale (Spdc-Csm), Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lettieri</LastName>
+            <ForeName>Maria</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiera, Centro salute mentale (Spdc-Csm), Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Paolacci</LastName>
+            <ForeName>Federica</ForeName>
+            <Initials>F</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiera Coordinatrice, Agenzia continuit&#224; ospedale-territorio (Acot), Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Martinelli</LastName>
+            <ForeName>Angela</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiera Coordinatrice, Aft Montagna, Presidio integrato ospedale territorio (Piot), San Marcello Pistoiese, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Panichi</LastName>
+            <ForeName>Paola</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere Coordinatore, Aft/Case della salute Pianura Pistoiese; Aft1/Case della Salute, Pistoia; Aft2/Case della Salute, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Pantini</LastName>
+            <ForeName>Marco</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere Coordinatore, Aft/Case della salute Pianura Pistoiese; Aft1/Case della Salute, Pistoia; Aft2/Case della Salute, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Gasperetti</LastName>
+            <ForeName>Emanuele</ForeName>
+            <Initials>E</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere Coordinatore, Aft/Case della salute Pianura Pistoiese; Aft1/Case della Salute, Pistoia; Aft2/Case della Salute, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ramazzotti</LastName>
+            <ForeName>Erica</ForeName>
+            <Initials>E</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere di Famiglia e Comunit&#224;, Case di Comunit&#224; Territorio Pistoiese.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Tozzi</LastName>
+            <ForeName>Camilla</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiere di Famiglia e Comunit&#224;, Case di Comunit&#224; Territorio Pistoiese.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Cascini</LastName>
+            <ForeName>Cristina</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Infermiera Coordinatrice, Dea PO San Jacopo, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Pacini</LastName>
+            <ForeName>Riccardo</ForeName>
+            <Initials>R</Initials>
+            <AffiliationInfo>
+              <Affiliation>Direzione Infermieristica Sos Gestione, Pistoia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ita</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Insieme &#8220;CONpatibilMENTE&#8221; &#8211; Riflessione sui Tempi di handover per rendere &#8220;visibile l&#8217;invisibile&#8221;.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Italy</Country>
+        <MedlineTA>Recenti Prog Med</MedlineTA>
+        <NlmUniqueID>0401271</NlmUniqueID>
+        <ISSNLinking>0034-1193</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2023</Year>
+          <Month>8</Month>
+          <Day>2</Day>
+          <Hour>6</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2023</Year>
+          <Month>8</Month>
+          <Day>2</Day>
+          <Hour>6</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2023</Year>
+          <Month>8</Month>
+          <Day>2</Day>
+          <Hour>5</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">37530005</ArticleId>
+        <ArticleId IdType="doi">10.1701/4088.40798</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/37743333.xml
+++ b/tests/fixtures/pmid_xml/37743333.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">37743333</PMID>
+      <DateCompleted>
+        <Year>2023</Year>
+        <Month>09</Month>
+        <Day>26</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2023</Year>
+        <Month>09</Month>
+        <Day>26</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0301-2603</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>51</Volume>
+            <Issue>5</Issue>
+            <PubDate>
+              <Year>2023</Year>
+              <Month>Sep</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>No shinkei geka. Neurological surgery</Title>
+          <ISOAbbreviation>No Shinkei Geka</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Glioblastoma, IDH-Wildtype].</ArticleTitle>
+        <Pagination>
+          <StartPage>821</StartPage>
+          <EndPage>828</EndPage>
+          <MedlinePgn>821-828</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.11477/mf.1436204823</ELocationID>
+        <Abstract>
+          <AbstractText>The 5th edition of the WHO Classification of Central Nervous System Tumours(WHO2021)emphasizes the importance of molecular classification. A significant update was that glioblastoma IDH-mutant from WHO2016 was renamed and classified as astrocytoma IDH-mutant WHO grade 4 in WHO2021. This review describes the current updates to the glioblastoma classification, and discusses the essential knowledge regarding daily practice, especially for young neurosurgeons.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Shibahara</LastName>
+            <ForeName>Ichiyo</ForeName>
+            <Initials>I</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Neurosurgery, Kitasato University School of Medicine.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kumabe</LastName>
+            <ForeName>Toshihiro</ForeName>
+            <Initials>T</Initials>
+          </Author>
+        </AuthorList>
+        <Language>jpn</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016454">Review</PublicationType>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Japan</Country>
+        <MedlineTA>No Shinkei Geka</MedlineTA>
+        <NlmUniqueID>0377015</NlmUniqueID>
+        <ISSNLinking>0301-2603</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005909" MajorTopicYN="Y">Glioblastoma</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001254" MajorTopicYN="Y">Astrocytoma</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000069471" MajorTopicYN="N">Neurosurgeons</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2023</Year>
+          <Month>9</Month>
+          <Day>26</Day>
+          <Hour>13</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2023</Year>
+          <Month>9</Month>
+          <Day>25</Day>
+          <Hour>0</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2023</Year>
+          <Month>9</Month>
+          <Day>24</Day>
+          <Hour>22</Hour>
+          <Minute>33</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">37743333</ArticleId>
+        <ArticleId IdType="doi">10.11477/mf.1436204823</ArticleId>
+        <ArticleId IdType="pii">1436204823</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/37967964.xml
+++ b/tests/fixtures/pmid_xml/37967964.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+      <PMID Version="1">37967964</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>02</Month>
+        <Day>14</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>02</Month>
+        <Day>14</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0021-4884</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>72</Volume>
+            <Issue>9</Issue>
+            <PubDate>
+              <Year>2023</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Arerugi = [Allergy]</Title>
+          <ISOAbbreviation>Arerugi</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>1174</StartPage>
+          <EndPage>1175</EndPage>
+          <MedlinePgn>1174-1175</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.15036/arerugi.72.1174</ELocationID>
+        <Language>jpn</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Japan</Country>
+        <MedlineTA>Arerugi</MedlineTA>
+        <NlmUniqueID>0241212</NlmUniqueID>
+        <ISSNLinking>0021-4884</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">memory B cell</Keyword>
+        <Keyword MajorTopicYN="N">memory T cell</Keyword>
+        <Keyword MajorTopicYN="N">trained immunity</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>2</Month>
+          <Day>13</Day>
+          <Hour>0</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2023</Year>
+          <Month>11</Month>
+          <Day>16</Day>
+          <Hour>0</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2023</Year>
+          <Month>11</Month>
+          <Day>15</Day>
+          <Hour>20</Hour>
+          <Minute>44</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">37967964</ArticleId>
+        <ArticleId IdType="doi">10.15036/arerugi.72.1174</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/38468501.xml
+++ b/tests/fixtures/pmid_xml/38468501.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">38468501</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>03</Month>
+        <Day>22</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>03</Month>
+        <Day>22</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0253-3766</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>46</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Mar</Month>
+              <Day>23</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Zhonghua zhong liu za zhi [Chinese journal of oncology]</Title>
+          <ISOAbbreviation>Zhonghua Zhong Liu Za Zhi</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Cancer incidence and mortality in China, 2022].</ArticleTitle>
+        <Pagination>
+          <StartPage>221</StartPage>
+          <EndPage>231</EndPage>
+          <MedlinePgn>221-231</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.3760/cma.j.cn112152-20240119-00035</ELocationID>
+        <Abstract>
+          <AbstractText><b>Objective:</b> The National Central Cancer Registry estimates the number of new cancer cases and deaths in China in 2022, using incidence and mortality data collected by the National Cancer Center. <b>Methods:</b> According to the data of 700 cancer registries in 2018 and the data of 106 cancer registries from 2010 to 2018, the age-period-cohort model was used to estimate the incidence rate and mortality rate of all cancers and 23 types of cancer in 2022, stratified by gender and urban and rural areas. We estimated the number of new cancer cases and deaths in China in 2022 based on the estimated rate and population data in 2022. <b>Results:</b> The estimated results showed that in 2022, there were approximately 4 824 700 new cancer cases in China (2 533 900 in males and 2 290 800 in females), with an age-standardized incidence rate of Chinese population (ASIR) of 208.58 per 100 000 (212.67 per 100 000 for males and 208.08 per 100 000 for females). Approximately 2 903 900 new cancer cases occurred in urban areas, with an ASIR of 212.95 per 100 000. It was estimated about 1 920 800 new cancer cases in rural areas, and the ASIR was 199.65 per 100 000. The top five cancers (lung cancer 1 060 600, colorectal cancer 517 100, thyroid cancer 466 100, liver cancer 367 700 and female breast cancer 357 200) accounted for 57.4% of all new cases. The estimated number of deaths from cancer in China in 2022 was 2 574 200 (1 629 300 in males and 944 900 in females), with an age-standardized mortality rate of Chinese population (ASMR) of 97.08 per 100 000 (127.70 per 100 000 in males and 68.67 per 100 000 in females). The number of deaths from cancer in urban and rural areas was about 1 400 600 and 1 173 400, with the ASMR of 92.37 and 103.97 per 100 000 in urban and rural areas, respectively. The top five leading cause of cancers death (lung cancer 733 300, liver cancer 316 500, gastric cancer 260 400, colorectal cancer 240 000 and esophageal cancer 187 500) accounted for 67.5% of all cancer deaths. Lung cancer ranked first in the incidence and mortality in men and women. The incidence rate in urban areas was higher than that in rural areas, while the mortality rate was lower than that in rural areas. <b>Conclusions:</b> The burden of cancer in China is still relatively heavy, with significant differences in cancer patterns in gender, urban-rural, and regional. The burden of cancer presents a coexistence of developed and developing countries, and the situation of cancer prevention and control is still serious in China.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Zheng</LastName>
+            <ForeName>R S</ForeName>
+            <Initials>RS</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Chen</LastName>
+            <ForeName>R</ForeName>
+            <Initials>R</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Han</LastName>
+            <ForeName>B F</ForeName>
+            <Initials>BF</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wang</LastName>
+            <ForeName>S M</ForeName>
+            <Initials>SM</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Li</LastName>
+            <ForeName>L</ForeName>
+            <Initials>L</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Sun</LastName>
+            <ForeName>K X</ForeName>
+            <Initials>KX</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Zeng</LastName>
+            <ForeName>H M</ForeName>
+            <Initials>HM</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wei</LastName>
+            <ForeName>W W</ForeName>
+            <Initials>WW</Initials>
+            <AffiliationInfo>
+              <Affiliation>Office for Cancer Registry, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>He</LastName>
+            <ForeName>J</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Thoracic Surgery, National Cancer Center/National Clinical Research Center for Cancer/Cancer Hospital, Chinese Academy of Medical Sciences and Peking Union Medical College, Beijing 100021, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>chi</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>2024-2G-40214</GrantID>
+            <Agency>Capital's Funds for Health Improvement and Research</Agency>
+            <Country/>
+          </Grant>
+          <Grant>
+            <GrantID>2021-I2M-1-010, 2021-I2M-1-011</GrantID>
+            <Agency>Major State Basic Innovation Program of the Chinese Academy of Medical Sciences</Agency>
+            <Country/>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>China</Country>
+        <MedlineTA>Zhonghua Zhong Liu Za Zhi</MedlineTA>
+        <NlmUniqueID>7910681</NlmUniqueID>
+        <ISSNLinking>0253-3766</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015994" MajorTopicYN="N">Incidence</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014505" MajorTopicYN="N">Urban Population</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008113" MajorTopicYN="Y">Liver Neoplasms</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008175" MajorTopicYN="Y">Lung Neoplasms</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012424" MajorTopicYN="N">Rural Population</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002681" MajorTopicYN="N" Type="Geographic">China</DescriptorName>
+          <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012042" MajorTopicYN="N">Registries</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015179" MajorTopicYN="Y">Colorectal Neoplasms</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="chi">
+        <AbstractText><b>&#30446;&#30340;&#65306;</b> &#26681;&#25454;&#20840;&#22269;&#32959;&#30244;&#30331;&#35760;&#20013;&#24515;&#25910;&#38598;&#30340;&#32959;&#30244;&#30331;&#35760;&#25968;&#25454;&#65292;&#20272;&#35745;2022&#24180;&#20013;&#22269;&#24694;&#24615;&#32959;&#30244;&#27969;&#34892;&#24773;&#20917;&#12290; <b>&#26041;&#27861;&#65306;</b> &#32435;&#20837;700&#20010;&#32959;&#30244;&#30331;&#35760;&#22788;&#30340;2018&#24180;&#25968;&#25454;&#21644;106&#20010;&#30331;&#35760;&#22788;&#30340;2010&#8212;2018&#24180;&#25968;&#25454;&#65292;&#37319;&#29992;&#24180;&#40836;-&#26102;&#26399;-&#38431;&#21015;&#27169;&#22411;&#65292;&#25353;&#24615;&#21035;&#12289;&#22478;&#20065;&#20998;&#23618;&#65292;&#20272;&#35745;2022&#24180;&#24635;&#20307;&#21450;23&#31867;&#20027;&#35201;&#24694;&#24615;&#32959;&#30244;&#30340;&#20013;&#22269;&#20154;&#21475;&#24180;&#40836;&#26631;&#20934;&#21270;&#21457;&#30149;&#29575;&#65288;&#20013;&#26631;&#21457;&#30149;&#29575;&#65289;&#21644;&#27515;&#20129;&#29575;&#65288;&#20013;&#26631;&#27515;&#20129;&#29575;&#65289;&#12290;&#32467;&#21512;2022&#24180;&#20154;&#21475;&#25968;&#25454;&#65292;&#20272;&#35745;2022&#24180;&#20013;&#22269;&#24694;&#24615;&#32959;&#30244;&#21457;&#30149;&#21644;&#27515;&#20129;&#20363;&#25968;&#12290; <b>&#32467;&#26524;&#65306;</b> 2022&#24180;&#20013;&#22269;&#24694;&#24615;&#32959;&#30244;&#26032;&#21457;&#30149;&#20363;&#20272;&#35745;&#20026;482.47&#19975;&#65288;&#30007;&#24615;253.39&#19975;&#65292;&#22899;&#24615;229.08&#19975;&#65289;&#65292;&#20013;&#26631;&#21457;&#30149;&#29575;&#20026;208.58/10&#19975;&#65288;&#30007;&#24615;212.67/10&#19975;&#65292;&#22899;&#24615;208.08/10&#19975;&#65289;&#12290;&#22478;&#24066;&#22320;&#21306;&#24694;&#24615;&#32959;&#30244;&#26032;&#21457;&#30149;&#20363;&#32422;290.39&#19975;&#65292;&#20013;&#26631;&#21457;&#30149;&#29575;&#20026;212.95/10&#19975;&#65307;&#20892;&#26449;&#22320;&#21306;192.08&#19975;&#65292;&#20013;&#26631;&#21457;&#30149;&#29575;&#20026;199.65/10&#19975;&#12290;&#21457;&#30149;&#20363;&#25968;&#21069;5&#20301;&#30340;&#24694;&#24615;&#32959;&#30244;&#65288;&#32954;&#30284;106.06&#19975;&#65292;&#32467;&#30452;&#32928;&#30284;51.71&#19975;&#65292;&#30002;&#29366;&#33146;&#30284;46.61&#19975;&#65292;&#32925;&#30284;36.77&#19975;&#65292;&#22899;&#24615;&#20083;&#33146;&#30284;35.72&#19975;&#65289;&#21344;&#20840;&#37096;&#26032;&#21457;&#30149;&#20363;&#30340;57.4%&#12290;2022&#24180;&#20013;&#22269;&#24694;&#24615;&#32959;&#30244;&#27515;&#20129;&#30149;&#20363;&#20272;&#35745;&#20026;257.42&#19975;&#65288;&#30007;&#24615;162.93&#19975;&#65292;&#22899;&#24615;94.49&#19975;&#65289;&#65292;&#20013;&#26631;&#27515;&#20129;&#29575;&#20026;97.08/10&#19975;&#65288;&#30007;&#24615;127.70/10&#19975;&#65292;&#22899;&#24615;68.67/10&#19975;&#65289;&#12290;&#22478;&#24066;&#22320;&#21306;&#24694;&#24615;&#32959;&#30244;&#27515;&#20129;&#30149;&#20363;&#32422;140.06&#19975;&#65292;&#20013;&#26631;&#27515;&#20129;&#29575;&#20026;92.37/10&#19975;&#65307;&#20892;&#26449;&#22320;&#21306;117.34&#19975;&#65292;&#20013;&#26631;&#27515;&#20129;&#29575;&#20026;103.97/10&#19975;&#12290;&#27515;&#20129;&#20363;&#25968;&#21069;5&#20301;&#30340;&#24694;&#24615;&#32959;&#30244;&#65288;&#32954;&#30284;73.33&#19975;&#65292;&#32925;&#30284;31.65&#19975;&#65292;&#32963;&#30284;26.04&#19975;&#65292;&#32467;&#30452;&#32928;&#30284;24.00&#19975;&#65292;&#39135;&#31649;&#30284;18.75&#19975;&#65289;&#21344;&#20840;&#37096;&#27515;&#20129;&#30149;&#20363;&#30340;67.5%&#12290;&#32954;&#30284;&#23621;&#30007;&#12289;&#22899;&#24694;&#24615;&#32959;&#30244;&#21457;&#30149;&#21644;&#27515;&#20129;&#39318;&#20301;&#65292;&#22478;&#24066;&#22320;&#21306;&#24694;&#24615;&#32959;&#30244;&#21457;&#30149;&#29575;&#39640;&#20110;&#20892;&#26449;&#22320;&#21306;&#65292;&#27515;&#20129;&#29575;&#20302;&#20110;&#20892;&#26449;&#22320;&#21306;&#12290; <b>&#32467;&#35770;&#65306;</b> &#20013;&#22269;&#24694;&#24615;&#32959;&#30244;&#30142;&#30149;&#36127;&#25285;&#23384;&#22312;&#24615;&#21035;&#12289;&#22478;&#20065;&#21644;&#22320;&#21306;&#24046;&#24322;&#65292;&#24635;&#20307;&#21576;&#29616;&#21457;&#36798;&#22269;&#23478;&#19982;&#21457;&#23637;&#20013;&#22269;&#23478;&#30284;&#35889;&#20849;&#23384;&#30340;&#23616;&#38754;&#65292;&#38450;&#25511;&#24418;&#21183;&#20005;&#23803;&#12290;.</AbstractText>
+      </OtherAbstract>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>3</Month>
+          <Day>22</Day>
+          <Hour>6</Hour>
+          <Minute>44</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>3</Month>
+          <Day>12</Day>
+          <Hour>6</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>3</Month>
+          <Day>12</Day>
+          <Hour>3</Hour>
+          <Minute>7</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">38468501</ArticleId>
+        <ArticleId IdType="doi">10.3760/cma.j.cn112152-20240119-00035</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/38880983.xml
+++ b/tests/fixtures/pmid_xml/38880983.xml
@@ -1,0 +1,1431 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">38880983</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>06</Month>
+        <Day>17</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>07</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">2001-1326</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>14</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Jun</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Clinical and translational medicine</Title>
+          <ISOAbbreviation>Clin Transl Med</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>e1666</StartPage>
+          <MedlinePgn>e1666</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="pii" ValidYN="Y">e1666</ELocationID>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1002/ctm2.1666</ELocationID>
+        <Abstract>
+          <AbstractText>Dysregulated RNA modifications, stemming from the aberrant expression and/or malfunction of RNA modification regulators operating through various pathways, play pivotal roles in driving the progression of haematological malignancies. Among RNA modifications, N<sup>6</sup>-methyladenosine (m<sup>6</sup>A) RNA modification, the most abundant internal mRNA modification, stands out as the most extensively studied modification. This prominence underscores the crucial role of the layer of epitranscriptomic regulation in controlling haematopoietic cell fate and therefore the development of haematological malignancies. Additionally, other RNA modifications (non-m<sup>6</sup>A RNA modifications) have gained increasing attention for their essential roles in haematological malignancies. Although the roles of the m<sup>6</sup>A modification machinery in haematopoietic malignancies have been well reviewed thus far, such reviews are lacking for non-m<sup>6</sup>A RNA modifications. In this review, we mainly focus on the roles and implications of non-m<sup>6</sup>A RNA modifications, including N<sup>4</sup>-acetylcytidine, pseudouridylation, 5-methylcytosine, adenosine to inosine editing, 2'-O-methylation, N<sup>1</sup>-methyladenosine and N<sup>7</sup>-methylguanosine in haematopoietic malignancies. We summarise the regulatory enzymes and cellular functions of non-m<sup>6</sup>A RNA modifications, followed by the discussions of the recent studies on the biological roles and underlying mechanisms of non-m<sup>6</sup>A RNA modifications in haematological malignancies. We also highlight the potential of therapeutically targeting dysregulated non-m<sup>6</sup>A modifiers in blood cancer.</AbstractText>
+          <CopyrightInformation>&#169; 2024 The Authors. Clinical and Translational Medicine published by John Wiley &amp; Sons Australia, Ltd on behalf of Shanghai Institute of Clinical Bioinformatics.</CopyrightInformation>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Chen</LastName>
+            <ForeName>Meiling</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Hematology, Fujian Institute of Hematology, Fujian Provincial Key Laboratory on Hematology, Fujian Medical University Union Hospital, Fuzhou, China.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Department of Systems Biology, Beckman Research Institute of City of Hope, Monrovia, California, USA.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Chen</LastName>
+            <ForeName>Yuanzhong</ForeName>
+            <Initials>Y</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Hematology, Fujian Institute of Hematology, Fujian Provincial Key Laboratory on Hematology, Fujian Medical University Union Hospital, Fuzhou, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wang</LastName>
+            <ForeName>Kitty</ForeName>
+            <Initials>K</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Systems Biology, Beckman Research Institute of City of Hope, Monrovia, California, USA.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Deng</LastName>
+            <ForeName>Xiaolan</ForeName>
+            <Initials>X</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Systems Biology, Beckman Research Institute of City of Hope, Monrovia, California, USA.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Chen</LastName>
+            <ForeName>Jianjun</ForeName>
+            <Initials>J</Initials>
+            <Identifier Source="ORCID">0000-0003-3749-2902</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Department of Systems Biology, Beckman Research Institute of City of Hope, Monrovia, California, USA.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Gehr Family Center for Leukemia Research, City of Hope Medical Center and Comprehensive Cancer Center, Duarte, California, USA.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ita</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>R01 CA236399</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA280389</GrantID>
+            <Acronym>NH</Acronym>
+            <Agency>NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <Agency>Simms/Mann Family Foundation</Agency>
+            <Country/>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA236399</GrantID>
+            <Acronym>NH</Acronym>
+            <Agency>NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA271497</GrantID>
+            <Acronym>NH</Acronym>
+            <Agency>NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA271497</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA280389</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA243386</GrantID>
+            <Acronym>NH</Acronym>
+            <Agency>NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>R01 CA243386</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Non&#8208;m<sup>6</sup>A RNA modifications in haematological malignancies.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Clin Transl Med</MedlineTA>
+        <NlmUniqueID>101597971</NlmUniqueID>
+        <ISSNLinking>2001-1326</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>63231-63-0</RegistryNumber>
+          <NameOfSubstance UI="D012313">RNA</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>K72T3FS567</RegistryNumber>
+          <NameOfSubstance UI="D000241">Adenosine</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>CLE6G00625</RegistryNumber>
+          <NameOfSubstance UI="C010223">N-methyladenosine</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019337" MajorTopicYN="Y">Hematologic Neoplasms</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012323" MajorTopicYN="N">RNA Processing, Post-Transcriptional</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012313" MajorTopicYN="N">RNA</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000241" MajorTopicYN="N">Adenosine</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="N">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">epitranscriptomics</Keyword>
+        <Keyword MajorTopicYN="N">haematological malignancies</Keyword>
+        <Keyword MajorTopicYN="N">non&#8208;m6A RNA modification</Keyword>
+      </KeywordList>
+      <CoiStatement>The authors declare they have no conflicts of interest.</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="revised">
+          <Year>2024</Year>
+          <Month>3</Month>
+          <Day>25</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="received">
+          <Year>2023</Year>
+          <Month>11</Month>
+          <Day>5</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2024</Year>
+          <Month>4</Month>
+          <Day>4</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>6</Month>
+          <Day>17</Day>
+          <Hour>6</Hour>
+          <Minute>45</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>6</Month>
+          <Day>17</Day>
+          <Hour>6</Hour>
+          <Minute>44</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>6</Month>
+          <Day>17</Day>
+          <Hour>0</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2024</Year>
+          <Month>6</Month>
+          <Day>16</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">38880983</ArticleId>
+        <ArticleId IdType="pmc">PMC11180698</ArticleId>
+        <ArticleId IdType="doi">10.1002/ctm2.1666</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Huang H, Weng H, Chen J. m6A modification in coding and non&#8208;coding RNAs: roles and therapeutic implications in cancer. Cancer Cell. 2020;37(3):270&#8208;288.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7141420</ArticleId>
+            <ArticleId IdType="pubmed">32183948</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yoon K&#8208;J, Vissers C, Ming G&#8208;L, Song H. Epigenetics and epitranscriptomics in temporal patterning of cortical neural progenitor competence. J Cell Biol. 2018;217(6):1901&#8208;1914.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5987727</ArticleId>
+            <ArticleId IdType="pubmed">29666150</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Deng X, Qing Y, Horne D, Huang H, Chen J. The roles and implications of RNA m(6)A modification in cancer. Nat Rev Clin Oncol. 2023;20(8):507&#8208;526.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC12466201</ArticleId>
+            <ArticleId IdType="pubmed">37221357</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Huang H, Weng H, Deng X, Chen J. RNA modifications in cancer: functions, mechanisms, and therapeutic implications. Annu Rev Cancer Biol. 2020;4:221&#8208;240.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Cayir A. RNA modifications as emerging therapeutic targets. Wiley Interdiscip Rev RNA. 2022;13(4):e1702.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">34816607</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Han L, Chen J, Su R. Epitranscriptomics in myeloid malignancies. Blood Sci. 2022;4(03):133&#8208;135.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9742087</ArticleId>
+            <ArticleId IdType="pubmed">36518589</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang Y, Yang Y. Effects of m6A RNA methylation regulators on endometrial cancer. J Clin Lab Anal. 2021;35(9):e23942.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8418492</ArticleId>
+            <ArticleId IdType="pubmed">34347888</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Farooqi AA, Fayyaz S, Poltronieri P, Calin G, Mallardo M. Epigenetic deregulation in cancer: enzyme players and non&#8208;coding RNAs. Semin Cancer Biol. 2022;83:197&#8208;207.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">32738290</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Esteve&#8208;Puig R, Bueno&#8208;Costa A, Esteller M. Writers, readers and erasers of RNA modifications in cancer. Cancer Lett. 2020;474:127&#8208;137.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">31991154</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cusenza VY, Tameni A, Neri A, Frazzi R. The lncRNA epigenetics: the significance of m6A and m5C lncRNA modifications in cancer. Front Oncol. 2023;13:1063636.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10033960</ArticleId>
+            <ArticleId IdType="pubmed">36969033</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li Z, Weng H, Su R, et&#160;al. FTO plays an oncogenic role in acute myeloid leukemia as a N6&#8208;methyladenosine RNA demethylase. Cancer Cell. 2017;31(1):127&#8208;141.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5234852</ArticleId>
+            <ArticleId IdType="pubmed">28017614</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Su R, Dong L, Li C, et&#160;al. R&#8208;2HG exhibits anti&#8208;tumor activity by targeting FTO/m(6)A/MYC/CEBPA signaling. Cell. 2018;172(1&#8208;2):90&#8208;105. e123.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5766423</ArticleId>
+            <ArticleId IdType="pubmed">29249359</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weng H, Huang H, Wu H, et&#160;al. METTL14 inhibits hematopoietic stem/progenitor differentiation and promotes leukemogenesis via mRNA m(6)A modification. Cell Stem Cell. 2018;22(2):191&#8208;205. e199.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5860916</ArticleId>
+            <ArticleId IdType="pubmed">29290617</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vu LP, Pickering BF, Cheng Y, et&#160;al. The N(6)&#8208;methyladenosine (m(6)A)&#8208;forming enzyme METTL3 controls myeloid differentiation of normal hematopoietic and leukemia cells. Nat Med. 2017;23(11):1369&#8208;1376.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5677536</ArticleId>
+            <ArticleId IdType="pubmed">28920958</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shen C, Sheng Y, Zhu AC, et&#160;al. RNA demethylase ALKBH5 selectively promotes tumorigenesis and cancer stem cell self&#8208;renewal in acute myeloid leukemia. Cell Stem Cell. 2020;27(1):64&#8208;80. e69.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7335338</ArticleId>
+            <ArticleId IdType="pubmed">32402250</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Paris J, Morgan M, Campos J, et&#160;al. Targeting the RNA m(6)A reader YTHDF2 selectively compromises cancer stem cells in acute myeloid leukemia. Cell Stem Cell. 2019;25(1):137&#8208;148. e136.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6617387</ArticleId>
+            <ArticleId IdType="pubmed">31031138</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Huang Y, Su R, Sheng Y, et&#160;al. Small&#8208;molecule targeting of oncogenic FTO demethylase in acute myeloid leukemia. Cancer Cell. 2019;35:677&#8208;691.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6812656</ArticleId>
+            <ArticleId IdType="pubmed">30991027</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Barbieri I, Tzelepis K, Pandolfini L, et&#160;al. Promoter&#8208;bound METTL3 maintains myeloid leukaemia by m(6)A&#8208;dependent translation control. Nature. 2017;552(7683):126&#8208;131.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6217924</ArticleId>
+            <ArticleId IdType="pubmed">29186125</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang J, Li Y, Wang P, et&#160;al. Leukemogenic chromatin alterations promote AML leukemia stem cells via a KDM4C&#8210;ALKBH5&#8210;AXL signaling axis. Cell Stem Cell. 2020;27(1):81&#8208;97. e88.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">32402251</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Su R, Dong L, Li Y, et&#160;al. Targeting FTO suppresses cancer stem cell maintenance and immune evasion. Cancer Cell. 2020;38(1):79&#8208;96. e11.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7363590</ArticleId>
+            <ArticleId IdType="pubmed">32531268</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Qing Y, Dong L, Gao L, et&#160;al. R&#8208;2&#8208;hydroxyglutarate attenuates aerobic glycolysis in leukemia by targeting the FTO/m(6)A/PFKP/LDHB axis. Mol Cell. 2021;81(5):922&#8208;939. e929.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7935770</ArticleId>
+            <ArticleId IdType="pubmed">33434505</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cheng Y, Xie W, Pickering BF, et&#160;al. N(6)&#8208;Methyladenosine on mRNA facilitates a phase&#8208;separated nuclear body that suppresses myeloid leukemic differentiation. Cancer Cell. 2021;39(7):958&#8208;972. e958.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8282764</ArticleId>
+            <ArticleId IdType="pubmed">34048709</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sheng Y, Wei J, Yu F, et&#160;al. A critical role of nuclear m6A reader YTHDC1 in leukemogenesis by regulating MCM complex&#8208;mediated DNA replication. Blood. 2021;138(26):2838&#8208;2852.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8718631</ArticleId>
+            <ArticleId IdType="pubmed">34255814</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weng H, Huang F, Yu Z, et&#160;al. The m(6)A reader IGF2BP2 regulates glutamine metabolism and represents a therapeutic target in acute myeloid leukemia. Cancer Cell. 2022;40:1&#8208;17.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9772162</ArticleId>
+            <ArticleId IdType="pubmed">36306790</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang Z, Zhou K, Han L, et&#160;al. RNA m(6)A reader YTHDF2 facilitates precursor miR&#8208;126 maturation to promote acute myeloid leukemia progression. Genes Dis. 2024;11(1):382&#8208;396.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10425806</ArticleId>
+            <ArticleId IdType="pubmed">37588203</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li Y, Xue M, Deng X, et&#160;al. TET2&#8208;mediated mRNA demethylation regulates leukemia stem cell homing and self&#8208;renewal. Cell Stem Cell. 2023;30(8):1072&#8208;1090. e1010.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC11166201</ArticleId>
+            <ArticleId IdType="pubmed">37541212</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Han L, Dong L, Leung K, et&#160;al. METTL16 drives leukemogenesis and leukemia stem cell self&#8208;renewal by reprogramming BCAA metabolism. Cell Stem Cell. 2023;30(1):52&#8208;68. e13.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9838187</ArticleId>
+            <ArticleId IdType="pubmed">36608679</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weng H, Huang H, Chen J. RNA N (6)&#8208;methyladenosine modification in normal and malignant hematopoiesis. Adv Exp Med Biol. 2019;1143:75&#8208;93.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">31338816</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Deng X, Su R, Weng H, Huang H, Li Z, Chen J. RNA N(6)&#8208;methyladenosine modification in cancers: current status and perspectives. Cell Res. 2018;28(5):507&#8208;517.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5951805</ArticleId>
+            <ArticleId IdType="pubmed">29686311</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Qing Y, Su R, Chen J. RNA modifications in hematopoietic malignancies: a new research frontier. Blood. 2021;138(8):637&#8208;648.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8394902</ArticleId>
+            <ArticleId IdType="pubmed">34157073</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sun H, Li K, Liu C, Yi C. Regulation and functions of non&#8208;m(6)A mRNA modifications. Nat Rev Mol Cell Biol. 2023;24(10):714&#8208;731.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">37369853</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jin G, Xu M, Zou M, Duan S. The processing, gene regulation, biological functions, and clinical relevance of N4&#8208;acetylcytidine on RNA: a systematic review. Mol Ther Nucleic Acids. 2020;20:13&#8208;24.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7068197</ArticleId>
+            <ArticleId IdType="pubmed">32171170</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zachau HG, D&#252;tting B, Feldmann H. The structures of two serine transfer ribonucleic acids. Hoppe Seylers Z Physiol Chem. 1966;347(4):212&#8208;235.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">5991670</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>
+Bruenger E, Kowalak JA, Kuchino Y, et&#160;al. 5S rRNA modification in the hyperthermophilic archaea <i>Sulfolobus solfataricus</i> and <i>Pyrodictium occultum</i>
+. FASEB J. 1993;7(1):196&#8208;200.
+</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">8422966</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arango D, Sturgill D, Alhusaini N, et&#160;al. Acetylation of cytidine in mRNA promotes translation efficiency. Cell. 2018;175(7):1872&#8208;1886. e1824.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6295233</ArticleId>
+            <ArticleId IdType="pubmed">30449621</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu R, Wubulikasimu Z, Cai R, et&#160;al. NAT10&#8208;mediated N4&#8208;acetylcytidine mRNA modification regulates self&#8208;renewal in human embryonic stem cells. Nucleic Acids Res. 2023;51(16):8514&#8208;8531.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10484679</ArticleId>
+            <ArticleId IdType="pubmed">37497776</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arango D, Sturgill D, Yang R, et&#160;al. Direct epitranscriptomic regulation of mammalian translation initiation through N4&#8208;acetylcytidine. Mol Cell. 2022;82(15):2797&#8208;2814. e2711.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9361928</ArticleId>
+            <ArticleId IdType="pubmed">35679869</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sas&#8208;Chen A, Thomas JM, Matzov D, et&#160;al. Dynamic RNA acetylation revealed by quantitative cross&#8208;evolutionary mapping. Nature. 2020;583(7817):638&#8208;643.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8130014</ArticleId>
+            <ArticleId IdType="pubmed">32555463</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ikeuchi Y, Kitahara K, Suzuki T. The RNA acetyltransferase driven by ATP hydrolysis synthesizes N4&#8208;acetylcytidine of tRNA anticodon. EMBO J. 2008;27(16):2194&#8208;2203.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC2500205</ArticleId>
+            <ArticleId IdType="pubmed">18668122</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sharma S, Langhendries J&#8208;L, Watzinger P, K&#246;tter P, Entian K&#8208;D, Lafontaine DL. Yeast Kre33 and human NAT10 are conserved 18S rRNA cytosine acetyltransferases that modify tRNAs assisted by the adaptor Tan1/THUMPD1. Nucleic Acids Res. 2015;43(4):2242&#8208;2258.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4344512</ArticleId>
+            <ArticleId IdType="pubmed">25653167</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liao L, He Y, Li SJ, et&#160;al. Lysine 2&#8208;hydroxyisobutyrylation of NAT10 promotes cancer metastasis in an ac4C&#8208;dependent manner. Cell Res. 2023;33(5):355&#8208;371.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10156899</ArticleId>
+            <ArticleId IdType="pubmed">36882514</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cerneckis J, Cui Q, He C, Yi C, Shi Y. Decoding pseudouridine: an emerging target for therapeutic development. Trends Pharmacol Sci. 2022;43(6):522&#8208;535.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">35461717</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dai Q, Zhang LS, Sun HL, et&#160;al. Quantitative sequencing using BID&#8208;seq uncovers abundant pseudouridines in mammalian mRNA at base resolution. Nat Biotechnol. 2023;41(3):344&#8208;354.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10017504</ArticleId>
+            <ArticleId IdType="pubmed">36302989</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang M, Jiang Z, Ma Y, et&#160;al. Quantitative profiling of pseudouridylation landscape in the human transcriptome. Nat Chem Biol. 2023;19(10):1185&#8208;1195.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">36997645</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Molinie B, Wang J, Lim KS, et&#160;al. m(6)A&#8208;LAIC&#8208;seq reveals the census and complexity of the m(6)A epitranscriptome. Nat Methods. 2016;13(8):692&#8208;698.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5704921</ArticleId>
+            <ArticleId IdType="pubmed">27376769</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Roundtree IA, Evans ME, Pan T, He C. Dynamic RNA modifications in gene expression regulation. Cell. 2017;169(7):1187&#8208;1200.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5657247</ArticleId>
+            <ArticleId IdType="pubmed">28622506</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>
+Stockert JA, Weil R, Yadav KK, Kyprianou N, Tewari AK. Pseudouridine as a novel biomarker in prostate cancer. <i>Paper presented at: Urologic Oncology: Seminars and Original Investigations</i>. 2021;39(1):63&#8208;71.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7880613</ArticleId>
+            <ArticleId IdType="pubmed">32712138</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wu G, Yu AT, Kantartzis A, Yu YT. Functions and mechanisms of spliceosomal small nuclear RNA pseudouridylation. Wiley Interdiscip Rev RNA. 2011;2(4):571&#8208;581.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4161978</ArticleId>
+            <ArticleId IdType="pubmed">21957045</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wu H, Feigon J. H/ACA small nucleolar RNA pseudouridylation pockets bind substrate RNA to form three&#8208;way junctions that position the target U for modification. Proc Natl Acad Sci U S A. 2007;104(16):6655&#8208;6660.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC1871841</ArticleId>
+            <ArticleId IdType="pubmed">17412831</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>De Zoysa MD, Yu Y&#8208;T. Posttranscriptional RNA pseudouridylation. Enzymes. 2017;41:151&#8208;167.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5694665</ArticleId>
+            <ArticleId IdType="pubmed">28601221</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li S, Duan J, Li D, Ma S, Ye K. Structure of the Shq1&#8210;Cbf5&#8210;Nop10&#8210;Gar1 complex and implications for H/ACA RNP biogenesis and dyskeratosis congenita. EMBO J. 2011;30(24):5010&#8208;5020.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3242979</ArticleId>
+            <ArticleId IdType="pubmed">22117216</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Borchardt EK, Martinez NM, Gilbert WV. Regulation and function of RNA pseudouridylation in human cells. Annu Rev Genet. 2020;54:309&#8208;336.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8007080</ArticleId>
+            <ArticleId IdType="pubmed">32870730</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schwartz S, Bernstein DA, Mumbach MR, et&#160;al. Transcriptome&#8208;wide mapping reveals widespread dynamic&#8208;regulated pseudouridylation of ncRNA and mRNA. Cell. 2014;159(1):148&#8208;162.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4180118</ArticleId>
+            <ArticleId IdType="pubmed">25219674</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hudson GA, Bloomingdale RJ, Znosko BM. Thermodynamic contribution and nearest&#8208;neighbor parameters of pseudouridine&#8208;adenosine base pairs in oligoribonucleotides. RNA. 2013;19(11):1474&#8208;1482.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3851715</ArticleId>
+            <ArticleId IdType="pubmed">24062573</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kierzek E, Malgowska M, Lisowiec J, Turner DH, Gdaniec Z, Kierzek R. The contribution of pseudouridine to stabilities and structure of RNAs. Nucleic Acids Res. 2014;42(5):3492&#8208;3501.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3950712</ArticleId>
+            <ArticleId IdType="pubmed">24369424</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Anderson BR, Muramatsu H, Nallagatla SR, et&#160;al. Incorporation of pseudouridine into mRNA enhances translation by diminishing PKR activation. Nucleic Acids Res. 2010;38(17):5884&#8208;5892.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC2943593</ArticleId>
+            <ArticleId IdType="pubmed">20457754</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nallagatla SR, Bevilacqua PC. Nucleoside modifications modulate activation of the protein kinase PKR in an RNA structure&#8208;specific manner. RNA. 2008;14(6):1201&#8208;1213.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC2390794</ArticleId>
+            <ArticleId IdType="pubmed">18426922</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Karijolich J, Yu YT. Converting nonsense codons into sense codons by targeted pseudouridylation. Nature. 2011;474(7351):395&#8208;398.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3381908</ArticleId>
+            <ArticleId IdType="pubmed">21677757</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Fernandez IS, Ng CL, Kelley AC, Wu G, Yu YT, Ramakrishnan V. Unusual base pairing during the decoding of a stop codon by the ribosome. Nature. 2013;500(7460):107&#8208;110.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3732562</ArticleId>
+            <ArticleId IdType="pubmed">23812587</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Trixl L, Lusser A. The dynamic RNA modification 5&#8208;methylcytosine and its emerging role as an epitranscriptomic mark. Wiley Interdiscip Rev RNA. 2019;10(1):e1510.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6492194</ArticleId>
+            <ArticleId IdType="pubmed">30311405</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Desrosiers R, Friderici K, Rottman F. Identification of methylated nucleosides in messenger RNA from Novikoff hepatoma cells. Proc Natl Acad Sci U S A. 1974;71(10):3971&#8208;3975.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC434308</ArticleId>
+            <ArticleId IdType="pubmed">4372599</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gao Y, Fang J. RNA 5&#8208;methylcytosine modification and its emerging role as an epitranscriptomic mark. RNA Biol. 2021;18(suppl 1):117&#8208;127.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8677007</ArticleId>
+            <ArticleId IdType="pubmed">34288807</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Huber SM, van Delft P, Mendil L, et&#160;al. Formation and abundance of 5&#8208;hydroxymethylcytosine in RNA. Chembiochem. 2015;16(5):752&#8208;755.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4471624</ArticleId>
+            <ArticleId IdType="pubmed">25676849</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li M, Tao Z, Zhao Y, et&#160;al. 5&#8208;Methylcytosine RNA methyltransferases and their potential roles in cancer. J Transl Med. 2022;20(1):214.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9102922</ArticleId>
+            <ArticleId IdType="pubmed">35562754</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liao H, Gaur A, McConie H, et&#160;al. Human NOP2/NSUN1 regulates ribosome biogenesis through non&#8208;catalytic complex formation with box C/D snoRNPs. Nucleic Acids Res. 2022;50(18):10695&#8208;10716.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9561284</ArticleId>
+            <ArticleId IdType="pubmed">36161484</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>
+Wei H, Jiang S, Chen L, He C, Wu S, Peng H. Characterization of cytosine methylation and the DNA methyltransferases of <i>Toxoplasma gondii</i>
+. Int J Biol Sci. 2017;13(4):458&#8208;470.
+</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5436566</ArticleId>
+            <ArticleId IdType="pubmed">28529454</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang Q, Liu F, Chen W, et&#160;al. The role of RNA m5C modification in cancer metastasis. Int J Biol Sci. 2021;17(13):3369.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8416729</ArticleId>
+            <ArticleId IdType="pubmed">34512153</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chen YS, Yang WL, Zhao YL, Yang YG. Dynamic transcriptomic m(5) C and its regulatory role in RNA processing. Wiley Interdiscip Rev RNA. 2021;12(4):e1639.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">33438329</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang Y, Wang L, Han X, et&#160;al. RNA 5&#8208;methylcytosine facilitates the maternal&#8208;to&#8208;zygotic transition by preventing maternal mRNA decay. Mol Cell. 2019;75(6):1188&#8208;1202. e1111.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">31399345</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tuorto F, Herbst F, Alerasool N, et&#160;al. The tRNA methyltransferase Dnmt2 is required for accurate polypeptide synthesis during haematopoiesis. EMBO J. 2015;34(18):2350&#8208;2362.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4570521</ArticleId>
+            <ArticleId IdType="pubmed">26271101</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Slotkin W, Nishikura K. Adenosine&#8208;to&#8208;inosine RNA editing and human disease. Genome Med. 2013;5(11):1&#8208;13.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3979043</ArticleId>
+            <ArticleId IdType="pubmed">24289319</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wang C, Zou J, Ma X, Wang E, Peng G. Mechanisms and implications of ADAR&#8208;mediated RNA editing in cancer. Cancer Lett. 2017;411:27&#8208;34.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28974449</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>
+Fritzell K, Xu L&#8208;D, Lagergren J, &#214;hman M. ADARs and editing: the role of A&#8208;to&#8208;I RNA modification in cancer progression. <i>Paper presented at: Seminars in Cell &amp; Developmental Biology</i>. 2018;79:123&#8208;130.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">29146145</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rajendren S, Ye X, Dunker W, Richardson A, Karijolich J. The cellular and KSHV A&#8208;to&#8208;I RNA editome in primary effusion lymphoma and its role in the viral lifecycle. Nat Commun. 2023;14(1):1367.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10011561</ArticleId>
+            <ArticleId IdType="pubmed">36914661</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rueter SM, Dawson TR, Emeson RB. Regulation of alternative splicing by RNA editing. Nature. 1999;399(6731):75&#8208;80.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">10331393</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nishikura K. A&#8208;to&#8208;I editing of coding and non&#8208;coding RNAs by ADARs. Nat Rev Mol Cell Biol. 2016;17(2):83&#8208;96.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4824625</ArticleId>
+            <ArticleId IdType="pubmed">26648264</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Eisenberg E, Levanon EY. A&#8208;to&#8208;I RNA editing&#8212;immune protector and transcriptome diversifier. Nat Rev Genet. 2018;19(8):473&#8208;490.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">29692414</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ivanov A, Memczak S, Wyler E, et&#160;al. Analysis of intron sequences reveals hallmarks of circular RNA biogenesis in animals. Cell Rep. 2015;10(2):170&#8208;177.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">25558066</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Stellos K, Gatsiou A, Stamatelopoulos K, et&#160;al. Adenosine&#8208;to&#8208;inosine RNA editing controls cathepsin S expression in atherosclerosis by enabling HuR&#8208;mediated post&#8208;transcriptional regulation. Nat Med. 2016;22(10):1140&#8208;1150.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">27595325</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chan TH, Lin CH, Qi L, et&#160;al. A disrupted RNA editing balance mediated by ADARs (adenosine DeAminases that act on RNA) in human hepatocellular carcinoma. Gut. 2014;63(5):832&#8208;843.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3995272</ArticleId>
+            <ArticleId IdType="pubmed">23766440</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shoshan E, Mobley AK, Braeuer RR, et&#160;al. Reduced adenosine&#8208;to&#8208;inosine miR&#8208;455&#8208;5p editing promotes melanoma growth and metastasis. Nat Cell Biol. 2015;17(3):311&#8208;321.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4344852</ArticleId>
+            <ArticleId IdType="pubmed">25686251</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nakano M, Nakajima M. Significance of A&#8208;to&#8208;I RNA editing of transcripts modulating pharmacokinetics and pharmacodynamics. Pharmacol Ther. 2018;181:13&#8208;21.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28716651</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jain M, Mann TD, Stulic M, et&#160;al. RNA editing of Filamin A pre&#8208;mRNA regulates vascular contraction and diastolic blood pressure. EMBO J. 2018;37(19):e94813.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6166124</ArticleId>
+            <ArticleId IdType="pubmed">30087110</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nakano M, Fukami T, Gotoh S, Nakajima M. A&#8208;to&#8208;I RNA editing up&#8208;regulates human dihydrofolate reductase in breast cancer. J Biol Chem. 2017;292(12):4873&#8208;4884.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5377802</ArticleId>
+            <ArticleId IdType="pubmed">28188287</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Park E, Jiang Y, Hao L, Hui J, Xing Y. Genetic variation and microRNA targeting of A&#8208;to&#8208;I RNA editing fine tune human tissue transcriptomes. Genome Biol. 2021;22(1):77.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7942016</ArticleId>
+            <ArticleId IdType="pubmed">33685485</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dimitrova DG, Teysset L, Carr&#233; C. RNA 2&#8242;&#8208;O&#8208;methylation (Nm) modification in human diseases. Genes. 2019;10(2):117.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6409641</ArticleId>
+            <ArticleId IdType="pubmed">30764532</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Angelova MT, Dimitrova DG, Da Silva B, et&#160;al. tRNA 2&#8242;&#8208;O&#8208;methylation by a duo of TRM7/FTSJ1 proteins modulates small RNA silencing in Drosophila. Nucleic Acids Res. 2020;48(4):2050&#8208;2072.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7038984</ArticleId>
+            <ArticleId IdType="pubmed">31943105</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Drazkowska K, Tomecki R, Warminski M, et&#160;al. 2'&#8208;O&#8208;Methylation of the second transcribed nucleotide within the mRNA 5' cap impacts the protein production level in a cell&#8208;specific manner and contributes to RNA immune evasion. Nucleic Acids Res. 2022;50(16):9051&#8208;9071.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9458431</ArticleId>
+            <ArticleId IdType="pubmed">36018811</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dai Q, Moshitch&#8208;Moshkovitz S, Han D, et&#160;al. Nm&#8208;seq maps 2'&#8208;O&#8208;methylation sites in human mRNA with base precision. Nat Methods. 2017;14(7):695&#8208;698.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5712428</ArticleId>
+            <ArticleId IdType="pubmed">28504680</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ayadi L, Galvanin A, Pichot F, Marchand V, Motorin Y. RNA ribose methylation (2&#697;&#8208;O&#8208;methylation): occurrence, biosynthesis and biological functions. Biochim Biophys Acta Gene Regul Mech. 2019;1862(3):253&#8208;269.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">30572123</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pauli C, Liu Y, Rohde C, et&#160;al. Site&#8208;specific methylation of 18S ribosomal RNA by SNORD42A is required for acute myeloid leukemia cell proliferation. Blood. 2020;135(23):2059&#8208;2070.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">32097467</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li J, Wang YN, Xu BS, et&#160;al. Intellectual disability&#8208;associated gene ftsj1 is responsible for 2&#8242;&#8208;O&#8208;methylation of specific tRNAs. EMBO Rep. 2020;21(8):e50095.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7403668</ArticleId>
+            <ArticleId IdType="pubmed">32558197</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ringeard M, Marchand V, Decroly E, Motorin Y, Bennasser Y. FTSJ3 is an RNA 2&#8242;&#8208;O&#8208;methyltransferase recruited by HIV to avoid innate immune sensing. Nature. 2019;565(7740):500&#8208;504.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">30626973</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>He Q, Yang L, Gao K, et&#160;al. FTSJ1 regulates tRNA 2&#697;&#8208;O&#8208;methyladenosine modification and suppresses the malignancy of NSCLC via inhibiting DRAM1 expression. Cell Death Dis. 2020;11(5):348.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7214438</ArticleId>
+            <ArticleId IdType="pubmed">32393790</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li H, Dong H, Xu B, et&#160;al. A dual role of human tRNA methyltransferase hTrmt13 in regulating translation and transcription. EMBO J. 2022;41(6):e108544.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8922252</ArticleId>
+            <ArticleId IdType="pubmed">34850409</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Inesta&#8208;Vaquera F, Cowling VH. Regulation and function of CMTR1&#8208;dependent mRNA cap methylation. Wiley Interdiscip Rev RNA. 2017;8(6):e1450.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7169794</ArticleId>
+            <ArticleId IdType="pubmed">28971629</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Peng L, Zhang F, Shang R, et&#160;al. Identification of substrates of the small RNA methyltransferase Hen1 in mouse spermatogonial stem cells and analysis of its methyl&#8208;transfer domain. J Biol Chem. 2018;293(26):9981&#8208;9994.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6028966</ArticleId>
+            <ArticleId IdType="pubmed">29703750</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liang H, Jiao Z, Rong W, et&#160;al. 3&#697;&#8208;Terminal 2&#697;&#8208;O&#8208;methylation of lung cancer miR&#8208;21&#8208;5p enhances its stability and association with Argonaute 2. Nucleic Acids Res. 2020;48(13):7027&#8208;7040.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7367198</ArticleId>
+            <ArticleId IdType="pubmed">32542340</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lim SL, Qu ZP, Kortschak RD, et&#160;al. HENMT1 and piRNA stability are required for adult male germ cell transposon repression and to define the spermatogenic program in the mouse. PLoS Genet. 2015;11(10):e1005620.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4619860</ArticleId>
+            <ArticleId IdType="pubmed">26496356</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Elliott BA, Ho HT, Ranganathan SV, et&#160;al. Modification of messenger RNA by 2&#697;&#8208;O&#8208;methylation regulates gene expression in vivo. Nat Commun. 2019;10(1):3401.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6667457</ArticleId>
+            <ArticleId IdType="pubmed">31363086</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Choi J, Indrisiunaite G, DeMirci H, et&#160;al. 2&#697;&#8208;O&#8208;methylation in mRNA disrupts tRNA decoding during translation elongation. Nat Struct Mol Biol. 2018;25(3):208&#8208;216.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5840002</ArticleId>
+            <ArticleId IdType="pubmed">29459784</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu J, Chen C, Wang Y, et&#160;al. Comprehensive of N1&#8208;methyladenosine modifications patterns and immunological characteristics in ovarian cancer. Front Immunol. 2021:12:746647.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8588846</ArticleId>
+            <ArticleId IdType="pubmed">34777359</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang C, Jia G. Reversible RNA modification N(1)&#8208;methyladenosine (m(1)A) in mRNA and tRNA. Genomics Proteomics Bioinform. 2018;16(3):155&#8208;161.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6076376</ArticleId>
+            <ArticleId IdType="pubmed">29908293</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dominissini D, Nachtergaele S, Moshitch&#8208;Moshkovitz S, et&#160;al. The dynamic N(1)&#8208;methyladenosine methylome in eukaryotic messenger RNA. Nature. 2016;530(7591):441&#8208;446.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4842015</ArticleId>
+            <ArticleId IdType="pubmed">26863196</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li X, Xiong X, Wang K, et&#160;al. Transcriptome&#8208;wide mapping reveals reversible and dynamic N(1)&#8208;methyladenosine methylome. Nat Chem Biol. 2016;12(5):311&#8208;316.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">26863410</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Xiong W, Zhao Y, Wei Z, et&#160;al. N1&#8208;methyladenosine formation, gene regulation, biological functions, and clinical relevance. Mol Ther. 2023;31(2):308&#8208;330.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Safra M, Sas&#8208;Chen A, Nir R, et&#160;al. The m1A landscape on cytosolic and mitochondrial mRNA at single&#8208;base resolution. Nature. 2017;551(7679):251&#8208;255.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">29072297</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bar&#8208;Yaacov D, Frumkin I, Yashiro Y, et&#160;al. Mitochondrial 16S rRNA is methylated by tRNA methyltransferase TRMT61B in all vertebrates. PLoS Biol. 2016;14(9):e1002557.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5025228</ArticleId>
+            <ArticleId IdType="pubmed">27631568</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu F, Clark W, Luo G, et&#160;al. ALKBH1&#8208;mediated tRNA demethylation regulates translation. Cell. 2016;167(3):816&#8208;828. e816.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5119773</ArticleId>
+            <ArticleId IdType="pubmed">27745969</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wei J, Liu F, Lu Z, et&#160;al. Differential m(6)A, m(6)A(m), and m(1)A demethylation mediated by FTO in the cell nucleus and cytoplasm. Mol Cell. 2018;71(6):973&#8208;985. e975.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6151148</ArticleId>
+            <ArticleId IdType="pubmed">30197295</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dai X, Wang T, Gonzalez G, Wang Y. Identification of YTH domain&#8208;containing proteins as the readers for N1&#8208;methyladenosine in RNA. Anal Chem. 2018;90(11):6380&#8208;6384.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6157021</ArticleId>
+            <ArticleId IdType="pubmed">29791134</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Seo KW, Kleiner RE. YTHDF2 recognition of N(1)&#8208;methyladenosine (m(1)A)&#8208;modified RNA is associated with transcript destabilization. ACS Chem Biol. 2020;15(1):132&#8208;139.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7025767</ArticleId>
+            <ArticleId IdType="pubmed">31815430</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Woo HH, Chambers SK. Human ALKBH3&#8208;induced m(1)A demethylation increases the CSF&#8208;1 mRNA stability in breast and ovarian cancer cells. Biochim Biophys Acta Gene Regul Mech. 2019;1862(1):35&#8208;46.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">30342176</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wu Y, Chen Z, Xie G, et&#160;al. RNA m(1)A methylation regulates glycolysis of cancer cells through modulating ATP5D. Proc Natl Acad Sci U S A. 2022;119(28):e2119038119.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9282374</ArticleId>
+            <ArticleId IdType="pubmed">35867754</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li X, Xiong X, Zhang M, et&#160;al. Base&#8208;resolution mapping reveals distinct m(1)A methylome in nuclear&#8208; and mitochondrial&#8208;encoded transcripts. Mol Cell. 2017;68(5):993&#8208;1005. e1009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5722686</ArticleId>
+            <ArticleId IdType="pubmed">29107537</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cowling VH. Regulation of mRNA cap methylation. Biochem J. 2010;425(2):295&#8208;302.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC2825737</ArticleId>
+            <ArticleId IdType="pubmed">20025612</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jackson RJ, Hellen CU, Pestova TV. The mechanism of eukaryotic translation initiation and principles of its regulation. Nat Rev Mol Cell Biol. 2010;11(2):113&#8208;127.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4461372</ArticleId>
+            <ArticleId IdType="pubmed">20094052</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang LS, Liu C, Ma H, et&#160;al. Transcriptome&#8208;wide mapping of internal N(7)&#8208;methylguanosine methylome in mammalian mRNA. Mol Cell. 2019;74(6):1304&#8208;1316. e1308.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6588483</ArticleId>
+            <ArticleId IdType="pubmed">31031084</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang LS, Ju CW, Liu C, et&#160;al. m(7)G&#8208;quant&#8208;seq: quantitative detection of RNA internal N(7)&#8208;methylguanosine. ACS Chem Biol. 2022;17(12):3306&#8208;3312.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9764283</ArticleId>
+            <ArticleId IdType="pubmed">36398936</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chu JM, Ye TT, Ma CJ, et&#160;al. Existence of internal N7&#8208;methylguanosine modification in mRNA determined by differential enzyme treatment coupled with mass spectrometry analysis. ACS Chem Biol. 2018;13(12):3243&#8208;3250.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">29313662</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang L&#8208;S, Liu C, Ma H, et&#160;al. Transcriptome&#8208;wide mapping of internal N7&#8208;methylguanosine methylome in mammalian mRNA. Mol Cell. 2019;74(6):1304&#8208;1316. e1308.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6588483</ArticleId>
+            <ArticleId IdType="pubmed">31031084</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Malbec L, Zhang T, Chen Y&#8208;S, et&#160;al. Dynamic methylome of internal mRNA N 7&#8208;methylguanosine and its regulatory role in translation. Cell Res. 2019;29(11):927&#8208;941.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6889513</ArticleId>
+            <ArticleId IdType="pubmed">31520064</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhao Z, Qing Y, Dong L, et&#160;al. QKI shuttles internal m(7)G&#8208;modified transcripts into stress granules and modulates mRNA metabolism. Cell. 2023;186(15):3208&#8208;3226. e3227.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10527483</ArticleId>
+            <ArticleId IdType="pubmed">37379838</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Xia P, Zhang H, Xu K, et&#160;al. MYC&#8208;targeted WDR4 promotes proliferation, metastasis, and sorafenib resistance by inducing CCNB1 translation in hepatocellular carcinoma. Cell Death Dis. 2021;12(7):691.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8270967</ArticleId>
+            <ArticleId IdType="pubmed">34244479</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jin C, Wang T, Zhang D, et&#160;al. Acetyltransferase NAT10 regulates the Wnt/&#946;&#8208;catenin signaling pathway to promote colorectal cancer progression via ac4C acetylation of KIF23 mRNA. J Exp Clin Cancer Res. 2022;41(1):345.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9753290</ArticleId>
+            <ArticleId IdType="pubmed">36522719</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li Q, Liu X, Jin K, et&#160;al. NAT10 is upregulated in hepatocellular carcinoma and enhances mutant p53 activity. BMC Cancer. 2017;17(1):1&#8208;10.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5579925</ArticleId>
+            <ArticleId IdType="pubmed">28859621</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu Z, Liu X, Li Y, et&#160;al. miR&#8208;6716&#8208;5p promotes metastasis of colorectal cancer through downregulating NAT10 expression. Cancer Manag Res. 2019;11:5317.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6559146</ArticleId>
+            <ArticleId IdType="pubmed">31239781</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oh T&#8208;I, Lee Y&#8208;M, Lim B&#8208;O, Lim J&#8208;H. Inhibition of NAT10 suppresses melanogenesis and melanoma growth by attenuating microphthalmia&#8208;associated transcription factor (MITF) expression. Int J Mol Sci. 2017;18(9):1924.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5618573</ArticleId>
+            <ArticleId IdType="pubmed">28880216</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wei W, Zhang S, Han H, et&#160;al. NAT10&#8208;mediated ac4C tRNA modification promotes EGFR mRNA translation and gefitinib resistance in cancer. Cell Rep. 2023;42(7):112810.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">37463108</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liang P, Hu R, Liu Z, Miao M, Jiang H, Li C. NAT10 upregulation indicates a poor prognosis in acute myeloid leukemia. Curr Probl Cancer. 2020;44(2):100491.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">31279531</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zi J, Han Q, Gu S, et&#160;al. Targeting NAT10 induces apoptosis associated with enhancing endoplasmic reticulum stress in acute myeloid leukemia cells. Front Oncol. 2020;10:598107.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7793641</ArticleId>
+            <ArticleId IdType="pubmed">33425753</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wei R, Cui X, Min J, et&#160;al. NAT10 promotes cell proliferation by acetylating CEP170 mRNA to enhance translation efficiency in multiple myeloma. Acta Pharm Sin B. 2022;12(8):3313&#8208;3325.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9366180</ArticleId>
+            <ArticleId IdType="pubmed">35967285</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang Y, Deng Z, Sun S, et&#160;al. NAT10 acetylates BCL&#8208;XL mRNA to promote the proliferation of multiple myeloma cells through PI3K&#8208;AKT pathway. Front Oncol. 2022;12:967811.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9376478</ArticleId>
+            <ArticleId IdType="pubmed">35978804</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li K, Liu J, Yang X, Tu Z, Huang K, Zhu X. Pan&#8208;cancer analysis of N4&#8208;acetylcytidine adaptor THUMPD1 as a predictor for prognosis and immunotherapy. Biosci Rep. 2021;41(12):BSR20212300.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8655504</ArticleId>
+            <ArticleId IdType="pubmed">34762107</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Poncet D, Belleville A, t'Kint de Roodenbeke C, et&#160;al. Changes in the expression of telomere maintenance genes suggest global telomere dysfunction in B&#8208;chronic lymphocytic leukemia. Blood. 2008;111(4):2388&#8208;2391.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">18077792</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rocchi L, Barbosa AJ, Onofrillo C, Del Rio A, Montanaro L. Inhibition of human dyskerin as a new approach to target ribosome biogenesis. PLoS One. 2014;9(7):e101971.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4092089</ArticleId>
+            <ArticleId IdType="pubmed">25010840</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Montanaro L. Dyskerin and cancer: more than telomerase. The defect in mRNA translation helps in explaining how a proliferative defect leads to cancer. J Pathol. 2010;222(4):345&#8208;349.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">20925138</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Su H, Hu J, Huang L, et&#160;al. SHQ1 regulation of RNA splicing is required for T&#8208;lymphoblastic leukemia cell survival. Nat Commun. 2018;9(1):4281.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC6189109</ArticleId>
+            <ArticleId IdType="pubmed">30323192</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guzzi N, Cie&#347;la M, Ngoc PCT, et&#160;al. Pseudouridylation of tRNA&#8208;derived fragments steers translational control in stem cells. Cell. 2018;173(5):1204&#8208;1216. e1226.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">29628141</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guzzi N, Muthukumar S, Cie&#347;la M, et&#160;al. Pseudouridine&#8208;modified tRNA fragments repress aberrant protein synthesis and predict leukaemic progression in myelodysplastic syndrome. Nat Cell Biol. 2022;24(3):299&#8208;306.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8924001</ArticleId>
+            <ArticleId IdType="pubmed">35292784</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>He Y, Yu X, Zhang M, Guo W. Pan&#8208;cancer analysis of m5C regulator genes reveals consistent epigenetic landscape changes in multiple cancers. World J Surg Oncol. 2021;19(1):1&#8208;12.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8323224</ArticleId>
+            <ArticleId IdType="pubmed">34325709</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nombela P, Miguel&#8208;L&#243;pez B, Blanco S. The role of m6A, m5C and &#936; RNA modifications in cancer: novel therapeutic opportunities. Mol Cancer. 2021;20(1):1&#8208;30.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7812662</ArticleId>
+            <ArticleId IdType="pubmed">33461542</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chellamuthu A, Gray SG. The RNA methyltransferase NSUN2 and its potential roles in cancer. Cells. 2020;9(8):1758.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7463552</ArticleId>
+            <ArticleId IdType="pubmed">32708015</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ma B, Wang P. NSUN6, a gene related with m5c methylation, may serve as a biomarker for pan&#8208;cancer. Research Square. 2022.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Cheng JX, Chen L, Li Y, et&#160;al. RNA cytosine methylation and methyltransferases mediate chromatin organization and 5&#8208;azacytidine response and resistance in leukaemia. Nat Commun. 2018;9(1):1163.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5862959</ArticleId>
+            <ArticleId IdType="pubmed">29563491</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schaefer M, Hagemann S, Hanna K, Lyko F. Azacytidine inhibits RNA methylation at DNMT2 target sites in human cancer cell lines. Cancer Res. 2009;69(20):8127&#8208;8132.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">19808971</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Anad&#243;n C, Guil S, Sim&#243;&#8208;Riudalbas L, et&#160;al. Gene amplification&#8208;associated overexpression of the RNA editing enzyme ADAR1 enhances human lung tumorigenesis. Oncogene. 2016;35(33):4407&#8208;4413.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4842009</ArticleId>
+            <ArticleId IdType="pubmed">26640150</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shi L, Yan P, Liang Y, et&#160;al. Circular RNA expression is suppressed by androgen receptor (AR)&#8208;regulated adenosine deaminase that acts on RNA (ADAR1) in human hepatocellular carcinoma. Cell Death Dis. 2017;8(11):e3171.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5775411</ArticleId>
+            <ArticleId IdType="pubmed">29144509</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Qiao J&#8208;J, Chan THM, Qin Y&#8208;R, Chen L. ADAR1: a promising new biomarker for esophageal squamous cell carcinoma? Expert Rev Anticancer Ther. 2014;14(8):865&#8208;868.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">24928581</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jiang Q, Crews LA, Barrett CL, et&#160;al. ADAR1 promotes malignant progenitor reprogramming in chronic myeloid leukemia. Proc Natl Acad Sci U S A. 2013;110(3):1041&#8208;1046.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC3549099</ArticleId>
+            <ArticleId IdType="pubmed">23275297</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zipeto MA, Court AC, Sadarangani A, et&#160;al. ADAR1 activation drives leukemia stem cell self&#8208;renewal by impairing Let&#8208;7 biogenesis. Cell Stem Cell. 2016;19(2):177&#8208;191.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4975616</ArticleId>
+            <ArticleId IdType="pubmed">27292188</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tomaselli S, Galeano F, Alon S, et&#160;al. Modulation of microRNA editing, expression and processing by ADAR2 deaminase in glioblastoma. Genome Biol. 2015;16(1):1&#8208;19.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC4326501</ArticleId>
+            <ArticleId IdType="pubmed">25582055</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guo M, Chan TMH, Zhou Q, et&#160;al. Core&#8208;binding factor fusion downregulation of ADAR2 RNA editing contributes to AML leukemogenesis. Blood. 2023;141(25):3078&#8208;3090.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">36796022</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>You X&#8208;J, Li L, Ji T&#8208;T, Xie N&#8208;B, Yuan B&#8208;F, Feng Y&#8208;Q. 6&#8208;Thioguanine incorporates into RNA and induces adenosine&#8208;to&#8208;inosine editing in acute lymphoblastic leukemia cells. Chin Chem Lett. 2023;34(1):107181.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Lazzari E, Mondala PK, Santos ND, et&#160;al. Alu&#8208;dependent RNA editing of GLI1 promotes malignant regeneration in multiple myeloma. Nat Commun. 2017;8(1):1922.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC5715072</ArticleId>
+            <ArticleId IdType="pubmed">29203771</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hanamura I. Gain/amplification of chromosome arm 1q21 in multiple myeloma. Cancers. 2021;13(2):256.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7827173</ArticleId>
+            <ArticleId IdType="pubmed">33445467</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Crews L, Lazzari E, Mondala P, et&#160;al. ADAR1&#8208;mediated GLI1 editing promotes malignant self&#8208;renewal in multiple myeloma. Blood. 2017;130:1204.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Zhang J, He P, Wang X, Wei S, Ma L, Zhao J. A novel model of tumor&#8208;infiltrating B lymphocyte specific RNA&#8208;binding protein&#8208;related genes with potential prognostic value and therapeutic targets in multiple myeloma. Front Genet. 2021;12:778715.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8719635</ArticleId>
+            <ArticleId IdType="pubmed">34976013</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shi J, Zhu T, Lin H, et&#160;al. Proteotranscriptomics of ocular adnexal B&#8208;cell lymphoma reveals an oncogenic role of alternative splicing and identifies a diagnostic marker. J Exp Clin Cancer Res. 2022;41(1):234.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9338531</ArticleId>
+            <ArticleId IdType="pubmed">35906682</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ohki K, Kiyokawa N, Watanabe S, et&#160;al. Characteristics of genetic alterations of peripheral T&#8208;cell lymphoma in childhood including identification of novel fusion genes: the Japan Children's Cancer Group (JCCG). Br J Haematol. 2021;194(4):718&#8208;729.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">34258755</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pecori R, Ren W, Pirmoradian M, et&#160;al. ADAR1&#8208;mediated RNA editing promotes B cell lymphomagenesis. iScience. 2023;26(6):106864.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10225930</ArticleId>
+            <ArticleId IdType="pubmed">37255666</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zipeto M, Jiang Q, Robertson LC, Jamieson CH. ADAR1&#8208;mediated microRNA regulation and blast crisis leukemia stem cell generation in chronic myeloid leukemia. Cancer Res. 2014;74(19_suppl):1912&#8208;1912.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Huang W, Sun Y&#8208;M, Pan Q, et&#160;al. The snoRNA&#8208;like lncRNA LNC&#8208;SNO49AB drives leukemia by activating the RNA&#8208;editing enzyme ADAR1. Cell Discov. 2022;8(1):117.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9622897</ArticleId>
+            <ArticleId IdType="pubmed">36316318</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gassner FJ, Zaborsky N, Buchumenski I, et&#160;al. RNA editing contributes to epitranscriptome diversity in chronic lymphocytic leukemia. Leukemia. 2021;35(4):1053&#8208;1063.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8024191</ArticleId>
+            <ArticleId IdType="pubmed">32728184</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhou F, Aroua N, Liu Y, et&#160;al. A dynamic rRNA ribomethylome drives stemness in acute myeloid leukemia. Cancer Discov. 2023;13(2):332&#8208;347.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC9900322</ArticleId>
+            <ArticleId IdType="pubmed">36259929</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jiang W, Wang H, Zhou S, et&#160;al. Establishment of a typing model for diffuse large B&#8208;cell lymphoma based on B&#8208;cell receptor repertoire sequencing. BMC Cancer. 2021;21(1):1&#8208;10.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7986026</ArticleId>
+            <ArticleId IdType="pubmed">33752626</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Begik O, Lucas MC, Liu H, Ramirez JM, Mattick JS, Novoa EM. Integrative analyses of the RNA modification machinery reveal tissue&#8208;and cancer&#8208;specific signatures. Genome Biol. 2020;21:1&#8208;24.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7204298</ArticleId>
+            <ArticleId IdType="pubmed">32375858</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhou F, Liu Y, Rohde C, et&#160;al. AML1&#8208;ETO requires enhanced C/D box snoRNA/RNP formation to induce self&#8208;renewal and leukaemia. Nat Cell Biol. 2017;19(7):844&#8208;855.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28650479</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Esteve&#8208;Puig R, Climent F, Pi&#241;eyro D, et&#160;al. Epigenetic loss of m1A RNA demethylase ALKBH3 in Hodgkin lymphoma targets collagen, conferring poor clinical outcome. Blood. 2021;137(7):994&#8208;999.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7918181</ArticleId>
+            <ArticleId IdType="pubmed">32915956</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Assouline S, Culjkovic B, Cocolakis E, et&#160;al. Molecular targeting of the oncogene eIF4E in acute myeloid leukemia (AML): a proof&#8208;of&#8208;principle clinical trial with ribavirin. Blood. 2009;114(2):257&#8208;260.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">19433856</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Orellana EA, Liu Q, Yankova E, et&#160;al. METTL1&#8208;mediated m7G modification of Arg&#8208;TCT tRNA drives oncogenic transformation. Mol Cell. 2021;81(16):3323&#8208;3338. e3314.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8380730</ArticleId>
+            <ArticleId IdType="pubmed">34352207</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Crews LA, Ma W, Ladel L, et&#160;al. Reversal of malignant ADAR1 splice isoform switching with Rebecsinib. Cell Stem Cell. 2023;30(3):250&#8208;263. e256.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC10134781</ArticleId>
+            <ArticleId IdType="pubmed">36803553</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dalhat MH, Altayb HN, Khan MI, Choudhry H. Structural insights of human N&#8208;acetyltransferase 10 and identification of its potential novel inhibitors. Sci Rep. 2021;11(1):6051.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC7960695</ArticleId>
+            <ArticleId IdType="pubmed">33723305</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shrimp JH, Jing Y, Gamage ST, et&#160;al. Remodelin is a cryptic assay interference chemotype that does not inhibit NAT10&#8208;dependent cytidine acetylation. ACS Med Chem Lett. 2020;12(6):887&#8208;892.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pmc">PMC8201477</ArticleId>
+            <ArticleId IdType="pubmed">34141066</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vogler W, Trulock P. Phase I study of pyrazofurin in refractory acute myelogenous leukemia. Cancer Treat Rep. 1978;62(10):1569&#8208;1571.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">152146</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39166619.xml
+++ b/tests/fixtures/pmid_xml/39166619.xml
@@ -1,0 +1,3407 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">39166619</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>08</Month>
+        <Day>21</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2026</Year>
+        <Month>05</Month>
+        <Day>06</Day>
+      </DateRevised>
+      <Article PubModel="Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1678-4170</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>121</Volume>
+            <Issue>7</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Aug</Month>
+              <Day>16</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Arquivos brasileiros de cardiologia</Title>
+          <ISOAbbreviation>Arq Bras Cardiol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Brazilian Guideline on Menopausal Cardiovascular Health - 2024.</ArticleTitle>
+        <Pagination>
+          <StartPage>e20240478</StartPage>
+          <MedlinePgn>e20240478</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="pii" ValidYN="Y">e20240478</ELocationID>
+        <ELocationID EIdType="doi" ValidYN="Y">10.36660/abc.20240478</ELocationID>
+        <ELocationID EIdType="pii" ValidYN="Y">S0066-782X2024000701202</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Oliveira</LastName>
+            <ForeName>Gl&#225;ucia Maria Moraes de</ForeName>
+            <Initials>GMM</Initials>
+            <Identifier Source="ORCID">0000-0002-0737-6188</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal do Rio de Janeiro (UFRJ), Rio de Janeiro, RJ - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Almeida</LastName>
+            <ForeName>Maria Cristina Costa de</ForeName>
+            <Initials>MCC</Initials>
+            <Identifier Source="ORCID">0000-0002-8471-5745</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Centro Universit&#225;rio de Belo Horizonte, Belo Horizonte, MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Arcelus</LastName>
+            <ForeName>Carolina Mar&#237;a Artucio</ForeName>
+            <Initials>CMA</Initials>
+            <Identifier Source="ORCID">0000-0001-9945-7171</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Centro Cardiovascular de Sanatorio Galicia, Montevideo - Uruguai.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Neto Esp&#237;ndola</LastName>
+            <ForeName>Larissa</ForeName>
+            <Initials>L</Initials>
+            <Identifier Source="ORCID">0000-0002-7377-2808</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Santa Izabel, Salvador, BA - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Hospital Municipal de Salvador, Salvador, BA - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rivera</LastName>
+            <ForeName>Maria Alayde Mendon&#231;a</ForeName>
+            <Initials>MAM</Initials>
+            <Identifier Source="ORCID">0000-0003-3322-0459</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Alagoas (UFAL), Macei&#243;, AL - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Silva-Filho</LastName>
+            <ForeName>Agnaldo Lopes da</ForeName>
+            <Initials>ALD</Initials>
+            <Identifier Source="ORCID">0000-0002-8486-7861</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Minas Gerais (UFMG), Belo Horizonte, MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Marques-Santos</LastName>
+            <ForeName>Celi</ForeName>
+            <Initials>C</Initials>
+            <Identifier Source="ORCID">0000-0003-2406-8184</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Tiradentes (UNIT), Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Hospital S&#227;o Lucas Rede D'Or S&#227;o Luis, Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Fernandes</LastName>
+            <ForeName>C&#233;sar Eduardo</ForeName>
+            <Initials>CE</Initials>
+            <Identifier Source="ORCID">0000-0002-7796-6386</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade de Medicina do ABC, Santo Andr&#233;, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Albuquerque</LastName>
+            <ForeName>Carlos Japhet da Matta</ForeName>
+            <Initials>CJDM</Initials>
+            <Identifier Source="ORCID">0000-0001-8161-9400</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Santa Joana Recife, Recife PE - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>EMCOR - Diagn&#243;sticos do Cora&#231;&#227;o LTDA, Recife PE - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Hospital Bar&#227;o de Lucena, Recife PE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Freire</LastName>
+            <ForeName>Claudia Maria Vilas</ForeName>
+            <Initials>CMV</Initials>
+            <Identifier Source="ORCID">0000-0002-1222-7734</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Minas Gerais (UFMG), Belo Horizonte, MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Izar</LastName>
+            <ForeName>Maria Cristina de Oliveira</ForeName>
+            <Initials>MCO</Initials>
+            <Identifier Source="ORCID">0000-0002-5738-2623</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de S&#227;o Paulo (UNIFESP), S&#227;o Paulo, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Costa</LastName>
+            <ForeName>Maria Elizabeth Navegantes Caetano</ForeName>
+            <Initials>MENC</Initials>
+            <Identifier Source="ORCID">0000-0002-1336-6517</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Centro Universit&#225;rio do Estado Par&#225; (CESUPA), Bel&#233;m PA - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Castro</LastName>
+            <ForeName>Marildes Luiza de</ForeName>
+            <Initials>ML</Initials>
+            <Identifier Source="ORCID">0000-0002-9938-8425</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade IPEMED de Ci&#234;ncias M&#233;dicas, Belo Horizonte MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lemke</LastName>
+            <ForeName>Viviana de Mello Guzzo</ForeName>
+            <Initials>VMG</Initials>
+            <Identifier Source="ORCID">0000-0002-0732-9920</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Cardiocare Cl&#237;nica Cardiol&#243;gica, Curitiba PR - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lucena</LastName>
+            <ForeName>Alexandre Jorge Gomes de</ForeName>
+            <Initials>AJG</Initials>
+            <Identifier Source="ORCID">0000-0002-2455-5612</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Agamenom Magalh&#227;es, Recife PE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Brand&#227;o</LastName>
+            <ForeName>Andr&#233;a Araujo</ForeName>
+            <Initials>AA</Initials>
+            <Identifier Source="ORCID">0000-0002-7040-396X</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade do Estado do Rio de Janeiro (UERJ), Rio de Janeiro RJ - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Macedo</LastName>
+            <ForeName>Ariane Vieira Scarlatelli</ForeName>
+            <Initials>AVS</Initials>
+            <Identifier Source="ORCID">0000-0002-3453-8488</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Santa Casa de Miseric&#243;rdia de S&#227;o Paulo, S&#227;o Paulo, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Polanczyk</LastName>
+            <ForeName>Carisi Anne</ForeName>
+            <Initials>CA</Initials>
+            <Identifier Source="ORCID">0000-0002-2447-2577</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital de Cl&#237;nicas da Universidade Federal do Rio Grande do Sul (UFRS), Porto Alegre RS - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Lantieri</LastName>
+            <ForeName>Carla Janice Baister</ForeName>
+            <Initials>CJB</Initials>
+            <Identifier Source="ORCID">0000-0001-9826-9152</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade de Medicina do ABC, Santo Andr&#233;, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Nahas</LastName>
+            <ForeName>Eliana Petri</ForeName>
+            <Initials>EP</Initials>
+            <Identifier Source="ORCID">0000-0002-0803-8535</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de S&#227;o Paulo (UNIFESP), S&#227;o Paulo, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Alexandre</LastName>
+            <ForeName>Elizabeth Regina Giunco</ForeName>
+            <Initials>ERG</Initials>
+            <Identifier Source="ORCID">0000-0002-5210-2848</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital do Cora&#231;&#227;o (HCor), S&#227;o Paulo SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Campana</LastName>
+            <ForeName>Erika Maria Gon&#231;alves</ForeName>
+            <Initials>EMG</Initials>
+            <Identifier Source="ORCID">0000-0002-6352-3330</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade do Estado do Rio de Janeiro (UERJ), Rio de Janeiro RJ - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Bragan&#231;a</LastName>
+            <ForeName>&#201;rika Olivier Vilela</ForeName>
+            <Initials>&#201;OV</Initials>
+            <Identifier Source="ORCID">0000-0002-9168-5513</Identifier>
+            <AffiliationInfo>
+              <Affiliation>RitmoCheck, S&#227;o Jos&#233; dos Campos, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Colombo</LastName>
+            <ForeName>Fernanda Marciano Consolim</ForeName>
+            <Initials>FMC</Initials>
+            <Identifier Source="ORCID">0000-0003-3220-019X</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Instituto do Cora&#231;&#227;o (Incor) do Hospital das Cl&#237;nicas FMUSP, S&#227;o Paulo SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Barbosa</LastName>
+            <ForeName>Imara Correia de Queiroz</ForeName>
+            <Initials>ICQ</Initials>
+            <Identifier Source="ORCID">0000-0003-1090-0443</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Campina Grande, Campina Grande, PB - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rivera</LastName>
+            <ForeName>Ivan Romero</ForeName>
+            <Initials>IR</Initials>
+            <Identifier Source="ORCID">0000-0001-9473-132X</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Alagoas (UFAL), Maceio AL - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Kulak</LastName>
+            <ForeName>Jaime</ForeName>
+            <Initials>J</Initials>
+            <Identifier Source="ORCID">0000-0002-8588-8074</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Macei&#243; AL - BrasilUniversidade Federal do Paran&#225; (UFPR), Curitiba, PR - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Moura</LastName>
+            <ForeName>Lidia Ana Zytynski</ForeName>
+            <Initials>LAZ</Initials>
+            <Identifier Source="ORCID">0000-0002-4741-322X</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Pontif&#237;cia Universidade Cat&#243;lica do Paran&#225; (PUC-PR), Curitiba, PR - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Pompei</LastName>
+            <ForeName>Luciano de Mello</ForeName>
+            <Initials>LM</Initials>
+            <Identifier Source="ORCID">0000-0001-7084-037X</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade de Medicina do ABC, Santo Andr&#233;, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Baccaro</LastName>
+            <ForeName>Luiz Francisco Cintra</ForeName>
+            <Initials>LFC</Initials>
+            <Identifier Source="ORCID">0000-0002-8837-8061</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Estadual de Campinas (UNICAMP), Campinas, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Barbosa</LastName>
+            <ForeName>Marcia Melo</ForeName>
+            <Initials>MM</Initials>
+            <Identifier Source="ORCID">0000-0001-9663-2966</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Socor, Belo Horizonte, MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rodrigues</LastName>
+            <ForeName>Marcio Alexandre Hip&#243;lito</ForeName>
+            <Initials>MAH</Initials>
+            <Identifier Source="ORCID">0000-0002-0969-4614</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Minas Gerais (UFMG), Belo Horizonte, MG - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Albernaz</LastName>
+            <ForeName>Marco Aurelio</ForeName>
+            <Initials>MA</Initials>
+            <Identifier Source="ORCID">0000-0003-1323-9590</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Estadual da Mulher, Goi&#226;nia, GO - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Decoud</LastName>
+            <ForeName>Maria Sotera Paniagua de</ForeName>
+            <Initials>MSP</Initials>
+            <Identifier Source="ORCID">0000-0002-9096-2259</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Sanatorio Italiano, Assun&#231;&#227;o - Paraguai.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Paiva</LastName>
+            <ForeName>Maria Sanali Moura de Oliveira</ForeName>
+            <Initials>MSMO</Initials>
+            <Identifier Source="ORCID">0000-0002-6457-3217</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal do Rio Grande do Norte, Natal, RN - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Sanchez-Zambrano</LastName>
+            <ForeName>Martha Beatriz</ForeName>
+            <Initials>MB</Initials>
+            <Identifier Source="ORCID">0000-0001-6087-0970</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Comit&#233; de Enfermedades Cardiovasculares de la Mujer, Sociedad Venezolana de Cardiolog&#237;a, Caracas - Venezuela.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Campos</LastName>
+            <ForeName>Milena Dos Santos Barros</ForeName>
+            <Initials>MDSB</Initials>
+            <Identifier Source="ORCID">0000-0003-4254-1609</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital S&#227;o Lucas, Rede D'Or S&#227;o Luiz, Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Acevedo</LastName>
+            <ForeName>Monica</ForeName>
+            <Initials>M</Initials>
+            <Identifier Source="ORCID">0000-0002-7989-6633</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Pontificia Universidad Cat&#243;lica de Chile, Santiago - Chile.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ramirez</LastName>
+            <ForeName>Monica Susana</ForeName>
+            <Initials>MS</Initials>
+            <Identifier Source="ORCID">0009-0006-1975-0778</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Privado Rosario, Rosario - Argentina.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Instituto Universitario Rosario (IUNIR), Santa Fe - Argentina.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Souza</LastName>
+            <ForeName>Olga Ferreira de</ForeName>
+            <Initials>OF</Initials>
+            <Identifier Source="ORCID">0000-0001-8722-7504</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Rede D'Or, Rio de Janeiro, RJ - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Medeiros</LastName>
+            <ForeName>Orlando Ot&#225;vio de</ForeName>
+            <Initials>OO</Initials>
+            <Identifier Source="ORCID">0009-0007-6726-1722</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Minist&#233;rio da Sa&#250;de, Bras&#237;lia, DF - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Carvalho</LastName>
+            <ForeName>Regina Coeli Marques de</ForeName>
+            <Initials>RCM</Initials>
+            <Identifier Source="ORCID">0000-0003-4075-3704</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital Geral de Fortaleza, Fortaleza CE - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Secretaria de Sa&#250;de do Estado do Cear&#225;, Fortaleza CE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Machado</LastName>
+            <ForeName>Rogerio Bonassi</ForeName>
+            <Initials>RB</Initials>
+            <Identifier Source="ORCID">0000-0001-9361-0905</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Faculdade de Medicina de Jundia&#237;, Jundia&#237;, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Silva</LastName>
+            <ForeName>Sheyla Cristina Tonheiro Ferro da</ForeName>
+            <Initials>SCTFD</Initials>
+            <Identifier Source="ORCID">0000-0002-6839-1541</Identifier>
+            <AffiliationInfo>
+              <Affiliation>CEMISE Oncocl&#237;nicas, Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Rodrigues</LastName>
+            <ForeName>Thais de Carvalho Vieira</ForeName>
+            <Initials>TCV</Initials>
+            <Identifier Source="ORCID">0000-0001-7136-3536</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital S&#227;o Lucas, Rede D'Or S&#227;o Luiz, Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Universidade Federal de Sergipe (UFS), Aracaju, SE - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Avila</LastName>
+            <ForeName>Walkiria Samuel</ForeName>
+            <Initials>WS</Initials>
+            <Identifier Source="ORCID">0000-0001-5686-7058</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Instituto do Cora&#231;&#227;o (Incor) do Hospital das Cl&#237;nicas FMUSP, S&#227;o Paulo SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Costa-Paiva</LastName>
+            <ForeName>Lucia Helena Sim&#245;es da</ForeName>
+            <Initials>LHSD</Initials>
+            <Identifier Source="ORCID">0000-0002-9088-6700</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Universidade Estadual de Campinas (UNICAMP), Campinas, SP - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Wender</LastName>
+            <ForeName>Maria Celeste Osorio</ForeName>
+            <Initials>MCO</Initials>
+            <Identifier Source="ORCID">0000-0001-9085-4605</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Hospital de Cl&#237;nicas de Porto Alegre, Porto Alegre, RS - Brasil.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <Language>por</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D017065">Practice Guideline</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Diretriz Brasileira sobre a Sa&#250;de Cardiovascular no Climat&#233;rio e na Menopausa &#8211; 2024.</VernacularTitle>
+        <ArticleDate DateType="Electronic">
+          <Year>2024</Year>
+          <Month>08</Month>
+          <Day>16</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Brazil</Country>
+        <MedlineTA>Arq Bras Cardiol</MedlineTA>
+        <NlmUniqueID>0421031</NlmUniqueID>
+        <ISSNLinking>0066-782X</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <CommentsCorrectionsList>
+        <CommentsCorrections RefType="ErratumIn">
+          <RefSource>Arq Bras Cardiol. 2024 Oct;121(10):e20240681. doi: 10.36660/abc.20240681.</RefSource>
+          <PMID Version="1">39607400</PMID>
+        </CommentsCorrections>
+      </CommentsCorrectionsList>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001938" MajorTopicYN="N" Type="Geographic">Brazil</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002318" MajorTopicYN="Y">Cardiovascular Diseases</DescriptorName>
+          <QualifierName UI="Q000517" MajorTopicYN="N">prevention &amp; control</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008593" MajorTopicYN="Y">Menopause</DescriptorName>
+          <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000082742" MajorTopicYN="N">Heart Disease Risk Factors</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012307" MajorTopicYN="N">Risk Factors</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016387" MajorTopicYN="N">Women's Health</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>8</Month>
+          <Day>21</Day>
+          <Hour>17</Hour>
+          <Minute>44</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>8</Month>
+          <Day>21</Day>
+          <Hour>17</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>8</Month>
+          <Day>21</Day>
+          <Hour>7</Hour>
+          <Minute>24</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2024</Year>
+          <Month>7</Month>
+          <Day>30</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>epublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39166619</ArticleId>
+        <ArticleId IdType="pmc">PMC11341215</ArticleId>
+        <ArticleId IdType="doi">10.36660/abc.20240478</ArticleId>
+        <ArticleId IdType="pii">S0066-782X2024000701202</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Rossouw JE, Anderson GL, Prentice RL, LaCroix AZ, Kooperberg C, Stefanick ML, et al. Risks and Benefits of Estrogen Plus Progestin in Healthy Postmenopausal Women: Principal Results from the Women's Health Initiative Randomized Controlled Trial. JAMA. 2002;288(3):321&#8211;333. doi: 10.1001/jama.288.3.321.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.288.3.321</ArticleId>
+            <ArticleId IdType="pubmed">12117397</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Haas JS, Kaplan CP, Gerstenberger EP, Kerlikowske K. Changes in the Use of Postmenopausal Hormone Therapy after the Publication of Clinical Trial Results. Ann Intern Med. 2004;140(3):184&#8211;188. doi: 10.7326/0003-4819-140-3-200402030-00009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-140-3-200402030-00009</ArticleId>
+            <ArticleId IdType="pubmed">14757616</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kelly JP, Kaufman DW, Rosenberg L, Kelley K, Cooper SG, Mitchell AA. Use of Postmenopausal Hormone Therapy Since the Women's Health Initiative Findings. Pharmacoepidemiol Drug Saf. 2005;14(12):837&#8211;842. doi: 10.1002/pds.1103.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/pds.1103</ArticleId>
+            <ArticleId IdType="pubmed">15812877</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Clarke CA, Glaser SL, Uratsu CS, Selby JV, Kushi LH, Herrinton LJ. Recent Declines in Hormone Therapy Utilization and Breast Cancer Incidence: Clinical and Population-based Evidence. J Clin Oncol. 2006;24(33):49&#8211;50. doi: 10.1200/JCO.2006.08.6504.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1200/JCO.2006.08.6504</ArticleId>
+            <ArticleId IdType="pubmed">17114650</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hemminki E, Kennedy DL, Baum C, McKinlay SM. Prescribing of Noncontraceptive Estrogens and Progestins in the United States, 1974-86. Am J Public Health. 1988;78(11):1479&#8211;1481. doi: 10.2105/ajph.78.11.1479.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2105/ajph.78.11.1479</ArticleId>
+            <ArticleId IdType="pmc">PMC1350246</ArticleId>
+            <ArticleId IdType="pubmed">3177727</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wysowski DK, Golden L, Burke L. Use of Menopausal Estrogens and Medroxyprogesterone in the United States, 1982-1992. Obstet Gynecol. 1995;85(1):6&#8211;10. doi: 10.1016/0029-7844(94)00339-f.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0029-7844(94)00339-f</ArticleId>
+            <ArticleId IdType="pubmed">7800326</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hersh AL, Stefanick ML, Stafford RS. National Use of Postmenopausal Hormone Therapy: Annual Trends and Response to Recent Evidence. JAMA. 2004;291(1):47&#8211;53. doi: 10.1001/jama.291.1.47.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.291.1.47</ArticleId>
+            <ArticleId IdType="pubmed">14709575</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hsu A, Card A, Lin SX, Mota S, Carrasquillo O, Moran A. Changes in Postmenopausal Hormone Replacement Therapy Use among Women with High Cardiovascular Risk. Am J Public Health. 2009;99(12):2184&#8211;2187. doi: 10.2105/AJPH.2009.159889.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2105/AJPH.2009.159889</ArticleId>
+            <ArticleId IdType="pmc">PMC2775780</ArticleId>
+            <ArticleId IdType="pubmed">19833984</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sprague BL, Trentham-Dietz A, Cronin KA. A Sustained Decline in Postmenopausal Hormone Use: Results from the National Health and Nutrition Examination Survey, 1999-2010. Obstet Gynecol. 2012;120(3):595&#8211;603. doi: 10.1097/AOG.0b013e318265df42.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/AOG.0b013e318265df42</ArticleId>
+            <ArticleId IdType="pmc">PMC3607288</ArticleId>
+            <ArticleId IdType="pubmed">22914469</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Faubion SS, Shufelt CL. Why is Everyone Talking about Menopause? Maturitas. 2023;177:107777&#8211;107777. doi: 10.1016/j.maturitas.2023.05.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2023.05.001</ArticleId>
+            <ArticleId IdType="pubmed">37268456</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Worldometer  . Current World Population [Internet] New York: Worldometer; 2024.  [cited 2024 Jan 27].  Available from:  https://www.worldometers.info/world-population/
+</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Del-Sueldo MA, Mendon&#231;a-Rivera MA, S&#225;nchez-Zambrano MB, Zilberman J, M&#250;nera-Echeverri AG, Paniagua M, et al. Clinical Practice Guideline of the Interamerican Society of Cardiology on Primary Prevention of Cardiovascular Disease in Women. Arch Cardiol Mex. 2022;92(Supl 2):1&#8211;68. doi: 10.24875/ACM.22000071.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.24875/ACM.22000071</ArticleId>
+            <ArticleId IdType="pmc">PMC9290436</ArticleId>
+            <ArticleId IdType="pubmed">35666723</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oliveira GMM, Almeida MCC, Marques-Santos C, Costa MENC, Carvalho RCM, Freire CMV, et al. Position Statement on Women's Cardiovascular Health - 2022. Arq Bras Cardiol. 2022;119(5):815&#8211;882. doi: 10.36660/abc.20220734.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.36660/abc.20220734</ArticleId>
+            <ArticleId IdType="pmc">PMC10473826</ArticleId>
+            <ArticleId IdType="pubmed">36453774</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>World Health Organization  . WHO Mortality Database. Interactive Platform Visualizing Mortality Data [Internet] Geneva: World Health Organization; 2024.  [cited 2024 Jan 27].  Available from:  https://platform.who.int/mortality/themes/theme-details/topics/topic-details/MDB/cardiovascular-diseases
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Almonte C, Mendon&#231;a-Rivera MA, Artucio C. Toma de la Sociedad Interamericana de Cardiolog&#237;a Sobre el Riesgo Cardiovascular en la Transici&#243;n Menop&#225;usica y en Otras situaciones relacionadas con las hormonas sexuales. Rev Costarric Cardiol. 2023;25(1):5&#8211;8.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Moore KL, Persaud TVN, Torchia MG. Embriologia Cl&#237;nica. 10th ed. Amsterdam: Elsevier; 2016.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Speroff L, Glass RH, Kase NG. Clinical Gynecologic Endocrinology and Infertility. 6th ed. Philadelphia: Lippincott Williams &amp; Wilkins; 1999.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Sultan C, Genazzani AR. Frontiers in Gynecological Endocrinology &#8211; Pediatric and Adolescent Gynecological Endocrinology. Berlin: Springer; 2017.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Miller WL. Androgen Synthesis in Adrenarche. Rev Endocr Metab Disord. 2009;10(1):3&#8211;17. doi: 10.1007/s11154-008-9102-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11154-008-9102-4</ArticleId>
+            <ArticleId IdType="pubmed">18821018</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wright CL, Schwarz JS, Dean SL, McCarthy MM. Cellular Mechanisms of Estradiol-mediated Sexual Differentiation of the Brain. Trends Endocrinol Metab. 2010;21(9):553&#8211;561. doi: 10.1016/j.tem.2010.05.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.tem.2010.05.004</ArticleId>
+            <ArticleId IdType="pmc">PMC2941875</ArticleId>
+            <ArticleId IdType="pubmed">20813326</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rupprecht R, Holsboer F. Neuropsychopharmacological Properties of Neuroactive Steroids. Steroids. 1999;64(1-2):83&#8211;91. doi: 10.1016/s0039-128x(98)00101-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0039-128x(98)00101-9</ArticleId>
+            <ArticleId IdType="pubmed">10323676</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mendelsohn ME. Protective Effects of Estrogen on the Cardiovascular System. Am J Cardiol. 2002;89(12):12&#8211;17. doi: 10.1016/s0002-9149(02)02405-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0002-9149(02)02405-0</ArticleId>
+            <ArticleId IdType="pubmed">12084397</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Reckelhoff JF. Sex Steroids, Cardiovascular Disease, and Hypertension: Unanswered Questions and Some Speculations. Hypertension. 2005;45(2):170&#8211;174. doi: 10.1161/01.HYP.0000151825.36598.36.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/01.HYP.0000151825.36598.36</ArticleId>
+            <ArticleId IdType="pubmed">15583070</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dubey RK, Imthurn B, Barton M, Jackson EK. Vascular Consequences of Menopause and Hormone Therapy: Importance of Timing of Treatment and Type of Estrogen. Cardiovasc Res. 2005;66(2):295&#8211;306. doi: 10.1016/j.cardiores.2004.12.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.cardiores.2004.12.012</ArticleId>
+            <ArticleId IdType="pubmed">15820198</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Walker MD, Shane E. Postmenopausal Osteoporosis. N Engl J Med. 2023;389(21):1979&#8211;1991. doi: 10.1056/NEJMcp2307353.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMcp2307353</ArticleId>
+            <ArticleId IdType="pubmed">37991856</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Takahashi TA, Johnson KM. Menopause. Med Clin North Am. 2015;99(3):521&#8211;534. doi: 10.1016/j.mcna.2015.01.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mcna.2015.01.006</ArticleId>
+            <ArticleId IdType="pubmed">25841598</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Utian WH. Ovarian Function, Therapy-oriented Definition of Menopause and Climacteric. Exp Gerontol. 1994;29(3-4):245&#8211;251. doi: 10.1016/0531-5565(94)90003-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0531-5565(94)90003-5</ArticleId>
+            <ArticleId IdType="pubmed">7925745</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Welt CK. Ovarian Development and Failure (Menopause) in Normal Women. Waltham: UpToDate; 2023.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Shifren JL, Gass ML, NAMS Recommendations for Clinical Care of Midlife Women Working Group The North American Menopause Society Recommendations for Clinical Care of Midlife Women. Menopause. 2014;21(10):1038&#8211;1062. doi: 10.1097/GME.0000000000000319.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000319</ArticleId>
+            <ArticleId IdType="pubmed">25225714</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Federa&#231;&#227;o Brasileira das Associa&#231;&#245;es de Ginecologia e Obstetr&#237;cia . Insufici&#234;ncia Ovariana Prematura. S&#227;o Paulo: Federa&#231;&#227;o Brasileira das Associa&#231;&#245;es de Ginecologia e Obstetr&#237;cia; 2021.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Coulam CB, Adamson SC, Annegers JF. Incidence of Premature Ovarian Failure. Obstet Gynecol. 1986;67(4):604&#8211;606.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">3960433</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Harlow SD, Gass M, Hall JE, Lobo R, Maki P, Rebar RW, et al. Executive Summary of the Stages of Reproductive Aging Workshop + 10: Addressing the Unfinished Agenda of Staging Reproductive Aging. J Clin Endocrinol Metab. 2012;97(4):1159&#8211;1168. doi: 10.1210/jc.2011-3362.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2011-3362</ArticleId>
+            <ArticleId IdType="pmc">PMC3319184</ArticleId>
+            <ArticleId IdType="pubmed">22344196</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Casper RF. Clinical Manifestations and Diagnosis of Menopause. Waltham: UpToDate; 2023.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Voda AM. Climacteric Hot Flash. Maturitas. 1981;3(1):73&#8211;90. doi: 10.1016/0378-5122(81)90022-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0378-5122(81)90022-0</ArticleId>
+            <ArticleId IdType="pubmed">7253937</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kaunitz AM, Manson JE. Management of Menopausal Symptoms. Obstet Gynecol. 2015;126(4):859&#8211;876. doi: 10.1097/AOG.0000000000001058.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/AOG.0000000000001058</ArticleId>
+            <ArticleId IdType="pmc">PMC4594172</ArticleId>
+            <ArticleId IdType="pubmed">26348174</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Freeman EW, Sammel MD, Sanders RJ. Risk of Long-term Hot Flashes after Natural Menopause: Evidence from the Penn Ovarian Aging Study Cohort. Menopause. 2014;21(9):924&#8211;932. doi: 10.1097/GME.0000000000000196.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000196</ArticleId>
+            <ArticleId IdType="pmc">PMC4574289</ArticleId>
+            <ArticleId IdType="pubmed">24473530</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Thurston RC, Joffe H. Vasomotor Symptoms and Menopause: Findings from the Study of Women's Health Across the Nation. Obstet Gynecol Clin North Am. 2011;38(3):489&#8211;501. doi: 10.1016/j.ogc.2011.05.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ogc.2011.05.006</ArticleId>
+            <ArticleId IdType="pmc">PMC3185243</ArticleId>
+            <ArticleId IdType="pubmed">21961716</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Baccaro LFC, Paiva LHSDC, Nasser EJ, Valadares ALR, Silva CRD, Nahas EAP, et al. Initial Evaluation in the Climacteric. Rev Bras Ginecol Obstet. 2022;44(5):548&#8211;556. doi: 10.1055/s-0042-1750282.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1055/s-0042-1750282</ArticleId>
+            <ArticleId IdType="pmc">PMC9948047</ArticleId>
+            <ArticleId IdType="pubmed">35697068</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Faculty of Sexual &amp; Reproductive Healthcare  . Contraception for Women Aged Over 40 Years [Internet] Londres: Faculty of Sexual &amp; Reproductive Healthcare; 2017.  [cited 2023 Dec 11].  Available from:  https://www.fsrh.org/documents/fsrh-guidance-contraception-for-women-aged-over-40-years-2017/
+</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Beksinska ME, Smit JA, Kleinschmidt I, Rees HV, Farley TM, Guidozzi F. Detection of Raised FSH Levels among Older Women Using Depomedroxyprogesterone Acetate and Norethisterone Enanthate. Contraception. 2003;68(5):339&#8211;343. doi: 10.1016/j.contraception.2003.08.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.contraception.2003.08.003</ArticleId>
+            <ArticleId IdType="pubmed">14636937</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mosca L, Hammond G, Mochari-Greenberger H, Towfighi A, Albert MA. American Heart Association Cardiovascular Disease and Stroke in Women and Special Populations Committee of the Council on Clinical Cardiology, Council on Epidemiology and Prevention, Council on Cardiovascular Nursing, Council on High Bloo. Fifteen-Year Trends in Awareness of Heart Disease in Women: Results of a 2012 American Heart Association National Survey. Circulation. 2013;127(11):1254&#8211;1263. doi: 10.1161/CIR.0b013e318287cf2f.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0b013e318287cf2f</ArticleId>
+            <ArticleId IdType="pmc">PMC3684065</ArticleId>
+            <ArticleId IdType="pubmed">23429926</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Stampfer MJ, Colditz GA. Estrogen Replacement Therapy and Coronary Heart Disease: A Quantitative Assessment of the Epidemiologic Evidence. Prev Med. 1991;20(1):47&#8211;63. doi: 10.1016/0091-7435(91)90006-p.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0091-7435(91)90006-p</ArticleId>
+            <ArticleId IdType="pubmed">1826173</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lakatta EG, Levy D. Arterial and Cardiac Aging: Major Shareholders in Cardiovascular Disease Enterprises: Part I: Aging Arteries: A "Set up" for Vascular Disease. Circulation. 2003;107(1):139&#8211;146. doi: 10.1161/01.cir.0000048892.83521.58.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/01.cir.0000048892.83521.58</ArticleId>
+            <ArticleId IdType="pubmed">12515756</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rossi R, Nuzzo A, Origliani G, Modena MG. Prognostic Role of Flow-Mediated Dilation and Cardiac Risk Factors in Post-Menopausal Women. J Am Coll Cardiol. 2008;51(10):997&#8211;1002. doi: 10.1016/j.jacc.2007.11.044.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2007.11.044</ArticleId>
+            <ArticleId IdType="pubmed">18325438</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Taddei S, Virdis A, Ghiadoni L, Mattei P, Sudano I, Bernini G, et al. Menopause is Associated with Endothelial Dysfunction in Women. Hypertension. 1996;28(4):576&#8211;582. doi: 10.1161/01.hyp.28.4.576.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/01.hyp.28.4.576</ArticleId>
+            <ArticleId IdType="pubmed">8843881</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sumino H, Ichikawa S, Kasama S, Takahashi T, Kumakura H, Takayama Y, et al. Different Effects of Oral Conjugated Estrogen and Transdermal Estradiol on Arterial Stiffness and Vascular Inflammatory Markers in Postmenopausal Women. Atherosclerosis. 2006;189(2):436&#8211;442. doi: 10.1016/j.atherosclerosis.2005.12.030.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.atherosclerosis.2005.12.030</ArticleId>
+            <ArticleId IdType="pubmed">16469323</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Stanhewicz AE, Wenner MM, Stachenfeld NS. Sex Differences in Endothelial Function Important to Vascular Health and Overall Cardiovascular Disease Risk Across the Lifespan. Am J Physiol Heart Circ Physiol. 2018;315(6):1569&#8211;1588. doi: 10.1152/ajpheart.00396.2018.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1152/ajpheart.00396.2018</ArticleId>
+            <ArticleId IdType="pmc">PMC6734083</ArticleId>
+            <ArticleId IdType="pubmed">30216121</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Matthews KA, Crawford SL, Chae CU, Everson-Rose SA, Sowers MF, Sternfeld B, et al. Are Changes in Cardiovascular Disease Risk Factors in Midlife Women due to Chronological Aging or to the Menopausal Transition? J Am Coll Cardiol. 2009;54(25):2366&#8211;2373. doi: 10.1016/j.jacc.2009.10.009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2009.10.009</ArticleId>
+            <ArticleId IdType="pmc">PMC2856606</ArticleId>
+            <ArticleId IdType="pubmed">20082925</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Matthews KA, El Khoudary SR, Brooks MM, Derby CA, Harlow SD, Barinas-Mitchell EJ, et al. Lipid Changes Around the Final Menstrual Period Predict Carotid Subclinical Disease in Postmenopausal Women. Stroke. 2017;48(1):70&#8211;76. doi: 10.1161/STROKEAHA.116.014743.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/STROKEAHA.116.014743</ArticleId>
+            <ArticleId IdType="pmc">PMC5183479</ArticleId>
+            <ArticleId IdType="pubmed">27909203</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Samargandy S, Matthews K, Janssen I, Brooks MM, Barinas-Mitchell EJ, Magnani J, et al. Central Arterial Stiffness Increases within One-year Interval of the Final Menstrual Period in Midlife Women: Study of Women's Health Across the Nation (SWAN) Heart. Circulation. 2018;137:362&#8211;362. doi: 10.1161/circ.137.suppl_1.p362.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/circ.137.suppl_1.p362</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lovejoy JC, Champagne CM, de Jonge L, Xie H, Smith SR. Increased Visceral Fat and Decreased Energy Expenditure During the Menopausal Transition. Int J Obes. 2008;32(6):949&#8211;958. doi: 10.1038/ijo.2008.25.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/ijo.2008.25</ArticleId>
+            <ArticleId IdType="pmc">PMC2748330</ArticleId>
+            <ArticleId IdType="pubmed">18332882</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Matthews KA, Abrams B, Crawford S, Miles T, Neer R, Powell LH, et al. Body Mass Index in Mid-Life Women: Relative Influence of Menopause, Hormone Use, and Ethnicity. Int J Obes Relat Metab Disord. 2001;25(6):863&#8211;873. doi: 10.1038/sj.ijo.0801618.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/sj.ijo.0801618</ArticleId>
+            <ArticleId IdType="pubmed">11439301</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Abdulnour J, Doucet E, Brochu M, Lavoie JM, Strychar I, Rabasa-Lhoret R, et al. The Effect of the Menopausal Transition on Body Composition and Cardiometabolic Risk Factors: A Montreal-Ottawa New Emerging Team Group Study. Menopause. 2012;19(7):760&#8211;767. doi: 10.1097/gme.0b013e318240f6f3.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e318240f6f3</ArticleId>
+            <ArticleId IdType="pubmed">22395454</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>El Khoudary SR, Nasr A. Cardiovascular Disease in Women: Does Menopause Matter? Curr Opin Endocr Metab Res. 2022;27:100419&#8211;100419. doi: 10.1016/j.coemr.2022.100419.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.coemr.2022.100419</ArticleId>
+            <ArticleId IdType="pmc">PMC10237361</ArticleId>
+            <ArticleId IdType="pubmed">37274015</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>El Khoudary SR, Aggarwal B, Beckie TM, Hodis HN, Johnson AE, Langer RD, et al. Menopause Transition and Cardiovascular Disease Risk: Implications for Timing of Early Prevention: A Scientific Statement from the American Heart Association. Circulation. 2020;142(25):506&#8211;532. doi: 10.1161/CIR.0000000000000912.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0000000000000912</ArticleId>
+            <ArticleId IdType="pubmed">33251828</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tadic M, Cuspidi C, Grassi G, Ivanovic B. Gender-specific Therapeutic Approach in Arterial Hypertension - Challenges Ahead. Pharmacol Res. 2019;141:181&#8211;188. doi: 10.1016/j.phrs.2018.12.021.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.phrs.2018.12.021</ArticleId>
+            <ArticleId IdType="pubmed">30584913</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wenger NK, Arnold A, Bairey Merz CN, Cooper-DeHoff RM, Ferdinand KC, Fleg JL, et al. Hypertension Across a Woman's Life Cycle. J Am Coll Cardiol. 2018;71(16):1797&#8211;1813. doi: 10.1016/j.jacc.2018.02.033.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2018.02.033</ArticleId>
+            <ArticleId IdType="pmc">PMC6005390</ArticleId>
+            <ArticleId IdType="pubmed">29673470</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Brasil. Minist&#233;rio da Sa&#250;de. Secretaria de Vigil&#226;ncia em Sa&#250;de . Vigil&#226;ncia de Fatores de Risco e Prote&#231;&#227;o para Doen&#231;as Cr&#244;nicas por Inqu&#233;rito Telef&#244;nico: Estimativas sobre Frequ&#234;ncia e Distribui&#231;&#227;o Sociodemogr&#225;fica de Fatores de Risco e Prote&#231;&#227;o para Doen&#231;as Cr&#244;nicas nas Capitais dos 26 Estados Brasileiros e no Distrito Federal em 2021. Bras&#237;lia: Minist&#233;rio da Sa&#250;de; 2021.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Mancia G, Kreutz R, Brunstr&#246;m M, Burnier M, Grassi G, Januszewicz A, et al. 2023 ESH Guidelines for the Management of Arterial Hypertension The Task Force for the Management of Arterial Hypertension of the European Society of Hypertension: Endorsed by the International Society of Hypertension (ISH) and the European Renal Association (ERA) J Hypertens. 2023;41(12):1874&#8211;2071. doi: 10.1097/HJH.0000000000003480.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/HJH.0000000000003480</ArticleId>
+            <ArticleId IdType="pubmed">37345492</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tasi&#263; T, Tadi&#263; M, Lozi&#263; M. Hypertension in Women. Front Cardiovasc Med. 2022;9:905504&#8211;905504. doi: 10.3389/fcvm.2022.905504.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fcvm.2022.905504</ArticleId>
+            <ArticleId IdType="pmc">PMC9203893</ArticleId>
+            <ArticleId IdType="pubmed">35722103</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Moretti C, Lanzolla G, Moretti M, Gnessi L, Carmina E. Androgens and Hypertension in Men and Women: A Unifying View. Curr Hypertens Rep. 2017;19(5):44&#8211;44. doi: 10.1007/s11906-017-0740-3.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11906-017-0740-3</ArticleId>
+            <ArticleId IdType="pubmed">28455674</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gerdts E, Sudano I, Brouwers S, Borghi C, Bruno RM, Ceconi C, et al. Sex Differences in Arterial Hypertension. Eur Heart J. 2022;43(46):4777&#8211;4788. doi: 10.1093/eurheartj/ehac470.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehac470</ArticleId>
+            <ArticleId IdType="pmc">PMC9726450</ArticleId>
+            <ArticleId IdType="pubmed">36136303</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Opoku AA, Abushama M, Konje JC. Obesity and Menopause. Best Pract Res Clin Obstet Gynaecol. 2023;88:102348&#8211;102348. doi: 10.1016/j.bpobgyn.2023.102348.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.bpobgyn.2023.102348</ArticleId>
+            <ArticleId IdType="pubmed">37244787</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>El Khoudary SR, Greendale G, Crawford SL, Avis NE, Brooks MM, Thurston RC, et al. The Menopause Transition and Women's Health at Midlife: A Progress Report from the Study of Women's Health Across the Nation (SWAN) Menopause. 2019;26(10):1213&#8211;1227. doi: 10.1097/GME.0000000000001424.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000001424</ArticleId>
+            <ArticleId IdType="pmc">PMC6784846</ArticleId>
+            <ArticleId IdType="pubmed">31568098</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Paramsothy P, Harlow SD, Nan B, Greendale GA, Santoro N, Crawford SL, et al. Duration of the Menopausal Transition is Longer in Women with Young Age at Onset: The Multiethnic Study of Women's Health Across the Nation. Menopause. 2017;24(2):142&#8211;149. doi: 10.1097/GME.0000000000000736.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000736</ArticleId>
+            <ArticleId IdType="pmc">PMC5266650</ArticleId>
+            <ArticleId IdType="pubmed">27676632</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Naufel MF, Frange C, Andersen ML, Gir&#227;o MJBC, Tufik S, Ribeiro EB, et al. Association between Obesity and Sleep Disorders in Postmenopausal Women. Menopause. 2018;25(2):139&#8211;144. doi: 10.1097/GME.0000000000000962.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000962</ArticleId>
+            <ArticleId IdType="pubmed">28926516</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nappi RE, Chedraui P, Lambrinoudaki I, Simoncini T. Menopause: A Cardiometabolic Transition. Lancet Diabetes Endocrinol. 2022;10(6):442&#8211;456. doi: 10.1016/S2213-8587(22)00076-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S2213-8587(22)00076-6</ArticleId>
+            <ArticleId IdType="pubmed">35525259</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Caretto M, Giannini A, Simoncini T, Genazzani AR. Obesity, Menopause, and Hormone Replacement Therapy. Amsterdam: Elsevier; 2020.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Hallajzadeh J, Khoramdad M, Izadi N, Karamzad N, Almasi-Hashiani A, Ayubi E, et al. Metabolic Syndrome and its Components in Premenopausal and Postmenopausal Women: A Comprehensive Systematic Review and Meta-analysis on Observational Studies. Menopause. 2018;25(10):1155&#8211;1164. doi: 10.1097/GME.0000000000001136.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000001136</ArticleId>
+            <ArticleId IdType="pubmed">29787477</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Meloni A, Cadeddu C, Cugusi L, Donataccio MP, Deidda M, Sciomer S, et al. Gender Differences and Cardiometabolic Risk: The Importance of the Risk Factors. Int J Mol Sci. 2023;24(2):1588&#8211;1588. doi: 10.3390/ijms24021588.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3390/ijms24021588</ArticleId>
+            <ArticleId IdType="pmc">PMC9864423</ArticleId>
+            <ArticleId IdType="pubmed">36675097</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gurka MJ, Vishnu A, Santen RJ, De Boer MD. Progression of Metabolic Syndrome Severity During the Menopausal Transition. J Am Heart Assoc. 2016;5(8):e003609. doi: 10.1161/JAHA.116.003609.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.116.003609</ArticleId>
+            <ArticleId IdType="pmc">PMC5015287</ArticleId>
+            <ArticleId IdType="pubmed">27487829</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mumusoglu S, Yildiz BO. Metabolic Syndrome During Menopause. Curr Vasc Pharmacol. 2019;17(6):595&#8211;603. doi: 10.2174/1570161116666180904094149.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2174/1570161116666180904094149</ArticleId>
+            <ArticleId IdType="pubmed">30179134</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ekelund U, Tarp J, Steene-Johannessen J, Hansen BH, Jefferis B, Fagerland MW, et al. Dose-response Associations between Accelerometry Measured Physical Activity and Sedentary Time and All Cause Mortality: Systematic Review and Harmonised Meta-analysis. BMJ. 2019;366:l4570&#8211;l4570. doi: 10.1136/bmj.l4570.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.l4570</ArticleId>
+            <ArticleId IdType="pmc">PMC6699591</ArticleId>
+            <ArticleId IdType="pubmed">31434697</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Patterson R, McNamara E, Tainio M, de S&#225; TH, Smith AD, Sharp SJ, et al. Sedentary Behaviour and Risk of All-cause, Cardiovascular and Cancer Mortality, and Incident Type 2 Diabetes: A Systematic Review and Dose Response Meta-analysis. Eur J Epidemiol. 2018;33(9):811&#8211;829. doi: 10.1007/s10654-018-0380-1.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s10654-018-0380-1</ArticleId>
+            <ArticleId IdType="pmc">PMC6133005</ArticleId>
+            <ArticleId IdType="pubmed">29589226</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li T, Zhang L. Effect of Exercise on Cardiovascular Risk in Sedentary Postmenopausal Women: A Systematic Review and Meta-analysis. Ann Palliat Med. 2023;12(1):150&#8211;162. doi: 10.21037/apm-22-1395.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.21037/apm-22-1395</ArticleId>
+            <ArticleId IdType="pubmed">36747389</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lloyd-Jones DM, Allen NB, Anderson CAM, Black T, Brewer LC, Foraker RE, et al. Life's Essential 8: Updating and Enhancing the American Heart Association's Construct of Cardiovascular Health: A Presidential Advisory from the American Heart Association. Circulation. 2022;146(5):18&#8211;43. doi: 10.1161/CIR.0000000000001078.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0000000000001078</ArticleId>
+            <ArticleId IdType="pmc">PMC10503546</ArticleId>
+            <ArticleId IdType="pubmed">35766027</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Creasy SA, Crane TE, Garcia DO, Thomson CA, Kohler LN, Wertheim BC, et al. Higher Amounts of Sedentary Time are Associated with Short Sleep Duration and Poor Sleep Quality in Postmenopausal Women. Sleep. 2019;42(7):zsz093&#8211;zsz093. doi: 10.1093/sleep/zsz093.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/sleep/zsz093</ArticleId>
+            <ArticleId IdType="pmc">PMC6612671</ArticleId>
+            <ArticleId IdType="pubmed">30994175</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>LaMonte MJ, Larson JC, Manson JE, Bellettiere J, Lewis CE, LaCroix AZ, et al. Association of Sedentary Time and Incident Heart Failure Hospitalization in Postmenopausal Women. Circ Heart Fail. 2020;13(12):e007508. doi: 10.1161/CIRCHEARTFAILURE.120.007508.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCHEARTFAILURE.120.007508</ArticleId>
+            <ArticleId IdType="pmc">PMC7738397</ArticleId>
+            <ArticleId IdType="pubmed">33228398</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Marin-Neto JA, Sim&#245;es MV. The Role of the Sympathetic Nervous System in Heart Failure. Rev. Soc. Cardiol. 2014;24(2):26&#8211;33.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kanis JA, Cooper C, Rizzoli R, Reginster JY. European Guidance for the Diagnosis and Management of Osteoporosis in Postmenopausal Women. Osteoporos Int. 2019;30(1):3&#8211;44. doi: 10.1007/s00198-018-4704-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s00198-018-4704-5</ArticleId>
+            <ArticleId IdType="pmc">PMC7026233</ArticleId>
+            <ArticleId IdType="pubmed">30324412</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dixon-Suen SC, Lewis SJ, Martin RM, English DR, Boyle T, Giles GG, et al. Physical Activity, Sedentary Time and Breast Cancer Risk: A Mendelian Randomisation Study. Br J Sports Med. 2022;56(20):1157&#8211;1170. doi: 10.1136/bjsports-2021-105132.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bjsports-2021-105132</ArticleId>
+            <ArticleId IdType="pmc">PMC9876601</ArticleId>
+            <ArticleId IdType="pubmed">36328784</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Brasil. Minist&#233;rio da Sa&#250;de . Guia de Atividade F&#237;sica para a Popula&#231;&#227;o Brasileira. Bras&#237;lia: Minist&#233;rio da Sa&#250;de; 2021.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Bull FC, Al-Ansari SS, Biddle S, Borodulin K, Buman MP, Cardon G, et al. World Health Organization 2020 Guidelines on Physical Activity and Sedentary Behaviour. Br J Sports Med. 2020;54(24):1451&#8211;1462. doi: 10.1136/bjsports-2020-102955.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bjsports-2020-102955</ArticleId>
+            <ArticleId IdType="pmc">PMC7719906</ArticleId>
+            <ArticleId IdType="pubmed">33239350</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhu D, Chung HF, Pandeya N, Dobson AJ, Cade JE, Greenwood DC, et al. Relationships between Intensity, Duration, Cumulative Dose, and Timing of Smoking with Age at Menopause: A Pooled Analysis of Individual Data from 17 Observational Studies. PLoS Med. 2018;15(11):e1002704. doi: 10.1371/journal.pmed.1002704.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1371/journal.pmed.1002704</ArticleId>
+            <ArticleId IdType="pmc">PMC6258514</ArticleId>
+            <ArticleId IdType="pubmed">30481189</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Stewart AL, Barinas-Mitchell E, Matthews KA, El Khoudary SR, Magnani JW, Jackson EA, et al. Social Role-Related Stress and Social Role-Related Reward as Related to Subsequent Subclinical Cardiovascular Disease in a Longitudinal Study of Midlife Women: The Study of Women's Health Across the Nation. Psychosom Med. 2019;81(9):821&#8211;832. doi: 10.1097/PSY.0000000000000733.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/PSY.0000000000000733</ArticleId>
+            <ArticleId IdType="pmc">PMC6832794</ArticleId>
+            <ArticleId IdType="pubmed">31299023</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Janssen I, Powell LH, Matthews KA, Jasielec MS, Hollenberg SM, Bromberger JT, et al. Relation of Persistent Depressive Symptoms to Coronary Artery Calcification in Women Aged 46 to 59 Years. Am J Cardiol. 2016;117(12):1884&#8211;1889. doi: 10.1016/j.amjcard.2016.03.035.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.amjcard.2016.03.035</ArticleId>
+            <ArticleId IdType="pmc">PMC4885775</ArticleId>
+            <ArticleId IdType="pubmed">27138181</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wassertheil-Smoller S, Shumaker S, Ockene J, Talavera GA, Greenland P, Cochrane B, et al. Depression and Cardiovascular Sequelae in Postmenopausal Women. The Women's Health Initiative (WHI) Arch Intern Med. 2004;164(3):289&#8211;298. doi: 10.1001/archinte.164.3.289.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/archinte.164.3.289</ArticleId>
+            <ArticleId IdType="pubmed">14769624</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Herson M, Kulkarni J. Hormonal Agents for the Treatment of Depression Associated with the Menopause. Drugs Aging. 2022;39(8):607&#8211;618. doi: 10.1007/s40266-022-00962-x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s40266-022-00962-x</ArticleId>
+            <ArticleId IdType="pmc">PMC9355926</ArticleId>
+            <ArticleId IdType="pubmed">35908135</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Koudouovoh-Tripp P, H&#252;fner K, Egeter J, Kandler C, Giesinger JM, Sopper S, et al. Stress Enhances Proinflammatory Platelet Activity: The Impact of Acute and Chronic Mental Stress. J Neuroimmune Pharmacol. 2021;16(2):500&#8211;512. doi: 10.1007/s11481-020-09945-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11481-020-09945-4</ArticleId>
+            <ArticleId IdType="pmc">PMC8087592</ArticleId>
+            <ArticleId IdType="pubmed">32757120</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Assad J, Femia G, Pender P, Badie T, Rajaratnam R. Takotsubo Syndrome: A Review of Presentation, Diagnosis and Management. Clin Med Insights Cardiol. 2022;16:11795468211065782&#8211;11795468211065782. doi: 10.1177/11795468211065782.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/11795468211065782</ArticleId>
+            <ArticleId IdType="pmc">PMC8733363</ArticleId>
+            <ArticleId IdType="pubmed">35002350</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ko SH, Kim HS. Menopause-Associated Lipid Metabolic Disorders and Foods Beneficial for Postmenopausal Women. Nutrients. 2020;12(1):202&#8211;202. doi: 10.3390/nu12010202.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3390/nu12010202</ArticleId>
+            <ArticleId IdType="pmc">PMC7019719</ArticleId>
+            <ArticleId IdType="pubmed">31941004</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Izar MCO, Fonseca FAH. Risk Factors in Women: Classical and Specific. Rev Soc Cardiol Estado de S&#227;o Paulo. 2023;33(2):264&#8211;270. doi: 10.29381/0103-8559/20233302264-70.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.29381/0103-8559/20233302264-70</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kok HS, van Asselt KM, van der Schouw YT, van der Tweel I, Peeters PH, Wilson PW, et al. Heart Disease Risk Determines Menopausal Age Rather Than the Reverse. J Am Coll Cardiol. 2006;47(10):1976&#8211;1983. doi: 10.1016/j.jacc.2005.12.066.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2005.12.066</ArticleId>
+            <ArticleId IdType="pubmed">16697313</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhu D, Chung HF, Pandeya N, Dobson AJ, Hardy R, Kuh D, et al. Premenopausal Cardiovascular Disease and Age at Natural Menopause: A Pooled Analysis of Over 170,000 Women. Eur J Epidemiol. 2019;34(3):235&#8211;246. doi: 10.1007/s10654-019-00490-w.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s10654-019-00490-w</ArticleId>
+            <ArticleId IdType="pubmed">30721378</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rosenson RS, Brewer HB, Jr, Chapman MJ, Fazio S, Hussain MM, Kontush A, et al. HDL Measures, Particle Heterogeneity, Proposed Nomenclature, and Relation to Atherosclerotic Cardiovascular Events. Clin Chem. 2011;57(3):392&#8211;410. doi: 10.1373/clinchem.2010.155333.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1373/clinchem.2010.155333</ArticleId>
+            <ArticleId IdType="pubmed">21266551</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>van Lennep JER, Tokg&#246;zo&#287;lu LS, Badimon L, Dumanski SM, Gulati M, Hess CN, et al. Women, Lipids, and Atherosclerotic Cardiovascular Disease: A Call to Action from the European Atherosclerosis Society. Eur Heart J. 2023;44(39):4157&#8211;4173. doi: 10.1093/eurheartj/ehad472.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehad472</ArticleId>
+            <ArticleId IdType="pmc">PMC10576616</ArticleId>
+            <ArticleId IdType="pubmed">37611089</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Paschou SA, Papanas N. Type 2 Diabetes Mellitus and Menopausal Hormone Therapy: An Update. Diabetes Ther. 2019;10(6):2313&#8211;2320. doi: 10.1007/s13300-019-00695-y.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s13300-019-00695-y</ArticleId>
+            <ArticleId IdType="pmc">PMC6848654</ArticleId>
+            <ArticleId IdType="pubmed">31549295</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yoshida Y, Chen Z, Baudier RL, Krousel-Wood M, Anderson AH, Fonseca VA, et al. Early Menopause and Cardiovascular Disease Risk in Women with or without Type 2 Diabetes: A Pooled Analysis of 9,374 Postmenopausal Women. Diabetes Care. 2021;44(11):2564&#8211;2572. doi: 10.2337/dc21-1107.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2337/dc21-1107</ArticleId>
+            <ArticleId IdType="pmc">PMC8546283</ArticleId>
+            <ArticleId IdType="pubmed">34475032</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Brandt EJ, Tobb K, Cambron JC, Ferdinand K, Douglass P, Nguyen PK, et al. Assessing and Addressing Social Determinants of Cardiovascular Health: JACC State-of-the-Art Review. J Am Coll Cardiol. 2023;81(14):1368&#8211;1385. doi: 10.1016/j.jacc.2023.01.042.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2023.01.042</ArticleId>
+            <ArticleId IdType="pmc">PMC11103489</ArticleId>
+            <ArticleId IdType="pubmed">37019584</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mirhaghjou SN, Niknami M, Moridi M, Pakseresht S, Kazemnejad E. Quality of Life and its Determinants in Postmenopausal Women: A Population-based Study. Appl Nurs Res. 2016;30:252&#8211;256. doi: 10.1016/j.apnr.2015.10.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.apnr.2015.10.004</ArticleId>
+            <ArticleId IdType="pubmed">27091286</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Namazi M, Sadeghi R, Behboodi Moghadam Z. Social Determinants of Health in Menopause: An Integrative Review. Int J Womens Health. 2019;11:637&#8211;647. doi: 10.2147/IJWH.S228594.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2147/IJWH.S228594</ArticleId>
+            <ArticleId IdType="pmc">PMC6910086</ArticleId>
+            <ArticleId IdType="pubmed">31849539</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Triebner K, Markevych I, Hustad S, Benediktsd&#243;ttir B, Forsberg B, Franklin KA, et al. Residential Surrounding Greenspace and Age at Menopause: A 20-year European Study (ECRHS) Environ Int. 2019;132:105088&#8211;105088. doi: 10.1016/j.envint.2019.105088.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.envint.2019.105088</ArticleId>
+            <ArticleId IdType="pubmed">31437647</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Garcia M, Mulvagh SL, Merz CN, Buring JE, Manson JE. Cardiovascular Disease in Women: Clinical Perspectives. Circ Res. 2016;118(8):1273&#8211;1293. doi: 10.1161/CIRCRESAHA.116.307547.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCRESAHA.116.307547</ArticleId>
+            <ArticleId IdType="pmc">PMC4834856</ArticleId>
+            <ArticleId IdType="pubmed">27081110</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Manson JE, Woodruff TK. Reproductive Health as a Marker of Subsequent Cardiovascular Disease: The Role of Estrogen. JAMA Cardiol. 2016;1(7):776&#8211;777. doi: 10.1001/jamacardio.2016.2662.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamacardio.2016.2662</ArticleId>
+            <ArticleId IdType="pmc">PMC5120648</ArticleId>
+            <ArticleId IdType="pubmed">27626902</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kannel WB, Hjortland MC, McNamara PM, Gordon T. Menopause and Risk of Cardiovascular Disease: The Framingham Study. Ann Intern Med. 1976;85(4):447&#8211;452. doi: 10.7326/0003-4819-85-4-447.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-85-4-447</ArticleId>
+            <ArticleId IdType="pubmed">970770</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kami&#324;ska MS, Schneider-Matyka D, Rachubi&#324;ska K, Panczyk M, Grochans E, Cybulska AM. Menopause Predisposes Women to Increased Risk of Cardiovascular Disease. J Clin Med. 2023;12(22):7058&#8211;7058. doi: 10.3390/jcm12227058.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3390/jcm12227058</ArticleId>
+            <ArticleId IdType="pmc">PMC10672665</ArticleId>
+            <ArticleId IdType="pubmed">38002671</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Freaney PM, Khan SS, Lloyd-Jones DM, Stone NJ. The Role of Sex-Specific Risk Factors in the Risk Assessment of Atherosclerotic Cardiovascular Disease for Primary Prevention in Women. Curr Atheroscler Rep. 2020;22(9):46&#8211;46. doi: 10.1007/s11883-020-00864-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11883-020-00864-6</ArticleId>
+            <ArticleId IdType="pmc">PMC7889439</ArticleId>
+            <ArticleId IdType="pubmed">32671475</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chu JH, Michos ED, Ouyang P, Vaidya D, Blumenthal RS, Budoff MJ, et al. Coronary Artery Calcium and Atherosclerotic Cardiovascular Disease Risk in Women with Early Menopause: The Multi-Ethnic Study of Atherosclerosis (MESA) Am J Prev Cardiol. 2022;11:100362&#8211;100362. doi: 10.1016/j.ajpc.2022.100362.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ajpc.2022.100362</ArticleId>
+            <ArticleId IdType="pmc">PMC9234594</ArticleId>
+            <ArticleId IdType="pubmed">35769201</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Johnston N, Schenck-Gustafsson K, Lagerqvist B. Are We Using Cardiovascular Medications and Coronary Angiography Appropriately in Men and Women with Chest Pain? Eur Heart J. 2011;32(11):1331&#8211;1336. doi: 10.1093/eurheartj/ehr009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehr009</ArticleId>
+            <ArticleId IdType="pubmed">21317147</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Krentz AJ, von M&#252;hlen D, Barrett-Connor E. Searching for Polycystic Ovary Syndrome in Postmenopausal Women: Evidence of a Dose-effect Association with Prevalent Cardiovascular Disease. Menopause. 2007;14(2):284&#8211;292. doi: 10.1097/GME.0b013e31802cc7ab.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0b013e31802cc7ab</ArticleId>
+            <ArticleId IdType="pmc">PMC2642654</ArticleId>
+            <ArticleId IdType="pubmed">17245231</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kalantaridou SN, Naka KK, Bechlioulis A, Makrigiannakis A, Michalis L, Chrousos GP. Premature Ovarian Failure, Endothelial Dysfunction and Estrogen-progestogen Replacement. Trends Endocrinol Metab. 2006;17(3):101&#8211;109. doi: 10.1016/j.tem.2006.02.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.tem.2006.02.003</ArticleId>
+            <ArticleId IdType="pubmed">16515863</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jacobsen BK, Nilssen S, Heuch I, Kv&#229;le G. Does Age at Natural Menopause Affect Mortality from Ischemic Heart Disease? J Clin Epidemiol. 1997;50(4):475&#8211;479. doi: 10.1016/s0895-4356(96)00425-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0895-4356(96)00425-8</ArticleId>
+            <ArticleId IdType="pubmed">9179106</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yang L, Lin L, Kartsonaki C, Guo Y, Chen Y, Bian Z, et al. Menopause Characteristics, Total Reproductive Years, and Risk of Cardiovascular Disease among Chinese Women. Circ Cardiovasc Qual Outcomes. 2017;10(11):e004235. doi: 10.1161/CIRCOUTCOMES.117.004235.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCOUTCOMES.117.004235</ArticleId>
+            <ArticleId IdType="pmc">PMC5704734</ArticleId>
+            <ArticleId IdType="pubmed">29117982</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hochman JS, Tamis JE, Thompson TD, Weaver WD, White HD, Van de Werf F, et al. Sex, Clinical Presentation, and Outcome in Patients with Acute Coronary Syndromes. Global Use of Strategies to Open Occluded Coronary Arteries in Acute Coronary Syndromes IIb Investigators. N Engl J Med. 1999;341(4):226&#8211;232. doi: 10.1056/NEJM199907223410402.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJM199907223410402</ArticleId>
+            <ArticleId IdType="pubmed">10413734</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Thygesen K, Alpert JS, Jaffe AS, Simoons ML, Chaitman BR, White HD, et al. Third Universal Definition of Myocardial Infarction. Circulation. 2012;126(16):2020&#8211;2035. doi: 10.1161/CIR.0b013e31826e1058.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0b013e31826e1058</ArticleId>
+            <ArticleId IdType="pubmed">22923432</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tweet MS, Hayes SN, Pitta SR, Simari RD, Lerman A, Lennon RJ, et al. Clinical Features, Management, and Prognosis of Spontaneous Coronary Artery Dissection. Circulation. 2012;126(5):579&#8211;588. doi: 10.1161/CIRCULATIONAHA.112.105718.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCULATIONAHA.112.105718</ArticleId>
+            <ArticleId IdType="pubmed">22800851</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Szmuilowicz ED, Manson JE, Rossouw JE, Howard BV, Margolis KL, Greep NC, et al. Vasomotor Symptoms and Cardiovascular Events in Postmenopausal Women. Menopause. 2011;18(6):603&#8211;610. doi: 10.1097/gme.0b013e3182014849.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e3182014849</ArticleId>
+            <ArticleId IdType="pmc">PMC3123435</ArticleId>
+            <ArticleId IdType="pubmed">21358352</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wei J, Mehta PK, Johnson BD, Samuels B, Kar S, Anderson RD, et al. Safety of Coronary Reactivity Testing in Women with no Obstructive Coronary Artery Disease: Results from the NHLBI-sponsored WISE (Women's Ischemia Syndrome Evaluation) Study. JACC Cardiovasc Interv. 2012;5(6):646&#8211;653. doi: 10.1016/j.jcin.2012.01.023.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jcin.2012.01.023</ArticleId>
+            <ArticleId IdType="pmc">PMC3417766</ArticleId>
+            <ArticleId IdType="pubmed">22721660</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Merz CNB, Shufelt C, Johnson BD, Azziz R, Braunstein GD. Reproductive Hormone Exposure Timing and Ischemic Heart Disease: Complicated Answers to a Simple Question. Maturitas. 2010;65(4):297&#8211;298. doi: 10.1016/j.maturitas.2010.01.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2010.01.003</ArticleId>
+            <ArticleId IdType="pmc">PMC2856326</ArticleId>
+            <ArticleId IdType="pubmed">20089376</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shufelt C, Waldman T, Wang E, Merz CN. Female-specific Factors for IHD: Across the Reproductive Lifespan. Curr Atheroscler Rep. 2015;17(2):481&#8211;481. doi: 10.1007/s11883-014-0481-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11883-014-0481-6</ArticleId>
+            <ArticleId IdType="pubmed">25620277</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Elias-Smale SE, G&#252;nal A, Maas AH. Gynecardiology: Distinct Patterns of Ischemic Heart Disease in Middle-aged Women. Maturitas. 2015;81(3):348&#8211;352. doi: 10.1016/j.maturitas.2015.04.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2015.04.012</ArticleId>
+            <ArticleId IdType="pubmed">26006301</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yoon CW, Bushnell CD. Stroke in Women: A Review Focused on Epidemiology, Risk Factors, and Outcomes. J Stroke. 2023;25(1):2&#8211;15. doi: 10.5853/jos.2022.03468.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.5853/jos.2022.03468</ArticleId>
+            <ArticleId IdType="pmc">PMC9911842</ArticleId>
+            <ArticleId IdType="pubmed">36746378</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>World Stroke Organization . Global Stroke Fact Sheet 2022. Geneva: World Stroke Organization; 2022.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Amarenco P, Lavall&#233;e PC, Tavares LM, Labreuche J, Albers GW, Abboud H, et al. Five-Year Risk of Stroke after TIA or Minor Ischemic Stroke. N Engl J Med. 2018;378(23):2182&#8211;2190. doi: 10.1056/NEJMoa1802712.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1802712</ArticleId>
+            <ArticleId IdType="pubmed">29766771</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Xu M, Vallejo AA, Cantalapiedra Calvete C, Rudd A, Wolfe C, O'Connell MDL, Douiri A. Stroke Outcomes in Women: A Population-Based Cohort Study. Stroke. 2022;53(10):3072&#8211;3081. doi: 10.1161/STROKEAHA.121.037829.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/STROKEAHA.121.037829</ArticleId>
+            <ArticleId IdType="pubmed">35735007</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>O'Donnell MJ, Chin SL, Rangarajan S, Xavier D, Liu L, Zhang H, et al. Global and Regional Effects of Potentially Modifiable Risk Factors Associated with Acute Stroke in 32 Countries (INTERSTROKE): A Case-control Study. Lancet. 2016;388(10046):761&#8211;775. doi: 10.1016/S0140-6736(16)30506-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0140-6736(16)30506-2</ArticleId>
+            <ArticleId IdType="pubmed">27431356</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Reeves MJ, Bushnell CD, Howard G, Gargano JW, Duncan PW, Lynch G, et al. Sex Differences in Stroke: Epidemiology, Clinical Presentation, Medical Care, and Outcomes. Lancet Neurol. 2008;7(10):915&#8211;926. doi: 10.1016/S1474-4422(08)70193-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S1474-4422(08)70193-5</ArticleId>
+            <ArticleId IdType="pmc">PMC2665267</ArticleId>
+            <ArticleId IdType="pubmed">18722812</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>D&#252;zenli MA, Ozdemir K, Sokmen A, Soylu A, Aygul N, Gezginc K, et al. Effects of Menopause on the Myocardial Velocities and Myocardial Performance Index. Circ J. 2007;71(11):1728&#8211;1733. doi: 10.1253/circj.71.1728.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1253/circj.71.1728</ArticleId>
+            <ArticleId IdType="pubmed">17965492</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shin J, Han K, Jung JH, Park HJ, Kim W, Huh Y, et al. Age at Menopause and Risk of Heart Failure and Atrial Fibrillation: A Nationwide Cohort Study. Eur Heart J. 2022;43(40):4148&#8211;4157. doi: 10.1093/eurheartj/ehac364.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehac364</ArticleId>
+            <ArticleId IdType="pubmed">36239217</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hsich EM, Pi&#241;a IL. Heart Failure in Women: A Need for Prospective Data. J Am Coll Cardiol. 2009;54(6):491&#8211;498. doi: 10.1016/j.jacc.2009.02.066.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2009.02.066</ArticleId>
+            <ArticleId IdType="pubmed">19643307</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Torbati T, Shufelt C, Wei J, Merz CNB. Premature Menopause and Cardiovascular Disease: Can We Blame Estrogen? Eur Heart J. 2022;43(40):4158&#8211;4160. doi: 10.1093/eurheartj/ehac321.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehac321</ArticleId>
+            <ArticleId IdType="pubmed">36239222</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Muka T, Oliver-Williams C, Kunutsor S, Laven JS, Fauser BC, Chowdhury R, et al. Association of Age at Onset of Menopause and Time Since Onset of Menopause with Cardiovascular Outcomes, Intermediate Vascular Traits, and All-Cause Mortality: A Systematic Review and Meta-analysis. JAMA Cardiol. 2016;1(7):767&#8211;776. doi: 10.1001/jamacardio.2016.2415.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamacardio.2016.2415</ArticleId>
+            <ArticleId IdType="pubmed">27627190</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Scott NS. Understanding Hormones, Menopause, and Heart Failure: Still a Work in Progress. J Am Coll Cardiol. 2017;69(20):2527&#8211;2529. doi: 10.1016/j.jacc.2017.03.561.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2017.03.561</ArticleId>
+            <ArticleId IdType="pubmed">28521891</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hall PS, Nah G, Howard BV, Lewis CE, Allison MA, Sarto GE, et al. Reproductive Factors and Incidence of Heart Failure Hospitalization in the Women's Health Initiative. J Am Coll Cardiol. 2017;69(20):2517&#8211;2526. doi: 10.1016/j.jacc.2017.03.557.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jacc.2017.03.557</ArticleId>
+            <ArticleId IdType="pmc">PMC5602586</ArticleId>
+            <ArticleId IdType="pubmed">28521890</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Canonico M, Plu-Bureau G, O'Sullivan MJ, Stefanick ML, Cochrane B, Scarabin PY, et al. Age at Menopause, Reproductive History, and Venous Thromboembolism Risk among Postmenopausal Women: The Women's Health Initiative Hormone Therapy Clinical Trials. Menopause. 2014;21(3):214&#8211;220. doi: 10.1097/GME.0b013e31829752e0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0b013e31829752e0</ArticleId>
+            <ArticleId IdType="pmc">PMC3815514</ArticleId>
+            <ArticleId IdType="pubmed">23760439</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oliver-Williams C, Glisic M, Shahzad S, Brown E, Baena CP, Chadni M, et al. The Route of Administration, Timing, Duration and Dose of Postmenopausal Hormone Therapy and Cardiovascular Outcomes in Women: A Systematic Review. Hum Reprod Update. 2019;25(2):257&#8211;271. doi: 10.1093/humupd/dmy039.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humupd/dmy039</ArticleId>
+            <ArticleId IdType="pubmed">30508190</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim JE, Chang JH, Jeong MJ, Choi J, Park J, Baek C, et al. A Systematic Review and Meta-analysis of Effects of Menopausal Hormone Therapy on Cardiovascular Diseases. Sci Rep. 2020;10(1):20631&#8211;20631. doi: 10.1038/s41598-020-77534-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41598-020-77534-9</ArticleId>
+            <ArticleId IdType="pmc">PMC7691511</ArticleId>
+            <ArticleId IdType="pubmed">33244065</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kapoor E, Kling JM, Lobo AS, Faubion SS. Menopausal Hormone Therapy in Women with Medical Conditions. Best Pract Res Clin Endocrinol Metab. 2021;35(6):101578&#8211;101578. doi: 10.1016/j.beem.2021.101578.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.beem.2021.101578</ArticleId>
+            <ArticleId IdType="pmc">PMC8648973</ArticleId>
+            <ArticleId IdType="pubmed">34583890</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ardissino M, Slob EAW, Carter P, Rogne T, Girling J, Burgess S, et al. Sex-Specific Reproductive Factors Augment Cardiovascular Disease Risk in Women: A Mendelian Randomization Study. J Am Heart Assoc. 2023;12(5):e027933. doi: 10.1161/JAHA.122.027933.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.122.027933</ArticleId>
+            <ArticleId IdType="pmc">PMC10111460</ArticleId>
+            <ArticleId IdType="pubmed">36846989</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Global Burden of Disease . Global Burden of Disease Study 2019 (GBD 2019) Results. Seattle: Institute for Health Metrics and Evaluation; 2020.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Oliveira GMM, Almeida MCC, Rassi DDC, Bragan&#231;a &#201;OV, Moura LZ, Arrais M, et al. Position Statement on Ischemic Heart Disease - Women-Centered Health Care - 2023. Arq Bras Cardiol. 2023;120(7):e20230303. doi: 10.36660/abc.20230303.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.36660/abc.20230303</ArticleId>
+            <ArticleId IdType="pmc">PMC10382148</ArticleId>
+            <ArticleId IdType="pubmed">37556656</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Wong JA, Rexrode KM, Sandhu RK, Moorthy MV, Conen D, Albert CM. Menopausal Age, Postmenopausal Hormone Therapy and Incident Atrial Fibrillation. Heart. 2017;103(24):1954&#8211;1961. doi: 10.1136/heartjnl-2016-311002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/heartjnl-2016-311002</ArticleId>
+            <ArticleId IdType="pmc">PMC5831356</ArticleId>
+            <ArticleId IdType="pubmed">28988211</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu J, Jin X, Chen W, Wang L, Feng Z, Huang J. Early Menopause is Associated with Increased Risk of Heart Failure and Atrial Fibrillation: A Systematic Review and Meta-analysis. Maturitas. 2023;176:107784&#8211;107784. doi: 10.1016/j.maturitas.2023.107784.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2023.107784</ArticleId>
+            <ArticleId IdType="pubmed">37454569</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gomez SE, Parizo J, Ermakov S, Larson J, Wallace R, Assimes T, et al. Evaluation of the Association between Circulating IL-1&#946; and Other Inflammatory Cytokines And Incident Atrial Fibrillation In A Cohort Of Postmenopausal Women. Am Heart J. 2023;258:157&#8211;167. doi: 10.1016/j.ahj.2023.01.010.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ahj.2023.01.010</ArticleId>
+            <ArticleId IdType="pmc">PMC10023332</ArticleId>
+            <ArticleId IdType="pubmed">36646198</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhao SX, Tindle HA, Larson JC, Woods NF, Crawford MH, Hoover V, et al. Association between Insomnia, Stress Events, and Other Psychosocial Factors and Incident Atrial Fibrillation in Postmenopausal Women: Insights from the Women's Health Initiative. J Am Heart Assoc. 2023;12(17):e030030. doi: 10.1161/JAHA.123.030030.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.123.030030</ArticleId>
+            <ArticleId IdType="pmc">PMC10547347</ArticleId>
+            <ArticleId IdType="pubmed">37646212</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Raychaudhuri S, Dieli-Conwright CM, Cheng RK, Barac A, Reding KW, Vasbinder A, et al. A Review of Research on the Intersection between Breast Cancer and Cardiovascular Research in the Women's Health Initiative (WHI) Front Oncol. 2023;12:1039246&#8211;1039246. doi: 10.3389/fonc.2022.1039246.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fonc.2022.1039246</ArticleId>
+            <ArticleId IdType="pmc">PMC10071996</ArticleId>
+            <ArticleId IdType="pubmed">37025252</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Buttros DAB, Branco MT, Orsatti CL, Almeida-Filho BS, Nahas-Neto J, Nahas EAP. High Risk for Cardiovascular Disease in Postmenopausal Breast Cancer Survivors. Menopause. 2019;26(9):1024&#8211;1030. doi: 10.1097/GME.0000000000001348.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000001348</ArticleId>
+            <ArticleId IdType="pubmed">31453965</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mehta LS, Watson KE, Barac A, Beckie TM, Bittner V, Cruz-Flores S, et al. Cardiovascular Disease and Breast Cancer: Where These Entities Intersect: A Scientific Statement from the American Heart Association. Circulation. 2018;137(8):30&#8211;66. doi: 10.1161/CIR.0000000000000556.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0000000000000556</ArticleId>
+            <ArticleId IdType="pmc">PMC6722327</ArticleId>
+            <ArticleId IdType="pubmed">29437116</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chen MH, Epstein SF. Tailored to a Woman's Heart: Gender Cardio-Oncology Across the Lifespan. Curr Cardiol Rep. 2023;25(11):1461&#8211;1474. doi: 10.1007/s11886-023-01967-7.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11886-023-01967-7</ArticleId>
+            <ArticleId IdType="pmc">PMC11034750</ArticleId>
+            <ArticleId IdType="pubmed">37819431</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kingsberg SA, Larkin LC, Liu JH. Clinical Effects of Early or Surgical Menopause. Obstet Gynecol. 2020;135(4):853&#8211;868. doi: 10.1097/AOG.0000000000003729.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/AOG.0000000000003729</ArticleId>
+            <ArticleId IdType="pubmed">32168205</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Haavisto A, Wettergren L, Lampic C, L&#228;hteenm&#228;ki PM, Jahnukainen K. Premature Ovarian Insufficiency and Chance of Pregnancy after Childhood Cancer: A Population-based Study (The Fex-Can Study) Int J Cancer. 2023;153(3):644&#8211;653. doi: 10.1002/ijc.34541.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ijc.34541</ArticleId>
+            <ArticleId IdType="pubmed">37078589</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Parashar S, Akhter N, Paplomata E, Elgendy IY, Upadhyaya D, Scherrer-Crosbie M, et al. Cancer Treatment-Related Cardiovascular Toxicity in Gynecologic Malignancies: JACC: CardioOncology State-of-the-Art Review. JACC CardioOncol. 2023;5(2):159&#8211;173. doi: 10.1016/j.jaccao.2023.02.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jaccao.2023.02.002</ArticleId>
+            <ArticleId IdType="pmc">PMC10152205</ArticleId>
+            <ArticleId IdType="pubmed">37144116</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Parashar S, Reid KJ, Spertus JA, Shaw LJ, Vaccarino V. Early Menopause Predicts Angina after Myocardial Infarction. Menopause. 2010;17(5):938&#8211;945. doi: 10.1097/gme.0b013e3181e41f54.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e3181e41f54</ArticleId>
+            <ArticleId IdType="pmc">PMC3088434</ArticleId>
+            <ArticleId IdType="pubmed">20651619</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Atsma F, Bartelink ML, Grobbee DE, van der Schouw YT. Postmenopausal Status and Early Menopause as Independent Risk Factors for Cardiovascular Disease: A Meta-analysis. Menopause. 2006;13(2):265&#8211;279. doi: 10.1097/01.gme.0000218683.97338.ea.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/01.gme.0000218683.97338.ea</ArticleId>
+            <ArticleId IdType="pubmed">16645540</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Curigliano G, Lenihan D, Fradley M, Ganatra S, Barac A, Blaes A, et al. Management of Cardiac Disease in Cancer Patients Throughout Oncological Treatment: ESMO Consensus Recommendations. Ann Oncol. 2020;31(2):171&#8211;190. doi: 10.1016/j.annonc.2019.10.023.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annonc.2019.10.023</ArticleId>
+            <ArticleId IdType="pmc">PMC8019325</ArticleId>
+            <ArticleId IdType="pubmed">31959335</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Okwuosa TM, Morgans A, Rhee JW, Reding KW, Maliski S, Plana JC, et al. Impact of Hormonal Therapies for Treatment of Hormone-Dependent Cancers (Breast and Prostate) on the Cardiovascular System: Effects and Modifications: A Scientific Statement from the American Heart Association. Circ Genom Precis Med. 2021;14(3):e000082. doi: 10.1161/HCG.0000000000000082.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/HCG.0000000000000082</ArticleId>
+            <ArticleId IdType="pubmed">33896190</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Baum M, Budzar AU, Cuzick J, Forbes J, Houghton JH, Klijn JG, et al. Anastrozole Alone or in Combination with Tamoxifen Versus Tamoxifen Alone for Adjuvant Treatment of Postmenopausal Women with Early Breast Cancer: First Results of the ATAC Randomised Trial. Lancet. 2002;359(9324):2131&#8211;2139. doi: 10.1016/s0140-6736(02)09088-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0140-6736(02)09088-8</ArticleId>
+            <ArticleId IdType="pubmed">12090977</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lyon AR, L&#243;pez-Fern&#225;ndez T, Couch LS, Asteggiano R, Aznar MC, Bergler-Klein J, et al. 2022 ESC Guidelines on Cardio-oncology Developed in Collaboration with the European Hematology Association (EHA), the European Society for Therapeutic Radiology and Oncology (ESTRO) and the International Cardio-Oncology Society (IC-OS) Eur Heart J. 2022;43(41):4229&#8211;4361. doi: 10.1093/eurheartj/ehac244.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehac244</ArticleId>
+            <ArticleId IdType="pubmed">36017568</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Smid J, Studart-Neto A, C&#233;sar-Freitas KG, Dourado MCN, Kochhann R, Barbosa BJAP, et al. Subjective Cognitive Decline, Mild Cognitive Impairment, and Dementia - Syndromic Approach: Recommendations of the Scientific Department of Cognitive Neurology and Aging of the Brazilian Academy of Neurology. Dement Neuropsychol. 2022;16(3 Suppl 1):1&#8211;24. doi: 10.1590/1980-5764-DN-2022-S101PT.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1590/1980-5764-DN-2022-S101PT</ArticleId>
+            <ArticleId IdType="pmc">PMC9745999</ArticleId>
+            <ArticleId IdType="pubmed">36533160</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gale SA, Acar D, Daffner KR. Dementia. Am J Med. 2018;131(10):1161&#8211;1169. doi: 10.1016/j.amjmed.2018.01.022.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.amjmed.2018.01.022</ArticleId>
+            <ArticleId IdType="pubmed">29425707</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Prince M, Wimo A, Guerchet G, Ali GC, Wu YT, Prina M, World Alzheimer Report 2015 . The Global Impact of Dementia: An Analysis of Prevalence, Incidence, Cost and Trends. London: Alzheimer's Disease International; 2015.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>GBD 2019 Dementia Forecasting Collaborators Estimation of the Global Prevalence of Dementia in 2019 and Forecasted Prevalence in 2050: an Analysis for the Global Burden of Disease Study 2019. Lancet Public Health. 2022;7(2):e105&#8211;e125. doi: 10.1016/S2468-2667(21)00249-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S2468-2667(21)00249-8</ArticleId>
+            <ArticleId IdType="pmc">PMC8810394</ArticleId>
+            <ArticleId IdType="pubmed">34998485</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mosconi L, Berti V, Dyke J, Schelbaum E, Jett S, Loughlin L, et al. Menopause Impacts Human Brain Structure, Connectivity, Energy Metabolism, and Amyloid-beta Deposition. Sci Rep. 2021;11(1):10867&#8211;10867. doi: 10.1038/s41598-021-90084-y.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41598-021-90084-y</ArticleId>
+            <ArticleId IdType="pmc">PMC8190071</ArticleId>
+            <ArticleId IdType="pubmed">34108509</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Frank-Raue K, Raue F. Thyroid Dysfunction in Periand Postmenopausal Women-Cumulative Risks. Dtsch Arztebl Int. 2023;120(18):311&#8211;316. doi: 10.3238/arztebl.m2023.0069.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3238/arztebl.m2023.0069</ArticleId>
+            <ArticleId IdType="pmc">PMC10398375</ArticleId>
+            <ArticleId IdType="pubmed">37013812</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shaikh S, Noor F, Ali S, Sajjad S. Hypothyroidism Screening in Menopausal Women. Pakistan Journal of Medical &amp; Health Sciences. 2017;11(1):14&#8211;17.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Uygur MM, Yoldemir T, Yavuz DG. Thyroid Disease in the Perimenopause and Postmenopause Period. Climacteric. 2018;21(6):542&#8211;548. doi: 10.1080/13697137.2018.1514004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2018.1514004</ArticleId>
+            <ArticleId IdType="pubmed">30296186</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Slopien R, Owecki M, Slopien A, Bala G, Meczekalski B. Climacteric Symptoms are Related to Thyroid Status in Euthyroid Menopausal Women. J Endocrinol Invest. 2020;43(1):75&#8211;80. doi: 10.1007/s40618-019-01078-7.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s40618-019-01078-7</ArticleId>
+            <ArticleId IdType="pmc">PMC6952338</ArticleId>
+            <ArticleId IdType="pubmed">31392574</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Panda S, Das A. Analyzing Thyroid Dysfunction in the Climacteric. J Midlife Health. 2018;9(3):113&#8211;116. doi: 10.4103/jmh.JMH_21_18.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.4103/jmh.JMH_21_18</ArticleId>
+            <ArticleId IdType="pmc">PMC6166421</ArticleId>
+            <ArticleId IdType="pubmed">30294181</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sgarbi JA, Teixeira PF, Maciel LM, Mazeto GM, Vaisman M, Montenegro RM, Jr, et al. The Brazilian Consensus for the Clinical Approach and Treatment of Subclinical Hypothyroidism in Adults: Recommendations of the Thyroid Department of the Brazilian Society of Endocrinology and Metabolism. Arq Bras Endocrinol Metabol. 2013;57(3):166&#8211;183. doi: 10.1590/s0004-27302013000300003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1590/s0004-27302013000300003</ArticleId>
+            <ArticleId IdType="pubmed">23681263</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Brenta G, Vaisman M, Sgarbi JA, Bergoglio LM, Andrada NC, Bravo PP, et al. Clinical Practice Guidelines for the Management of Hypothyroidism. Arq Bras Endocrinol Metabol. 2013;57(4):265&#8211;291. doi: 10.1590/s0004-27302013000400003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1590/s0004-27302013000400003</ArticleId>
+            <ArticleId IdType="pubmed">23828433</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Razvi S, Weaver JU, Vanderpump MP, Pearce SH. The Incidence of Ischemic Heart Disease and Mortality in People with Subclinical Hypothyroidism: Reanalysis of the Whickham Survey Cohort. J Clin Endocrinol Metab. 2010;95(4):1734&#8211;1740. doi: 10.1210/jc.2009-1749.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2009-1749</ArticleId>
+            <ArticleId IdType="pubmed">20150579</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rodondi N, den Elzen WP, Bauer DC, Cappola AR, Razvi S, Walsh JP, et al. Subclinical Hypothyroidism and the Risk of Coronary Heart Disease and Mortality. JAMA. 2010;304(12):1365&#8211;1374. doi: 10.1001/jama.2010.1361.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2010.1361</ArticleId>
+            <ArticleId IdType="pmc">PMC3923470</ArticleId>
+            <ArticleId IdType="pubmed">20858880</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Avila WS, Rivera MAM, Rivera IR. Depression, Cardiovascular Disease, and Female Gender: An Underestimated Triad. Arq Bras Cardiol. 2023;120(7):e20220858. doi: 10.36660/abc.20220858.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.36660/abc.20220858</ArticleId>
+            <ArticleId IdType="pmc">PMC10364992</ArticleId>
+            <ArticleId IdType="pubmed">37466622</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Borgi M, Biondi-Zoccai G, Frati G, Peruzzi M. Cardiovascular Disease and Mental Health: A Dangerous Duo? Eur J Prev Cardiol. 2023;30(15):1686&#8211;1688. doi: 10.1093/eurjpc/zwad199.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurjpc/zwad199</ArticleId>
+            <ArticleId IdType="pubmed">37294922</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Riahi SM, Yousefi A, Saeedi F, Martin SS. Associations of Emotional Social Support, Depressive Symptoms, Chronic Stress, and Anxiety with Hard Cardiovascular Disease Events in the United States: the Multi-ethnic Study of Atherosclerosis (MESA) BMC Cardiovasc Disord. 2023;23(1):236&#8211;236. doi: 10.1186/s12872-023-03195-x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s12872-023-03195-x</ArticleId>
+            <ArticleId IdType="pmc">PMC10161545</ArticleId>
+            <ArticleId IdType="pubmed">37142978</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vaccarino V, Sullivan S, Hammadah M, Wilmot K, Al Mheid I, Ramadan R, et al. Mental Stress-Induced-Myocardial Ischemia in Young Patients with Recent Myocardial Infarction: Sex Differences and Mechanisms. Circulation. 2018;137(8):794&#8211;805. doi: 10.1161/CIRCULATIONAHA.117.030849.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCULATIONAHA.117.030849</ArticleId>
+            <ArticleId IdType="pmc">PMC5822741</ArticleId>
+            <ArticleId IdType="pubmed">29459465</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nash Z, Al-Wattar BH, Davies M. Bone and Heart Health in Menopause. Best Pract Res Clin Obstet Gynaecol. 2022;81:61&#8211;68. doi: 10.1016/j.bpobgyn.2022.03.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.bpobgyn.2022.03.002</ArticleId>
+            <ArticleId IdType="pubmed">35400590</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Almeida M, Laurent MR, Dubois V, Claessens F, O'Brien CA, Bouillon R, et al. Estrogens and Androgens in Skeletal Physiology and Pathophysiology. Physiol Rev. 2017;97(1):135&#8211;187. doi: 10.1152/physrev.00033.2015.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1152/physrev.00033.2015</ArticleId>
+            <ArticleId IdType="pmc">PMC5539371</ArticleId>
+            <ArticleId IdType="pubmed">27807202</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>North American Menopause Society The 2022 Hormone Therapy Position Statement of The North American Menopause Society. Menopause. 2022;29(7):767&#8211;794. doi: 10.1097/GME.0000000000002028.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000002028</ArticleId>
+            <ArticleId IdType="pubmed">35797481</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rajendran A, Minhas AS, Kazzi B, Varma B, Choi E, Thakkar A, et al. Sex-specific Differences in Cardiovascular Risk Factors and Implications for Cardiovascular Disease Prevention in Women. Atherosclerosis. 2023;384:117269&#8211;117269. doi: 10.1016/j.atherosclerosis.2023.117269.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.atherosclerosis.2023.117269</ArticleId>
+            <ArticleId IdType="pmc">PMC10841060</ArticleId>
+            <ArticleId IdType="pubmed">37752027</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Streed CG, Jr, Beach LB, Caceres BA, Dowshen NL, Moreau KL, Mukherjee M, et al. Assessing and Addressing Cardiovascular Health in People Who Are Transgender and Gender Diverse: A Scientific Statement from the American Heart Association. Circulation. 2021;144(6):136&#8211;148. doi: 10.1161/CIR.0000000000001003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIR.0000000000001003</ArticleId>
+            <ArticleId IdType="pmc">PMC8638087</ArticleId>
+            <ArticleId IdType="pubmed">34235936</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Barros BS, Kuschnir MCMC, Bloch KV, Silva TLND. ERICA: Age at Menarche and its Association with Nutritional Status. J Pediatr. 2019;95(1):106&#8211;111. doi: 10.1016/j.jped.2017.12.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jped.2017.12.004</ArticleId>
+            <ArticleId IdType="pubmed">29352861</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kim C, Catov J, Schreiner PJ, Appiah D, Wellons MF, Siscovick D, et al. Women's Reproductive Milestones and Cardiovascular Disease Risk: A Review of Reports and Opportunities from the CARDIA Study. J Am Heart Assoc. 2023;12(5):e028132. doi: 10.1161/JAHA.122.028132.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.122.028132</ArticleId>
+            <ArticleId IdType="pmc">PMC10111436</ArticleId>
+            <ArticleId IdType="pubmed">36847077</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lakshman R, Forouhi NG, Sharp SJ, Luben R, Bingham SA, Khaw KT, et al. Early Age at Menarche Associated with Cardiovascular Disease and Mortality. J Clin Endocrinol Metab. 2009;94(12):4953&#8211;4960. doi: 10.1210/jc.2009-1789.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2009-1789</ArticleId>
+            <ArticleId IdType="pubmed">19880785</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Feng Y, Hong X, Wilker E, Li Z, Zhang W, Jin D, et al. Effects of Age at Menarche, Reproductive Years, and Menopause on Metabolic Risk Factors for Cardiovascular Diseases. Atherosclerosis. 2008;196(2):590&#8211;597. doi: 10.1016/j.atherosclerosis.2007.06.016.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.atherosclerosis.2007.06.016</ArticleId>
+            <ArticleId IdType="pmc">PMC2271121</ArticleId>
+            <ArticleId IdType="pubmed">17675039</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>O'Kelly AC, Michos ED, Shufelt CL, Vermunt JV, Minissian MB, Quesada O, et al. Pregnancy and Reproductive Risk Factors for Cardiovascular Disease in Women. Circ Res. 2022;130(4):652&#8211;672. doi: 10.1161/CIRCRESAHA.121.319895.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCRESAHA.121.319895</ArticleId>
+            <ArticleId IdType="pmc">PMC8870397</ArticleId>
+            <ArticleId IdType="pubmed">35175837</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Remsberg KE, Demerath EW, Schubert CM, Chumlea WC, Sun SS, Siervogel RM. Early Menarche and the Development of Cardiovascular Disease Risk Factors in Adolescent Girls: the Fels Longitudinal Study. J Clin Endocrinol Metab. 2005;90(5):2718&#8211;2724. doi: 10.1210/jc.2004-1991.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2004-1991</ArticleId>
+            <ArticleId IdType="pubmed">15728207</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mueller NT, Odegaard AO, Gross MD, Koh WP, Yuan JM, Pereira MA. Age at Menarche and Cardiovascular Disease Mortality in Singaporean Chinese Women: The Singapore Chinese Health Study. Ann Epidemiol. 2012;22(10):717&#8211;722. doi: 10.1016/j.annepidem.2012.08.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.annepidem.2012.08.002</ArticleId>
+            <ArticleId IdType="pmc">PMC3459135</ArticleId>
+            <ArticleId IdType="pubmed">22939833</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Charalampopoulos D, McLoughlin A, Elks CE, Ong KK. Age at Menarche and Risks of All-cause and Cardiovascular Death: A Systematic Review and Meta-analysis. Am J Epidemiol. 2014;180(1):29&#8211;40. doi: 10.1093/aje/kwu113.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/aje/kwu113</ArticleId>
+            <ArticleId IdType="pmc">PMC4070937</ArticleId>
+            <ArticleId IdType="pubmed">24920784</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lee JJ, Cook-Wiens G, Johnson BD, Braunstein GD, Berga SL, Stanczyk FZ, et al. Age at Menarche and Risk of Cardiovascular Disease Outcomes: Findings from the National Heart Lung and Blood Institute-Sponsored Women's Ischemia Syndrome Evaluation. J Am Heart Assoc. 2019;8(12):e012406. doi: 10.1161/JAHA.119.012406.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.119.012406</ArticleId>
+            <ArticleId IdType="pmc">PMC6645646</ArticleId>
+            <ArticleId IdType="pubmed">31165670</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Canoy D, Beral V, Balkwill A, Wright FL, Kroll ME, Reeves GK, et al. Age at Menarche and Risks of Coronary Heart and Other Vascular Diseases in a Large UK Cohort. Circulation. 2015;131(3):237&#8211;244. doi: 10.1161/CIRCULATIONAHA.114.010070.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCULATIONAHA.114.010070</ArticleId>
+            <ArticleId IdType="pubmed">25512444</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vessey M, Mant D, Smith A, Yeates D. Oral Contraceptives and Venous Thromboembolism: Findings in a Large Prospective Study. Br Med J. 1986;292(6519):526&#8211;526. doi: 10.1136/bmj.292.6519.526.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.292.6519.526</ArticleId>
+            <ArticleId IdType="pmc">PMC1339511</ArticleId>
+            <ArticleId IdType="pubmed">3081157</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sitruk-Ware R, Nath A. Metabolic Effects of Contraceptive Steroids. Rev Endocr Metab Disord. 2011;12(2):63&#8211;75. doi: 10.1007/s11154-011-9182-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s11154-011-9182-4</ArticleId>
+            <ArticleId IdType="pubmed">21538049</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sitruk-Ware R, Nath A. Characteristics and Metabolic Effects of Estrogen and Progestins Contained in Oral Contraceptive Pills. Best Pract Res Clin Endocrinol Metab. 2013;27(1):13&#8211;24. doi: 10.1016/j.beem.2012.09.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.beem.2012.09.004</ArticleId>
+            <ArticleId IdType="pubmed">23384742</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dragoman MV. The Combined Oral Contraceptive Pill &#8211; Recent Developments, Risks and Benefits. Best Pract Res Clin Obstet Gynaecol. 2014;28(6):825&#8211;834. doi: 10.1016/j.bpobgyn.2014.06.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.bpobgyn.2014.06.003</ArticleId>
+            <ArticleId IdType="pubmed">25028259</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nelson AL. Drospirenone and Estetrol: Evaluation of a Newly Approved Novel Oral Contraceptive. Expert Opin Pharmacother. 2023;24(16):1757&#8211;1764. doi: 10.1080/14656566.2023.2247979.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/14656566.2023.2247979</ArticleId>
+            <ArticleId IdType="pubmed">37691580</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Junge W, Mellinger U, Parke S, Serrani M. Metabolic and Haemostatic Effects of Estradiol Valerate/Dienogest, a Novel Oral Contraceptive: A Randomized, Open-label, Single-centre Study. Clin Drug Investig. 2011;31(8):573&#8211;584. doi: 10.2165/11590220-000000000-00000.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2165/11590220-000000000-00000</ArticleId>
+            <ArticleId IdType="pubmed">21721593</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Brabaharan S, Veettil SK, Kaiser JE, Rao VRR, Wattanayingcharoenchai R, Maharajan M, et al. Association of Hormonal Contraceptive Use with Adverse Health Outcomes: An Umbrella Review of Meta-analyses of Randomized Clinical Trials and Cohort Studies. JAMA Netw Open. 2022;5(1):e2143730. doi: 10.1001/jamanetworkopen.2021.43730.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamanetworkopen.2021.43730</ArticleId>
+            <ArticleId IdType="pmc">PMC8760614</ArticleId>
+            <ArticleId IdType="pubmed">35029663</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Roach RE, Helmerhorst FM, Lijfering WM, Stijnen T, Algra A, Dekkers OM. Combined Oral Contraceptives: The Risk of Myocardial Infarction and Ischemic Stroke. Cochrane Database Syst Rev. 2015;2015(8):CD011054. doi: 10.1002/14651858.CD011054.pub2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD011054.pub2</ArticleId>
+            <ArticleId IdType="pmc">PMC6494192</ArticleId>
+            <ArticleId IdType="pubmed">26310586</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lidegaard &#216;, L&#248;kkegaard E, Jensen A, Skovlund CW. Keiding N. Thrombotic Stroke and Myocardial Infarction with Hormonal Contraception. N Engl J Med. 2012;366(24):2257&#8211;2266. doi: 10.1056/NEJMoa1111840.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1111840</ArticleId>
+            <ArticleId IdType="pubmed">22693997</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Weill A, Dalichampt M, Raguideau F, Ricordeau P, Bloti&#232;re PO, Rudant J, et al. Low Dose Oestrogen Combined Oral Contraception and Risk of Pulmonary Embolism, Stroke, and Myocardial Infarction in Five Million French Women: Cohort Study. BMJ. 2016;353:2002&#8211;2002. doi: 10.1136/bmj.i2002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.i2002</ArticleId>
+            <ArticleId IdType="pmc">PMC4862376</ArticleId>
+            <ArticleId IdType="pubmed">27164970</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu H, Yao J, Wang W, Zhang D. Association between Duration of Oral Contraceptive Use and Risk of Hypertension: A Meta-analysis. J Clin Hypertens. 2017 Oct;19(10):1032&#8211;1041. doi: 10.1111/jch.13042.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/jch.13042</ArticleId>
+            <ArticleId IdType="pmc">PMC8030990</ArticleId>
+            <ArticleId IdType="pubmed">28612347</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oliveira SS, Petto J, Diogo DP, Santos ACN, Sacramento MS, Ladeia AMT. Plasma Renin in Women Using and Not Using Combined Oral Contraceptive. Int J Cardiovasc Sci. 2020;33(3):208&#8211;214. doi: 10.36660/ijcs.20180021.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.36660/ijcs.20180021</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li F, Zhu L, Zhang J, He H, Qin Y, Cheng Y, et al. Oral Contraceptive Use and Increased Risk of Stroke: A Dose-Response Meta-Analysis of Observational Studies. Front Neurol. 2019;10:993&#8211;993. doi: 10.3389/fneur.2019.00993.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fneur.2019.00993</ArticleId>
+            <ArticleId IdType="pmc">PMC6767325</ArticleId>
+            <ArticleId IdType="pubmed">31592249</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tepper NK, Whiteman MK, Marchbanks PA, James AH, Curtis KM. Progestin-only Contraception and Thromboembolism: A Systematic Review. Contraception. 2016;94(6):678&#8211;700. doi: 10.1016/j.contraception.2016.04.014.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.contraception.2016.04.014</ArticleId>
+            <ArticleId IdType="pmc">PMC11034842</ArticleId>
+            <ArticleId IdType="pubmed">27153743</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Practice Committee of the American Society for Reproductive Medicine Combined Hormonal Contraception and the Risk of Venous Thromboembolism: A Guideline. Fertil Steril. 2017;107(1):43&#8211;51. doi: 10.1016/j.fertnstert.2016.09.027.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.fertnstert.2016.09.027</ArticleId>
+            <ArticleId IdType="pubmed">27793376</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dragoman MV, Tepper NK, Fu R, Curtis KM, Chou R, Gaffield ME. A systematic Review and Meta-analysis of Venous Thrombosis Risk among Users of Combined Oral Contraception. Int J Gynaecol Obstet. 2018;141(3):287&#8211;294. doi: 10.1002/ijgo.12455.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ijgo.12455</ArticleId>
+            <ArticleId IdType="pmc">PMC5969307</ArticleId>
+            <ArticleId IdType="pubmed">29388678</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Oedingen C, Scholz S, Razum O. Systematic Review and Meta-analysis of the Association of Combined Oral Contraceptives on the Risk of Venous Thromboembolism: The Role of the Progestogen Type and Estrogen Dose. Thromb Res. 2018;165:68&#8211;78. doi: 10.1016/j.thromres.2018.03.005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.thromres.2018.03.005</ArticleId>
+            <ArticleId IdType="pubmed">29573722</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Timmer CJ, Mulders TM. Pharmacokinetics of Etonogestrel and Ethinylestradiol Released from a Combined Contraceptive Vaginal Ring. Clin Pharmacokinet. 2000;39(3):233&#8211;242. doi: 10.2165/00003088-200039030-00005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2165/00003088-200039030-00005</ArticleId>
+            <ArticleId IdType="pubmed">11020137</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Serfaty D. Update on the Contraceptive Contraindications. J Gynecol Obstet Hum Reprod. 2019;48(5):297&#8211;307. doi: 10.1016/j.jogoh.2019.02.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.jogoh.2019.02.006</ArticleId>
+            <ArticleId IdType="pubmed">30796985</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Avila WS, Grinberg M, Melo NR, Pinotti JA, Pileggi F. Contraceptive Use in Women with Heart Disease. Arq Bras Cardiol. 1996;66(4):205&#8211;211.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">8935685</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dou W, Huang Y, Liu X, Huang C, Huang J, Xu B, et al. Associations of Oral Contraceptive Use with Cardiovascular Disease and All-Cause Death: Evidence from the UK Biobank Cohort Study. J Am Heart Assoc. 2023;12(16):e030105. doi: 10.1161/JAHA.123.030105.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.123.030105</ArticleId>
+            <ArticleId IdType="pmc">PMC10492942</ArticleId>
+            <ArticleId IdType="pubmed">37581386</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Barsky L, Shufelt C, Lauzon M, Johnson BD, Berga SL, Braunstein G, et al. Prior Oral Contraceptive Use and Longer Term Mortality Outcomes in Women with Suspected Ischemic Heart Disease. J Womens Health. 2021;30(3):377&#8211;384. doi: 10.1089/jwh.2020.8743.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1089/jwh.2020.8743</ArticleId>
+            <ArticleId IdType="pmc">PMC8098756</ArticleId>
+            <ArticleId IdType="pubmed">33481672</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Spitzer WO. Oral Contraceptives and Cardiovascular Outcomes: Cause or Bias? Contraception. 2000;62(2 Suppl):3&#8211;9. doi: 10.1016/s0010-7824(00)00149-9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0010-7824(00)00149-9</ArticleId>
+            <ArticleId IdType="pubmed">11102597</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Merz CNB, Johnson BD, Sharaf BL, Bittner V, Berga SL, Braunstein GD, et al. Hypoestrogenemia of Hypothalamic Origin and Coronary Artery Disease in Premenopausal Women: A Report from the NHLBI-sponsored WISE Study. J Am Coll Cardiol. 2003;41(3):413&#8211;419. doi: 10.1016/s0735-1097(02)02763-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0735-1097(02)02763-8</ArticleId>
+            <ArticleId IdType="pubmed">12575968</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hanson B, Johnstone E, Dorais J, Silver B, Peterson CM, Hotaling J. Female Infertility, Infertility-Associated Diagnoses, and Comorbidities: A Review. J Assist Reprod Genet. 2017;34(2):167&#8211;177. doi: 10.1007/s10815-016-0836-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s10815-016-0836-8</ArticleId>
+            <ArticleId IdType="pmc">PMC5306404</ArticleId>
+            <ArticleId IdType="pubmed">27817040</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vogel B, Acevedo M, Appelman Y, Merz CNB, Chieffo A, Figtree GA, et al. The Lancet Women and Cardiovascular Disease Commission: Reducing the Global Burden by 2030. Lancet. 2021;397(10292):2385&#8211;2438. doi: 10.1016/S0140-6736(21)00684-X.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0140-6736(21)00684-X</ArticleId>
+            <ArticleId IdType="pubmed">34010613</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Malachias MVB. Polycystic Ovary Syndrome and Cardiovascular Diseases: Still an Open Door. Arq Bras Cardiol. 2019;112(4):430&#8211;431. doi: 10.5935/abc.20190062.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.5935/abc.20190062</ArticleId>
+            <ArticleId IdType="pmc">PMC6459439</ArticleId>
+            <ArticleId IdType="pubmed">30994722</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Berni TR, Morgan CL, Rees DA. Women with Polycystic Ovary Syndrome Have an Increased Risk of Major Cardiovascular Events: a Population Study. J Clin Endocrinol Metab. 2021;106(9):3369&#8211;3380. doi: 10.1210/clinem/dgab392.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/clinem/dgab392</ArticleId>
+            <ArticleId IdType="pmc">PMC8372630</ArticleId>
+            <ArticleId IdType="pubmed">34061968</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Calderon-Margalit R, Siscovick D, Merkin SS, Wang E, Daviglus ML, Schreiner PJ, et al. Prospective Association of Polycystic Ovary Syndrome with Coronary Artery Calcification and Carotid-Intima-Media Thickness: The Coronary Artery Risk Development in Young Adults Women's Study. Arterioscler Thromb Vasc Biol. 2014;34(12):2688&#8211;2694. doi: 10.1161/ATVBAHA.114.304136.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/ATVBAHA.114.304136</ArticleId>
+            <ArticleId IdType="pubmed">25359859</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhang J, Xu JH, Qu QQ, Zhong GQ. Risk of Cardiovascular and Cerebrovascular Events in Polycystic Ovarian Syndrome Women: A Meta-Analysis of Cohort Studies. Front Cardiovasc Med. 2020;7:552421&#8211;552421. doi: 10.3389/fcvm.2020.552421.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fcvm.2020.552421</ArticleId>
+            <ArticleId IdType="pmc">PMC7690560</ArticleId>
+            <ArticleId IdType="pubmed">33282917</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Okoth K, Chandan JS, Marshall T, Thangaratinam S, Thomas GN, Nirantharakumar K, et al. Association between the Reproductive Health of Young Women and Cardiovascular Disease in Later Life: Umbrella Review. BMJ. 2020;371:m3502. doi: 10.1136/bmj.m3502.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.m3502</ArticleId>
+            <ArticleId IdType="pmc">PMC7537472</ArticleId>
+            <ArticleId IdType="pubmed">33028606</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Davis SR. Use of Testosterone in Postmenopausal Women. Endocrinol Metab Clin North Am. 2021;50(1):113&#8211;124. doi: 10.1016/j.ecl.2020.11.002.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ecl.2020.11.002</ArticleId>
+            <ArticleId IdType="pubmed">33518180</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Armeni E, Lambrinoudaki I. Menopause, Androgens, and Cardiovascular Ageing: A Narrative Review. Ther Adv Endocrinol Metab. 2022;13:20420188221129946&#8211;20420188221129946. doi: 10.1177/20420188221129946.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/20420188221129946</ArticleId>
+            <ArticleId IdType="pmc">PMC9619256</ArticleId>
+            <ArticleId IdType="pubmed">36325501</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Moreau KL, Babcock MC, Hildreth KL. Sex Differences in Vascular Aging in Response to Testosterone. Biol Sex Differ. 2020;11(1):18&#8211;18. doi: 10.1186/s13293-020-00294-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13293-020-00294-8</ArticleId>
+            <ArticleId IdType="pmc">PMC7161199</ArticleId>
+            <ArticleId IdType="pubmed">32295637</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Spoletini I, Vitale C, Pelliccia F, Fossati C, Rosano GM. Androgens and Cardiovascular Disease in Postmenopausal Women: A Systematic Review. Climacteric. 2014;17(6):625&#8211;634. doi: 10.3109/13697137.2014.887669.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2014.887669</ArticleId>
+            <ArticleId IdType="pubmed">24559253</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Davis SR, Baber R, Panay N, Bitzer J, Perez SC, Islam RM, et al. Global Consensus Position Statement on the Use of Testosterone Therapy for Women. Climacteric. 2019;22(5):429&#8211;434. doi: 10.1080/13697137.2019.1637079.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2019.1637079</ArticleId>
+            <ArticleId IdType="pubmed">31474158</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Islam RM, Bell RJ, Handelsman DJ, McNeil JJ, Nelson MR, Reid CM, et al. Associations between Blood Sex Steroid Concentrations and Risk of Major Adverse Cardiovascular Events in Healthy Older Women in Australia: A Prospective Cohort Substudy of the ASPREE Trial. Lancet Healthy Longev. 2022;3(2):109&#8211;118. doi: 10.1016/S2666-7568(22)00001-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S2666-7568(22)00001-0</ArticleId>
+            <ArticleId IdType="pmc">PMC8896500</ArticleId>
+            <ArticleId IdType="pubmed">35252940</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lopez DS, Mulla JS, El Haddad D, Tahashilder MI, Polychronopolou E, Baillargeon J, et al. Testosterone Replacement Therapy in Relation with Cardiovascular Disease in Cisgender Women and Transgender People. J Clin Endocrinol Metab. 2023;108(12):1515&#8211;1523. doi: 10.1210/clinem/dgad388.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/clinem/dgad388</ArticleId>
+            <ArticleId IdType="pmc">PMC10655536</ArticleId>
+            <ArticleId IdType="pubmed">37392459</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Connelly PJ, Freel EM, Perry C, Ewan J, Touyz RM, Currie G, et al. Gender-Affirming Hormone Therapy, Vascular Health and Cardiovascular Disease in Transgender Adults. Hypertension. 2019;74(6):1266&#8211;1274. doi: 10.1161/HYPERTENSIONAHA.119.13080.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/HYPERTENSIONAHA.119.13080</ArticleId>
+            <ArticleId IdType="pmc">PMC6887638</ArticleId>
+            <ArticleId IdType="pubmed">31656099</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>D'hoore L, T'Sjoen G. Gender-affirming Hormone Therapy: An Updated Literature Review with an Eye on the Future. J Intern Med. 2022;291(5):574&#8211;592. doi: 10.1111/joim.13441.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/joim.13441</ArticleId>
+            <ArticleId IdType="pubmed">34982475</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Murphy CN, Delles C, Davies E, Connelly PJ. Cardiovascular Disease in Transgender Individuals. Atherosclerosis. 2023;384:117282&#8211;117282. doi: 10.1016/j.atherosclerosis.2023.117282.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.atherosclerosis.2023.117282</ArticleId>
+            <ArticleId IdType="pubmed">37821271</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Coleman E, Radix AE, Bouman WP, Brown GR, de Vries ALC, Deutsch MB, et al. Standards of Care for the Health of Transgender and Gender Diverse People, Version 8. Int J Transgend Health. 2022;23(Suppl 1):1&#8211;259. doi: 10.1080/26895269.2022.2100644.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/26895269.2022.2100644</ArticleId>
+            <ArticleId IdType="pmc">PMC9553112</ArticleId>
+            <ArticleId IdType="pubmed">36238954</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sociedade Brasileira de Patologia Cl&#237;nica . Medicina Diagn&#243;stica Inclusiva: Cuidando de Pacientes Transg&#234;nero. Rio de Janeiro: Sociedade Brasileira de Patologia Cl&#237;nica; 2019.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Aranda G, Halperin I, Gomez-Gil E, Hanzu FA, Segu&#237; N, Guillamon A, et al. Cardiovascular Risk Associated with Gender Affirming Hormone Therapy in Transgender Population. Front Endocrinol. 2021;12:718200&#8211;718200. doi: 10.3389/fendo.2021.718200.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fendo.2021.718200</ArticleId>
+            <ArticleId IdType="pmc">PMC8515285</ArticleId>
+            <ArticleId IdType="pubmed">34659112</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>O'Connell MA, Nguyen TP, Ahler A, Skinner SR, Pang KC. Approach to the Patient: Pharmacological Management of Trans and Gender-Diverse Adolescents. J Clin Endocrinol Metab. 2022;107(1):241&#8211;257. doi: 10.1210/clinem/dgab634.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/clinem/dgab634</ArticleId>
+            <ArticleId IdType="pmc">PMC8684462</ArticleId>
+            <ArticleId IdType="pubmed">34476487</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cheung AS, Nolan BJ. Zwickl S. Transgender Health and the Impact of Aging and Menopause. Climacteric. 2023;26(3):256&#8211;262. doi: 10.1080/13697137.2023.2176217.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2023.2176217</ArticleId>
+            <ArticleId IdType="pubmed">37011669</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hodis HN, Mack WJ. Menopausal Hormone Replacement Therapy and Reduction of All-Cause Mortality and Cardiovascular Disease: It Is About Time and Timing. Cancer J. 2022;28(3):208&#8211;223. doi: 10.1097/PPO.0000000000000591.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/PPO.0000000000000591</ArticleId>
+            <ArticleId IdType="pmc">PMC9178928</ArticleId>
+            <ArticleId IdType="pubmed">35594469</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hodis HN, Mack WJ, Lobo RA, Shoupe D, Sevanian A, Mahrer PR, et al. Estrogen in the Prevention of Atherosclerosis. A Randomized, Double-Blind, Placebo-Controlled Trial. Ann Intern Med. 2001;135(11):939&#8211;953. doi: 10.7326/0003-4819-135-11-200112040-00005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-135-11-200112040-00005</ArticleId>
+            <ArticleId IdType="pubmed">11730394</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Christian RC, Harrington S, Edwards WD, Oberg AL, Fitzpatrick LA. Estrogen Status Correlates with the Calcium Content of Coronary Atherosclerotic Plaques in Women. J Clin Endocrinol Metab. 2002;87(3):1062&#8211;1067. doi: 10.1210/jcem.87.3.8354.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jcem.87.3.8354</ArticleId>
+            <ArticleId IdType="pubmed">11889163</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Anderson GL, Limacher M, Assaf AR, Bassford T, Beresford SA, Black H, et al. Effects of Conjugated Equine Estrogen in Postmenopausal Women with Hysterectomy: The Women's Health Initiative Randomized Controlled Trial. JAMA. 2004;291(14):1701&#8211;1712. doi: 10.1001/jama.291.14.1701.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.291.14.1701</ArticleId>
+            <ArticleId IdType="pubmed">15082697</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Madsen TE, Sobel T, Negash S, Allen TS, Stefanick ML, Manson JE, et al. A Review of Hormone and Non-Hormonal Therapy Options for the Treatment of Menopause. Int J Womens Health. 2023;15:825&#8211;836. doi: 10.2147/IJWH.S379808.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2147/IJWH.S379808</ArticleId>
+            <ArticleId IdType="pmc">PMC10226543</ArticleId>
+            <ArticleId IdType="pubmed">37255734</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Glynne S, Newson L, Reisel D. Hormone Therapy for the Prevention of Chronic Conditions in Postmenopausal Persons. JAMA. 2023;329(11):940&#8211;941. doi: 10.1001/jama.2023.0180.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2023.0180</ArticleId>
+            <ArticleId IdType="pubmed">36943221</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Davis SR, Taylor S, Hemachandra C, Magraith K, Ebeling PR, Jane F, et al. The 2023 Practitioner's Toolkit for Managing Menopause. Climacteric. 2023;26(6):517&#8211;536. doi: 10.1080/13697137.2023.2258783.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2023.2258783</ArticleId>
+            <ArticleId IdType="pubmed">37902335</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Boardman HM, Hartley L, Eisinga A, Main C, Roqu&#233; i Figuls M, et al. Hormone Therapy for Preventing Cardiovascular Disease in Post-Menopausal Women. Cochrane Database Syst Rev. 2015;2015(3):CD002229. doi: 10.1002/14651858.CD002229.pub4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD002229.pub4</ArticleId>
+            <ArticleId IdType="pmc">PMC10183715</ArticleId>
+            <ArticleId IdType="pubmed">25754617</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Marjoribanks J, Farquhar C, Roberts H, Lethaby A, Lee J. Long-Term Hormone Therapy for Perimenopausal and Postmenopausal Women. Cochrane Database Syst Rev. 2017;1(1):CD004143. doi: 10.1002/14651858.CD004143.pub5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD004143.pub5</ArticleId>
+            <ArticleId IdType="pmc">PMC6465148</ArticleId>
+            <ArticleId IdType="pubmed">28093732</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Santoro N, El Khoudary SR, Sokalska A, Szmuilowicz ED, Wolfman W. In: Menopause Practice: A Clinician's Guide. The North American Menopause Society, editor. Denver: The North American Menopause Society; 2019. Menopause; pp. 1&#8211;21.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>El Khoudary SR, Thurston RC. Cardiovascular Implications of the Menopause Transition: Endogenous Sex Hormones and Vasomotor Symptoms. Obstet Gynecol Clin North Am. 2018;45(4):641&#8211;661. doi: 10.1016/j.ogc.2018.07.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ogc.2018.07.006</ArticleId>
+            <ArticleId IdType="pubmed">30401548</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kravitz HM, Kazlauskaite R, Joffe H. Sleep, Health, and Metabolism in Midlife Women and Menopause: Food for Thought. Obstet Gynecol Clin North Am. 2018;45(4):679&#8211;694. doi: 10.1016/j.ogc.2018.07.008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ogc.2018.07.008</ArticleId>
+            <ArticleId IdType="pmc">PMC6338227</ArticleId>
+            <ArticleId IdType="pubmed">30401550</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bromberger JT, Epperson CN. Depression During and after the Perimenopause: Impact of Hormones, Genetics, and Environmental Determinants of Disease. Obstet Gynecol Clin North Am. 2018;45(4):663&#8211;678. doi: 10.1016/j.ogc.2018.07.007.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ogc.2018.07.007</ArticleId>
+            <ArticleId IdType="pmc">PMC6226029</ArticleId>
+            <ArticleId IdType="pubmed">30401549</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Szegda KL, Whitcomb BW, Purdue-Smithe AC, Boutot ME, Manson JE, Hankinson SE, et al. Adult Adiposity and Risk of Early Menopause. Hum Reprod. 2017;32(12):2522&#8211;2531. doi: 10.1093/humrep/dex304.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/humrep/dex304</ArticleId>
+            <ArticleId IdType="pmc">PMC5850492</ArticleId>
+            <ArticleId IdType="pubmed">29087465</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ley SH, Li Y, Tobias DK, Manson JE, Rosner B, Hu FB, et al. Duration of Reproductive Life Span, Age at Menarche, and Age at Menopause are Associated with Risk of Cardiovascular Disease in Women. J Am Heart Assoc. 2017;6(11):e006713. doi: 10.1161/JAHA.117.006713.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.117.006713</ArticleId>
+            <ArticleId IdType="pmc">PMC5721766</ArticleId>
+            <ArticleId IdType="pubmed">29097389</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Appiah D, Schreiner PJ, Demerath EW, Loehr LR, Chang PP, Folsom AR. Association of Age at Menopause with Incident Heart Failure: A Prospective Cohort Study and Meta-Analysis. J Am Heart Assoc. 2016;5(8):e003769. doi: 10.1161/JAHA.116.003769.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/JAHA.116.003769</ArticleId>
+            <ArticleId IdType="pmc">PMC5015298</ArticleId>
+            <ArticleId IdType="pubmed">27468929</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dam V, van der Schouw YT, Onland-Moret NC, Groenwold RHH, Peters SAE, Burgess S, et al. Association of Menopausal Characteristics and Risk of Coronary Heart Disease: A pan-European Case-Cohort Analysis. Int J Epidemiol. 2019;48(4):1275&#8211;1285. doi: 10.1093/ije/dyz016.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/ije/dyz016</ArticleId>
+            <ArticleId IdType="pmc">PMC6693816</ArticleId>
+            <ArticleId IdType="pubmed">30796459</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mangione CM, Barry MJ, Nicholson WK, Cabana M, Caughey AB, Chelmow D, et al. Hormone Therapy for the Primary Prevention of Chronic Conditions in Postmenopausal Persons: US Preventive Services Task Force Recommendation Statement. JAMA. 2022;328(17):1740&#8211;1746. doi: 10.1001/jama.2022.18625.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2022.18625</ArticleId>
+            <ArticleId IdType="pubmed">36318127</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Johansen LL, Thinggaard M, Hallas J, Osler M, Christensen K. Postmenopausal Hormone Therapy and Mortality Before and after the Women's Health Initiative study. Sci Rep. 2023;13(1):539&#8211;539. doi: 10.1038/s41598-023-27731-z.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41598-023-27731-z</ArticleId>
+            <ArticleId IdType="pmc">PMC9834226</ArticleId>
+            <ArticleId IdType="pubmed">36631522</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lu DH, Zhou SY, Xu LZ. Association between Hormone Replacement Therapy and Sex Hormones in Postmenopausal Women: A Systematic Review and Meta-Analysis. Eur Rev Med Pharmacol Sci. 2023;27(11):5264&#8211;5279. doi: 10.26355/eurrev_202306_32646.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.26355/eurrev_202306_32646</ArticleId>
+            <ArticleId IdType="pubmed">37318501</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vigneswaran K, Hamoda H. Hormone Replacement Therapy - Current Recommendations. Best Pract Res Clin Obstet Gynaecol. 2022;81:8&#8211;21. doi: 10.1016/j.bpobgyn.2021.12.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.bpobgyn.2021.12.001</ArticleId>
+            <ArticleId IdType="pubmed">35000809</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tr&#233;mollieres FA, Chabbert-Buffet N, Plu-Bureau G, Rousset-Jablonski C, Lecerf JM, Duclos M, et al. Management of Postmenopausal Women: Coll&#232;ge National des Gyn&#233;cologues et Obst&#233;triciens Fran&#231;ais (CNGOF) and Groupe d'Etude sur la M&#233;nopause et le Vieillissement (GEMVi) Clinical Practice Guidelines. Maturitas. 2022;163:62&#8211;81. doi: 10.1016/j.maturitas.2022.05.008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2022.05.008</ArticleId>
+            <ArticleId IdType="pubmed">35717745</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Avis NE, Crawford SL, Green R. Vasomotor Symptoms Across the Menopause Transition: Differences among Women. Obstet Gynecol Clin North Am. 2018;45(4):629&#8211;640. doi: 10.1016/j.ogc.2018.07.005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.ogc.2018.07.005</ArticleId>
+            <ArticleId IdType="pmc">PMC6226273</ArticleId>
+            <ArticleId IdType="pubmed">30401547</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Zhou T. Estimation of Placebo Effect in Randomized Placebo-Controlled Trials for Moderate or Severe Vasomotor Symptoms: A Meta-Analysis. Menopause. 2023;30(1):5&#8211;10. doi: 10.1097/GME.0000000000002094.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000002094</ArticleId>
+            <ArticleId IdType="pubmed">36576440</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Grygorieva NV, Kovalenko VM, K&#1086;rzh M&#1054;, Tatarchuk TF, Dedukh NV, Strafun SS. Guideline for Diagnostic, Prevention and Treatment of Postmenopausal Osteoporosis. Pain, Joints, Spine. 2023;13(3):128&#8211;154. doi: 10.22141/pjs.13.3.2023.378.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.22141/pjs.13.3.2023.378</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Liu J, Jin X, Liu W, Chen W, Wang L, Feng Z, et al. The Risk of Long-Term Cardiometabolic Disease in Women with Premature or Early Menopause: A Systematic Review and Meta-Analysis. Front Cardiovasc Med. 2023;10:1131251&#8211;1131251. doi: 10.3389/fcvm.2023.1131251.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3389/fcvm.2023.1131251</ArticleId>
+            <ArticleId IdType="pmc">PMC10072266</ArticleId>
+            <ArticleId IdType="pubmed">37025693</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hussain I, Talaulikar VS. A Systematic Review of Randomised Clinical Trials - The Safety of Vaginal Hormones and Selective Estrogen Receptor Modulators for the Treatment of Genitourinary Menopausal Symptoms in Breast Cancer Survivors. Post Reprod Health. 2023;29(4):222&#8211;231. doi: 10.1177/20533691231208473.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/20533691231208473</ArticleId>
+            <ArticleId IdType="pmc">PMC10704880</ArticleId>
+            <ArticleId IdType="pubmed">37840298</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Divaris E, Anagnostis P, Gkekas NK, Kouidi E, Goulis DG. Early Menopause and Premature Ovarian Insufficiency May Increase the Risk of Sarcopenia: A Systematic Review and Meta-Analysis. Maturitas. 2023;175:107782&#8211;107782. doi: 10.1016/j.maturitas.2023.05.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2023.05.006</ArticleId>
+            <ArticleId IdType="pubmed">37331156</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Simon JA, Ferenczy A, Black D, Castonguay A, Royer C, Marouf R, et al. Efficacy, Tolerability, and Endometrial Safety of Ospemifene Compared with Current Therapies for the Treatment of Vulvovaginal Atrophy: A Systematic Literature Review and Network Meta-Analysis. Menopause. 2023;30(8):855&#8211;866. doi: 10.1097/GME.0000000000002211.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000002211</ArticleId>
+            <ArticleId IdType="pmc">PMC10389189</ArticleId>
+            <ArticleId IdType="pubmed">37369079</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Khan SJ, Kapoor E, Faubion SS, Kling JM. Vasomotor Symptoms During Menopause: A Practical Guide on Current Treatments and Future Perspectives. Int J Womens Health. 2023;15:273&#8211;287. doi: 10.2147/IJWH.S365808.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2147/IJWH.S365808</ArticleId>
+            <ArticleId IdType="pmc">PMC9938702</ArticleId>
+            <ArticleId IdType="pubmed">36820056</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>H&#228;ndel MN, Cardoso I, von B&#252;low C, Rohde JF, Ussing A, Nielsen SM, et al. Fracture Risk Reduction and Safety by Osteoporosis Treatment Compared with Placebo or Active Comparator in Postmenopausal Women: Systematic Review, Network Meta-Analysis, and Meta-Regression Analysis of Randomised Clinical Trials. BMJ. 2023;381:e068033. doi: 10.1136/bmj-2021-068033.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj-2021-068033</ArticleId>
+            <ArticleId IdType="pmc">PMC10152340</ArticleId>
+            <ArticleId IdType="pubmed">37130601</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Long G, Liu C, Liang T, Zhang Z, Qin Z, Zhan X. Predictors of Osteoporotic Fracture in Postmenopausal Women: A Meta-Analysis. J Orthop Surg Res. 2023;18(1):574&#8211;574. doi: 10.1186/s13018-023-04051-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s13018-023-04051-6</ArticleId>
+            <ArticleId IdType="pmc">PMC10404374</ArticleId>
+            <ArticleId IdType="pubmed">37543616</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gold&#353;tajn M&#352;, Miku&#353; M, Ferrari FA, Bosco M, Uccella S, Noventa M, et al. Effects of Transdermal versus Oral Hormone Replacement Therapy in Postmenopause: A Systematic Review. Arch Gynecol Obstet. 2023;307(6):1727&#8211;1745. doi: 10.1007/s00404-022-06647-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s00404-022-06647-5</ArticleId>
+            <ArticleId IdType="pmc">PMC10147786</ArticleId>
+            <ArticleId IdType="pubmed">35713694</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Eastell R, Rosen CJ, Black DM, Cheung AM, Murad MH, Shoback D. Pharmacological Management of Osteoporosis in Postmenopausal Women: An Endocrine Society* Clinical Practice Guideline. J Clin Endocrinol Metab. 2019;104(5):1595&#8211;1522. doi: 10.1210/jc.2019-00221.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2019-00221</ArticleId>
+            <ArticleId IdType="pubmed">30907953</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li B, Duan H, Chang Y, Wang S. Efficacy and Safety of Current Therapies for Genitourinary Syndrome of Menopause: A Bayesian Network Analysis of 29 Randomized Trials and 8311 Patients. Pharmacol Res. 2021;164:105360&#8211;105360. doi: 10.1016/j.phrs.2020.105360.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.phrs.2020.105360</ArticleId>
+            <ArticleId IdType="pubmed">33307219</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Manson JE, Aragaki AK, Bassuk SS, Chlebowski RT, Anderson GL, Rossouw JE, et al. Menopausal Estrogen-Alone Therapy and Health Outcomes in Women with and without Bilateral Oophorectomy: A Randomized Trial. Ann Intern Med. 2019;171(6):406&#8211;414. doi: 10.7326/M19-0274.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/M19-0274</ArticleId>
+            <ArticleId IdType="pmc">PMC8120507</ArticleId>
+            <ArticleId IdType="pubmed">31499528</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Grodstein F, Stampfer MJ, Colditz GA, Willett WC, Manson JE, Joffe M, et al. Postmenopausal Hormone Therapy and Mortality. N Engl J Med. 1997;336(25):1769&#8211;1775. doi: 10.1056/NEJM199706193362501.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJM199706193362501</ArticleId>
+            <ArticleId IdType="pubmed">9187066</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sullivan JM, Zwaag RV, Lemp GF, Hughes JP, Maddock V, Kroetz FW, et al. Postmenopausal Estrogen Use and Coronary Atherosclerosis. Ann Intern Med. 1988;108(3):358&#8211;363. doi: 10.7326/0003-4819-108-3-358.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-108-3-358</ArticleId>
+            <ArticleId IdType="pubmed">3341672</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gruchow HW, Anderson AJ, Barboriak JJ, Sobocinski KA. Postmenopausal Use of Estrogen and Occlusion of Coronary Arteries. Am Heart J. 1988;115(5):954&#8211;963. doi: 10.1016/0002-8703(88)90063-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0002-8703(88)90063-4</ArticleId>
+            <ArticleId IdType="pubmed">3364352</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>McFarland KF, Boniface ME, Hornung CA, Earnhardt W, Humphries JO. Risk Factors and Noncontraceptive Estrogen Use in Women with and without Coronary Disease. Am Heart J. 1989;117(6):1209&#8211;1214. doi: 10.1016/0002-8703(89)90398-0.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/0002-8703(89)90398-0</ArticleId>
+            <ArticleId IdType="pubmed">2729050</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hamoda H, Moger S, Morris E, Baldeweg SE, Kasliwal A, Gabbay F. Menopause Practice Standards. Clin Endocrinol. 2024;100(1):50&#8211;55. doi: 10.1111/cen.14789.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/cen.14789</ArticleId>
+            <ArticleId IdType="pubmed">35713204</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Manson JE, Aragaki AK, Rossouw JE, Anderson GL, Prentice RL, LaCroix AZ, et al. Menopausal Hormone Therapy and Long-Term All-Cause and Cause-Specific Mortality: The Women's Health Initiative Randomized Trials. JAMA. 2017;318(10):927&#8211;938. doi: 10.1001/jama.2017.11217.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2017.11217</ArticleId>
+            <ArticleId IdType="pmc">PMC5728370</ArticleId>
+            <ArticleId IdType="pubmed">28898378</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mikkola TS, Tuomikoski P, Lyytinen H, Korhonen P, Hoti F, Vattulainen P, et al. Estradiol-Based Postmenopausal Hormone Therapy and Risk of Cardiovascular and All-Cause Mortality. Menopause. 2015;22(9):976&#8211;983. doi: 10.1097/GME.0000000000000450.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000450</ArticleId>
+            <ArticleId IdType="pubmed">25803671</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hodis HN, Mack WJ, Henderson VW, Shoupe D, Budoff MJ, Hwang-Levine J, et al. Vascular Effects of Early versus Late Postmenopausal Treatment with Estradiol. N Engl J Med. 2016;374(13):1221&#8211;1231. doi: 10.1056/NEJMoa1505241.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1056/NEJMoa1505241</ArticleId>
+            <ArticleId IdType="pmc">PMC4921205</ArticleId>
+            <ArticleId IdType="pubmed">27028912</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Shufelt CL, Merz CN, Prentice RL, Pettinger MB, Rossouw JE, Aroda VR, et al. Hormone Therapy Dose, Formulation, Route of Delivery, and Risk of Cardiovascular Events in Women: Findings from the Women's Health Initiative Observational Study. Menopause. 2014;21(3):260&#8211;266. doi: 10.1097/GME.0b013e31829a64f9.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0b013e31829a64f9</ArticleId>
+            <ArticleId IdType="pmc">PMC3872264</ArticleId>
+            <ArticleId IdType="pubmed">24045672</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gartlehner G, Patel SV, Reddy S, Rains C, Schwimmer M, Kahwati L. Hormone Therapy for the Primary Prevention of Chronic Conditions in Postmenopausal Persons: Updated Evidence Report and Systematic Review for the US Preventive Services Task Force. JAMA. 2022;328(17):1747&#8211;1765. doi: 10.1001/jama.2022.18324.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2022.18324</ArticleId>
+            <ArticleId IdType="pubmed">36318128</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Prentice RL, Aragaki AK, Chlebowski RT, Rossouw JE, Anderson GL, Stefanick ML, et al. Randomized Trial Evaluation of the Benefits and Risks of Menopausal Hormone Therapy among Women 50-59 Years of Age. Am J Epidemiol. 2021;190(3):365&#8211;375. doi: 10.1093/aje/kwaa210.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/aje/kwaa210</ArticleId>
+            <ArticleId IdType="pmc">PMC8086238</ArticleId>
+            <ArticleId IdType="pubmed">33025002</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Henderson VW, St John JA, Hodis HN, McCleary CA, Stanczyk FZ, Shoupe D, et al. Cognitive Effects of Estradiol after Menopause: A Randomized Trial of the Timing Hypothesis. Neurology. 2016;87(7):699&#8211;708. doi: 10.1212/WNL.0000000000002980.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1212/WNL.0000000000002980</ArticleId>
+            <ArticleId IdType="pmc">PMC4999165</ArticleId>
+            <ArticleId IdType="pubmed">27421538</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Espeland MA, Rapp SR, Manson JE, Goveas JS, Shumaker SA, Hayden KM, et al. Long-term Effects on Cognitive Trajectories of Postmenopausal Hormone Therapy in Two Age Groups. J Gerontol A Biol Sci Med Sci. 2017;72(6):838&#8211;845. doi: 10.1093/gerona/glw156.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/gerona/glw156</ArticleId>
+            <ArticleId IdType="pmc">PMC6075542</ArticleId>
+            <ArticleId IdType="pubmed">27506836</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kantarci K, Tosakulwong N, Lesnick TG, Zuk SM, Gunter JL, Gleason CE, et al. Effects of Hormone Therapy on Brain Structure: A randomized Controlled Trial. Neurology. 2016;87(9):887&#8211;896. doi: 10.1212/WNL.0000000000002970.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1212/WNL.0000000000002970</ArticleId>
+            <ArticleId IdType="pmc">PMC5035155</ArticleId>
+            <ArticleId IdType="pubmed">27473135</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>American College of Obstetricians and Gynecologists ACOG Committee Opinion No. 565: Hormone therapy and heart disease. Obstet Gynecol. 2013;121(6):1407&#8211;1410. doi: 10.1097/01.AOG.0000431053.33593.2d.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/01.AOG.0000431053.33593.2d</ArticleId>
+            <ArticleId IdType="pubmed">23812486</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cobin RH, Goodman NF, AACE Reproductive Endocrinology Scientific Committee American Association of Clinical Endocrinologists and American College of Endocrinology Position Statement on Menopause&#8212;2017 Update. Endocr Pract. 2017;23(7):869&#8211;880.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">28703650</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>US Food and Drug Administration  . Menopause: Medicines to Help You [Internet] Maryland: Food and Drug Administration; 2019.  [cited 2024 Jan 30].  Available from:  https://www.fda.gov/consumers/free-publications-women/menopause-medicineshelp-you
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Effects of Estrogen or Estrogen/Progestin Regimens on Heart Disease Risk Factors in Postmenopausal Women. The Postmenopausal Estrogen/Progestin Interventions (PEPI) Trial. The Writing Group for the PEPI Trial. JAMA. 1995;273(3):199&#8211;208. doi: 10.1001/jama.1995.03520270033028.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.1995.03520270033028</ArticleId>
+            <ArticleId IdType="pubmed">7807658</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chapman N, Ching SM, Konradi AO, Nuyt AM, Khan T, Twumasi-Ankrah B, et al. Arterial Hypertension in Women: State of the Art and Knowledge Gaps. Hypertension. 2023;80(6):1140&#8211;1149. doi: 10.1161/HYPERTENSIONAHA.122.20448.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/HYPERTENSIONAHA.122.20448</ArticleId>
+            <ArticleId IdType="pubmed">36919603</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>D'Ignazio T, Grand'Maison S, B&#233;rub&#233; L, Forcillo J, Pacheco C. Hypertension Across a Woman's lifespan. Maturitas. 2023;168:84&#8211;91. doi: 10.1016/j.maturitas.2022.11.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2022.11.006</ArticleId>
+            <ArticleId IdType="pubmed">36549261</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Urban LABD, Chala LF, Paula IB, Bauab SDP, Schaefer MB, Oliveira ALK, et al. Recommendations for Breast Cancer Screening in Brazil, from the Brazilian College of Radiology and Diagnostic Imaging, the Brazilian Society of Mastology, and the Brazilian Federation of Gynecology and Obstetrics Associations. Radiol Bras. 2023;56(4):207&#8211;214. doi: 10.1590/0100-3984.2023.0064-en.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1590/0100-3984.2023.0064-en</ArticleId>
+            <ArticleId IdType="pmc">PMC10567087</ArticleId>
+            <ArticleId IdType="pubmed">37829583</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gartlehner G, Patel SV, Reddy S, Rains C, Coker-Schwimmer M, Kahwati L. Hormone Therapy for the Primary Prevention of Chronic Conditions in Postmenopausal Persons: An Evidence Review for the U.S. Preventive Services Task Force. Rockville: Agency for Healthcare Research and Quality (US); 2022.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">36413605</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guthrie KA, LaCroix AZ, Ensrud KE, Joffe H, Newton KM, Reed SD, et al. Pooled Analysis of Six Pharmacologic and Nonpharmacologic Interventions for Vasomotor Symptoms. Obstet Gynecol. 2015;126(2):413&#8211;422. doi: 10.1097/AOG.0000000000000927.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/AOG.0000000000000927</ArticleId>
+            <ArticleId IdType="pmc">PMC4526122</ArticleId>
+            <ArticleId IdType="pubmed">26241433</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Handley AP, Williams M. The Efficacy and Tolerability of SSRI/SNRIs in the Treatment of Vasomotor Symptoms in Menopausal Women: A Systematic Review. J Am Assoc Nurse Pract. 2015;27(1):54&#8211;61. doi: 10.1002/2327-6924.12137.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/2327-6924.12137</ArticleId>
+            <ArticleId IdType="pubmed">24944075</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cushman M, Kuller LH, Prentice R, Rodabough RJ, Psaty BM, Stafford RS, et al. Estrogen Plus Progestin and Risk of Venous Thrombosis. JAMA. 2004;292(13):1573&#8211;1580. doi: 10.1001/jama.292.13.1573.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.292.13.1573</ArticleId>
+            <ArticleId IdType="pubmed">15467059</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Joffe H, Guthrie KA, LaCroix AZ, Reed SD, Ensrud KE, Manson JE, et al. Low-Dose Estradiol and the Serotonin-Norepinephrine Reuptake Inhibitor Venlafaxine for Vasomotor Symptoms: A Randomized Clinical Trial. JAMA Intern Med. 2014;174(7):1058&#8211;1066. doi: 10.1001/jamainternmed.2014.1891.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jamainternmed.2014.1891</ArticleId>
+            <ArticleId IdType="pmc">PMC4179877</ArticleId>
+            <ArticleId IdType="pubmed">24861828</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Johnson KA, Martin N, Nappi RE, Neal-Perry G, Shapiro M, Stute P, et al. Efficacy and Safety of Fezolinetant in Moderate to Severe Vasomotor Symptoms Associated with Menopause: A Phase 3 RCT. J Clin Endocrinol Metab. 2023;108(8):1981&#8211;1997. doi: 10.1210/clinem/dgad058.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/clinem/dgad058</ArticleId>
+            <ArticleId IdType="pmc">PMC10348473</ArticleId>
+            <ArticleId IdType="pubmed">36734148</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lederman S, Ottery FD, Cano A, Santoro N, Shapiro M, Stute P, et al. Fezolinetant for Treatment of Moderate-To-Severe Vasomotor Symptoms Associated with Menopause (SKYLIGHT 1): A Phase 3 Randomised Controlled Study. Lancet. 2023;401(10382):1091&#8211;1102. doi: 10.1016/S0140-6736(23)00085-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0140-6736(23)00085-5</ArticleId>
+            <ArticleId IdType="pubmed">36924778</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pinkerton JV, Constantine G, Hwang E, Cheng RF, Study 3353 Investigators Desvenlafaxine Compared with Placebo for Treatment of Menopausal Vasomotor Symptoms: A 12-Week, Multicenter, Parallel-Group, Randomized, Double-Blind, Placebo-Controlled Efficacy Trial. Menopause. 2013;20(1):28&#8211;37. doi: 10.1097/gme.0b013e31826421a8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e31826421a8</ArticleId>
+            <ArticleId IdType="pubmed">23010882</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pinkerton JV, Kagan R, Portman D, Sathyanarayana R, Sweeney M. Breeze 3 Investigators. Phase 3 Randomized Controlled Study of Gastroretentive Gabapentin for the Treatment of Moderate-To-Severe Hot Flashes in Menopause. Menopause. 2014;21(6):567&#8211;573. doi: 10.1097/GME.0b013e3182a7c073.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0b013e3182a7c073</ArticleId>
+            <ArticleId IdType="pubmed">24149930</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chlebowski RT, Anderson GL, Aragaki AK, Manson JE, Stefanick ML, Pan K, et al. Association of Menopausal Hormone Therapy with Breast Cancer Incidence and Mortality During Long-term Follow-up of the Women's Health Initiative Randomized Clinical Trials. JAMA. 2020;324(4):369&#8211;380. doi: 10.1001/jama.2020.9482.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2020.9482</ArticleId>
+            <ArticleId IdType="pmc">PMC7388026</ArticleId>
+            <ArticleId IdType="pubmed">32721007</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Prentice RL, Aragaki AK, Chlebowski RT, Zhao S, Anderson GL, Rossouw JE, et al. Dual-Outcome Intention-to-Treat Analyses in the Women's Health Initiative Randomized Controlled Hormone Therapy Trials. Am J Epidemiol. 2020;189(9):972&#8211;981. doi: 10.1093/aje/kwaa033.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/aje/kwaa033</ArticleId>
+            <ArticleId IdType="pmc">PMC7443766</ArticleId>
+            <ArticleId IdType="pubmed">32314781</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Crandall CJ, Mehta JM, Manson JE. Management of Menopausal Symptoms: A Review. JAMA. 2023;329(5):405&#8211;420. doi: 10.1001/jama.2022.24140.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2022.24140</ArticleId>
+            <ArticleId IdType="pubmed">36749328</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>National Academies of Sciences, Engineering, and Medicine; Health and Medicine Division; Board on Health Sciences Policy; Committee on the Clinical Utility of Treating Patients with Compounded Bioidentical Hormone Replacement Therapy . In: The Clinical Utility of Compounded Bioidentical Hormone Therapy: A Review of Safety, Effectiveness, and Use. Jackson LM, Parker RM, Mattison DR, editors. Washington: National Academies Press; 2020.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">33048485</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dodin S, Blanchet C, Marc I, Ernst E, Wu T, Vaillancourt C, et al. Acupuncture for Menopausal Hot Flushes. Cochrane Database Syst Rev. 2013;2013(7):CD007410. doi: 10.1002/14651858.CD007410.pub2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD007410.pub2</ArticleId>
+            <ArticleId IdType="pmc">PMC6544807</ArticleId>
+            <ArticleId IdType="pubmed">23897589</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Saensak S, Vutyavanich T, Somboonporn W, Srisurapanont M. Relaxation for Perimenopausal and Postmenopausal Symptoms. Cochrane Database Syst Rev. 2014;(7):CD008582. doi: 10.1002/14651858.CD008582.pub2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD008582.pub2</ArticleId>
+            <ArticleId IdType="pmc">PMC11094687</ArticleId>
+            <ArticleId IdType="pubmed">25039019</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lethaby A, Marjoribanks J, Kronenberg F, Roberts H, Eden J, Brown J. Phytoestrogens for Menopausal Vasomotor Symptoms. Cochrane Database Syst Rev. 2013;2013(12):CD001395. doi: 10.1002/14651858.CD001395.pub4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD001395.pub4</ArticleId>
+            <ArticleId IdType="pmc">PMC10247921</ArticleId>
+            <ArticleId IdType="pubmed">24323914</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Daley A, Stokes-Lampard H, Thomas A, MacArthur C. Exercise for Vasomotor Menopausal Symptoms. Cochrane Database Syst Rev. 2014;2014(11):CD006108. doi: 10.1002/14651858.CD006108.pub4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD006108.pub4</ArticleId>
+            <ArticleId IdType="pmc">PMC10116337</ArticleId>
+            <ArticleId IdType="pubmed">25431132</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Maclennan AH, Broadbent JL, Lester S, Moore V. Oral Oestrogen and Combined Oestrogen/Progestogen Therapy versus Placebo for Hot Flushes. Cochrane Database Syst Rev. 2004;2004(4):CD002978. doi: 10.1002/14651858.CD002978.pub2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/14651858.CD002978.pub2</ArticleId>
+            <ArticleId IdType="pmc">PMC7004247</ArticleId>
+            <ArticleId IdType="pubmed">15495039</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Baber RJ, Panay N, Fenton A, IMS Writing Group 2016 IMS Recommendations on Women's Midlife Health and Menopause Hormone Therapy. Climacteric. 2016;19(2):109&#8211;150. doi: 10.3109/13697137.2015.1129166.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2015.1129166</ArticleId>
+            <ArticleId IdType="pubmed">26872610</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Nahas E, Nahas J., Neto Hormonal Therapy: Benefits, Risks and Therapeutic Regimens. Femina. 2019;47(7):443&#8211;448.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Kenemans P, Speroff L, International Tibolone Consensus Group Tibolone: Clinical Recommendations and Practical Guidelines. A Report of the International Tibolone Consensus Group. Maturitas. 2005;51(1):21&#8211;28. doi: 10.1016/j.maturitas.2005.02.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2005.02.011</ArticleId>
+            <ArticleId IdType="pubmed">15883105</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cox S, Nasseri R, Rubin RS, Santiago-Lastra Y. Genitourinary Syndrome of Menopause. Med Clin North Am. 2023;107(2):357&#8211;369. doi: 10.1016/j.mcna.2022.10.017.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mcna.2022.10.017</ArticleId>
+            <ArticleId IdType="pubmed">36759102</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Goodman MP. Are All Estrogens Created Equal? A Review Of oral vs. Transdermal Therapy. J Womens Health. 2012;21(2):161&#8211;169. doi: 10.1089/jwh.2011.2839.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1089/jwh.2011.2839</ArticleId>
+            <ArticleId IdType="pubmed">22011208</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Godsland IF. Effects of Postmenopausal Hormone Replacement Therapy on Lipid, Lipoprotein, and Apolipoprotein (a) Concentrations: Analysis of Studies Published from 1974-2000. Fertil Steril. 2001;75(5):898&#8211;915. doi: 10.1016/s0015-0282(01)01699-5.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0015-0282(01)01699-5</ArticleId>
+            <ArticleId IdType="pubmed">11334901</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Canonico M, Oger E, Plu-Bureau G, Conard J, Meyer G, L&#233;vesque H, et al. Hormone Therapy and Venous Thromboembolism among Postmenopausal Women: Impact of the Route of Estrogen Administration and Progestogens: The ESTHER Study. Circulation. 2007;115(7):840&#8211;845. doi: 10.1161/CIRCULATIONAHA.106.642280.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCULATIONAHA.106.642280</ArticleId>
+            <ArticleId IdType="pubmed">17309934</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Renoux C, Dell'Aniello S, Suissa S. Hormone Replacement Therapy and the Risk of Venous Thromboembolism: A Population-Based Study. J Thromb Haemost. 2010;8(5):979&#8211;986. doi: 10.1111/j.1538-7836.2010.03839.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/j.1538-7836.2010.03839.x</ArticleId>
+            <ArticleId IdType="pubmed">20230416</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vinogradova Y, Coupland C, Hippisley-Cox J. Use of Hormone Replacement Therapy and Risk of Venous Thromboembolism: Nested Case-Control Studies Using the QResearch and CPRD Databases. BMJ. 2019;364:k4810. doi: 10.1136/bmj.k4810.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.k4810</ArticleId>
+            <ArticleId IdType="pmc">PMC6326068</ArticleId>
+            <ArticleId IdType="pubmed">30626577</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Notelovitz M, Lenihan JP, McDermott M, Kerber IJ, Nanavati N, Arce J. Initial 17beta-Estradiol Dose for Treating Vasomotor Symptoms. Obstet Gynecol. 2000;95(5):726&#8211;731. doi: 10.1016/s0029-7844(99)00643-2.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/s0029-7844(99)00643-2</ArticleId>
+            <ArticleId IdType="pubmed">10775738</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pompei LM, Machado RB, Wender COM, Fernandes CE. Consenso Brasileiro de Terap&#234;utica Hormonal da Menopausa. S&#227;o Paulo: Leitura M&#233;dica; 2018.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Grodstein F, Manson JE, Colditz GA, Willett WC, Speizer FE, Stampfer MJ. A Prospective Observational Study of Postmenopausal Hormone Therapy and Primary Prevention of Cardiovascular Disease. Ann Intern Med. 2000;133(12):933&#8211;941. doi: 10.7326/0003-4819-133-12-200012190-00008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-133-12-200012190-00008</ArticleId>
+            <ArticleId IdType="pubmed">11119394</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Manson JE, Chlebowski RT, Stefanick ML, Aragaki AK, Rossouw JE, Prentice RL, et al. Menopausal Hormone Therapy and Health Outcomes During the Intervention and Extended Poststopping Phases of the Women's Health Initiative Randomized Trials. JAMA. 2013;310(13):1353&#8211;1368. doi: 10.1001/jama.2013.278040.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.2013.278040</ArticleId>
+            <ArticleId IdType="pmc">PMC3963523</ArticleId>
+            <ArticleId IdType="pubmed">24084921</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schierbeck LL, Rejnmark L, Tofteng CL, Stilgren L, Eiken P, Mosekilde L, et al. Effect of Hormone Replacement Therapy on Cardiovascular Events in Recently Postmenopausal Women: Randomised Trial. BMJ. 2012;345:e6409. doi: 10.1136/bmj.e6409.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.e6409</ArticleId>
+            <ArticleId IdType="pubmed">23048011</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rossouw JE. Coronary Heart Disease in Menopausal Women: Implications of Primary and Secondary Prevention Trials of Hormones. Maturitas. 2005;51(1):51&#8211;63. doi: 10.1016/j.maturitas.2005.02.015.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2005.02.015</ArticleId>
+            <ArticleId IdType="pubmed">15883110</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Grodstein F, Manson JE, Stampfer MJ, Willett WC. The Discrepancy between Observational Studies and Randomized Trials of Menopausal Hormone Therapy. Ann Intern Med. 2004;140(9):764&#8211;765. doi: 10.7326/0003-4819-140-9-200405040-00026.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.7326/0003-4819-140-9-200405040-00026</ArticleId>
+            <ArticleId IdType="pubmed">15126266</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rossouw JE, Prentice RL, Manson JE, Wu L, Barad D, Barnabei VM, et al. Postmenopausal Hormone Therapy and Risk of Cardiovascular Disease by Age and Years Since Menopause. JAMA. 2007;297(13):1465&#8211;1477. doi: 10.1001/jama.297.13.1465.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.297.13.1465</ArticleId>
+            <ArticleId IdType="pubmed">17405972</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Davis SR, Baber RJ. Treating Menopause - MHT and Beyond. Nat Rev Endocrinol. 2022;18(8):490&#8211;502. doi: 10.1038/s41574-022-00685-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41574-022-00685-4</ArticleId>
+            <ArticleId IdType="pubmed">35624141</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Flores VA, Pal L, Manson JE. Hormone Therapy in Menopause: Concepts, Controversies, and Approach to Treatment. Endocr Rev. 2021;42(6):720&#8211;752. doi: 10.1210/endrev/bnab011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/endrev/bnab011</ArticleId>
+            <ArticleId IdType="pubmed">33858012</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Canonico M, Plu-Bureau G, Lowe GD, Scarabin PY. Hormone Replacement Therapy and Risk of Venous Thromboembolism in Postmenopausal Women: Systematic Review and Meta-Analysis. BMJ. 2008;336(7655):1227&#8211;1231. doi: 10.1136/bmj.39555.441944.BE.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmj.39555.441944.BE</ArticleId>
+            <ArticleId IdType="pmc">PMC2405857</ArticleId>
+            <ArticleId IdType="pubmed">18495631</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Mohammed K, Abu Dabrh AM, Benkhadra K, Al Nofal A, Leon BGC, Prokop LJ, et al. Oral vs Transdermal Estrogen Therapy and Vascular Events: A Systematic Review and Meta-Analysis. J Clin Endocrinol Metab. 2015;100(11):4012&#8211;4020. doi: 10.1210/jc.2015-2237.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1210/jc.2015-2237</ArticleId>
+            <ArticleId IdType="pubmed">26544651</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hirsch H, Manson JE. Menopausal Symptom Management in Women with Cardiovascular Disease or Vascular Risk Factors. Maturitas. 2022;161:1&#8211;6. doi: 10.1016/j.maturitas.2022.01.016.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2022.01.016</ArticleId>
+            <ArticleId IdType="pubmed">35688488</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cho L, Kaunitz AM, Faubion SS, Hayes SN, Lau ES, Pristera N, et al. Rethinking Menopausal Hormone Therapy: For Whom, What, When, and How Long? Circulation. 2023;147(7):597&#8211;610. doi: 10.1161/CIRCULATIONAHA.122.061559.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1161/CIRCULATIONAHA.122.061559</ArticleId>
+            <ArticleId IdType="pmc">PMC10708894</ArticleId>
+            <ArticleId IdType="pubmed">36780393</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Salpeter SR, Walsh JM, Ormiston TM, Greyber E, Buckley NS, Salpeter EE. Meta-Analysis: Effect of Hormone-Replacement Therapy on Components of the Metabolic Syndrome in Postmenopausal Women. Diabetes Obes Metab. 2006;8(5):538&#8211;554. doi: 10.1111/j.1463-1326.2005.00545.x.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/j.1463-1326.2005.00545.x</ArticleId>
+            <ArticleId IdType="pubmed">16918589</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bontempo S, Yeganeh L, Giri R, Vincent AJ. Use of MHT in Women with Cardiovascular Disease: A Systematic Review and Meta-Analysis. Climacteric. 2024;27(1):93&#8211;103. doi: 10.1080/13697137.2023.2273524.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2023.2273524</ArticleId>
+            <ArticleId IdType="pubmed">37933495</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cherry N, McNamee R, Heagerty A, Kitchener H, Hannaford P. Long-Term Safety of Unopposed Estrogen Used by Women Surviving Myocardial Infarction: 14-Year Follow-Up of the ESPRIT Randomised Controlled Trial. BJOG. 2014;121(6):700&#8211;705. doi: 10.1111/1471-0528.12598.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/1471-0528.12598</ArticleId>
+            <ArticleId IdType="pubmed">24533510</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jiang X, Bossert A, Parthasarathy KN, Leaman K, Minassian SS, Schnatz PF, et al. Safety Assessment of Compounded Non-FDA-Approved Hormonal Therapy versus FDA-Approved Hormonal Therapy in Treating Postmenopausal Women. Menopause. 2021;28(8):867&#8211;874. doi: 10.1097/GME.0000000000001782.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000001782</ArticleId>
+            <ArticleId IdType="pubmed">33973545</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Glaser R, Kalantaridou S, Dimitrakakis C. Testosterone Implants in Women: Pharmacological Dosing for a Physiologic Effect. Maturitas. 2013;74(2):179&#8211;184. doi: 10.1016/j.maturitas.2012.11.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2012.11.004</ArticleId>
+            <ArticleId IdType="pubmed">23265303</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Glaser RL, York AE, Dimitrakakis C. Incidence of Invasive Breast Cancer in Women Treated with Testosterone Implants: A Prospective 10-Year Cohort Study. BMC Cancer. 2019;19(1):1271&#8211;1271. doi: 10.1186/s12885-019-6457-8.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s12885-019-6457-8</ArticleId>
+            <ArticleId IdType="pmc">PMC6937705</ArticleId>
+            <ArticleId IdType="pubmed">31888528</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Donovitz GS. Low Complication Rates of Testosterone and Estradiol Implants for Androgen and Estrogen Replacement Therapy in Over 1 Million Procedures. Ther Adv Endocrinol Metab. 2021;12:20420188211015238&#8211;20420188211015238. doi: 10.1177/20420188211015238.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/20420188211015238</ArticleId>
+            <ArticleId IdType="pmc">PMC8165877</ArticleId>
+            <ArticleId IdType="pubmed">34104398</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Federa&#231;&#227;o Brasileira das Associa&#231;&#245;es de Ginecologia e Obstetr&#237;cia  . Posi&#231;&#227;o das Comiss&#245;es Nacionais Especializadas de Anticoncep&#231;&#227;o e Climat&#233;rio da Febrasgo sobre Implantes Hormonais [Internet] Rio de Janeiro: Federa&#231;&#227;o Brasileira das Associa&#231;&#245;es de Ginecologia e Obstetr&#237;cia; 2021.  [cited 2024 Jan 30].  Available from:  https://www.febrasgo.org.br/pt/noticias/item/1312-posicao-das-comissoes-nacionais-especializadas-de-anticoncepcao-e-climaterio-da-febrasgo-sobre-implantes-hormonais%2021.3
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Nelson HD, Vesco KK, Haney E, Fu R, Nedrow A, Miller J, et al. Nonhormonal Therapies for Menopausal Hot Flashes: Systematic Review and Meta-Analysis. JAMA. 2006;295(17):2057&#8211;2071. doi: 10.1001/jama.295.17.2057.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.295.17.2057</ArticleId>
+            <ArticleId IdType="pubmed">16670414</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Azizi M, Khani S, Kamali M, Elyasi F. The Efficacy and Safety of Selective Serotonin Reuptake Inhibitors and Serotonin-Norepinephrine Reuptake Inhibitors in the Treatment of Menopausal Hot Flashes: A Systematic Review of Clinical Trials. Iran J Med Sci. 2022;47(3):173&#8211;193. doi: 10.30476/ijms.2020.87687.1817.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.30476/ijms.2020.87687.1817</ArticleId>
+            <ArticleId IdType="pmc">PMC9126898</ArticleId>
+            <ArticleId IdType="pubmed">35634530</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Yoon SH, Lee JY, Lee C, Lee H, Kim SN. Gabapentin for the Treatment of Hot Flushes in Menopause: A Meta-Analysis. Menopause. 2020;27(4):485&#8211;493. doi: 10.1097/GME.0000000000001491.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000001491</ArticleId>
+            <ArticleId IdType="pubmed">32049930</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>North American Menopause Society The 2023 Nonhormone Therapy Position Statement of The North American Menopause Society. Menopause. 2023;30(6):573&#8211;590. doi: 10.1097/GME.0000000000002200.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000002200</ArticleId>
+            <ArticleId IdType="pubmed">37252752</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>hen MN, Lin CC, Liu CF. Efficacy of phytoestrogens for Menopausal Symptoms: A Meta-Analysis and Systematic Review. Climacteric. 2015;18(2):260&#8211;269. doi: 10.3109/13697137.2014.966241.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2014.966241</ArticleId>
+            <ArticleId IdType="pmc">PMC4389700</ArticleId>
+            <ArticleId IdType="pubmed">25263312</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sarri G, Pedder H, Dias S, Guo Y, Lumsden MA. Vasomotor Symptoms Resulting from Natural Menopause: A Systematic Review and Network Meta-Analysis of Treatment Effects from the National Institute for Health and Care Excellence Guideline on Menopause. BJOG. 2017;124(10):1514&#8211;1523. doi: 10.1111/1471-0528.14619.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1111/1471-0528.14619</ArticleId>
+            <ArticleId IdType="pubmed">28276200</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rees M, Bitzer J, Cano A, Ceausu I, Chedraui P, Durmusoglu F, et al. Global Consensus Recommendations on Menopause in the Workplace: A European Menopause and Andropause Society (EMAS) Position Statement. Maturitas. 2021;151:55&#8211;62. doi: 10.1016/j.maturitas.2021.06.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2021.06.006</ArticleId>
+            <ArticleId IdType="pubmed">34274202</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Verdonk P, Bendien E, Appelman Y. Menopause and Work: A Narrative Literature Review about Menopause, Work and Health. Work. 2022;72(2):483&#8211;496. doi: 10.3233/WOR-205214.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3233/WOR-205214</ArticleId>
+            <ArticleId IdType="pmc">PMC9277682</ArticleId>
+            <ArticleId IdType="pubmed">35570508</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Sarrel PM. Women, Work, and Menopause. Menopause. 2012;19(3):250&#8211;252. doi: 10.1097/gme.0b013e3182434e0c.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e3182434e0c</ArticleId>
+            <ArticleId IdType="pubmed">22228323</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>O'Neill MT, Jones V, Reid A. Impact of Menopausal Symptoms on Work and Careers: A Cross-Sectional Study. Occup Med. 2023;73(6):332&#8211;338. doi: 10.1093/occmed/kqad078.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/occmed/kqad078</ArticleId>
+            <ArticleId IdType="pmc">PMC10540666</ArticleId>
+            <ArticleId IdType="pubmed">37542726</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Carter S, Jay O, Black KI. Talking about Menopause in the Workplace. Case Rep Womens Health. 2021;30:e00306. doi: 10.1016/j.crwh.2021.e00306.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.crwh.2021.e00306</ArticleId>
+            <ArticleId IdType="pmc">PMC7995468</ArticleId>
+            <ArticleId IdType="pubmed">33796445</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Geukes M, van Aalst MP, Robroek SJ, Laven JS, Oosterhof H. The Impact of Menopause on Work Ability in Women with Severe Menopausal Symptoms. Maturitas. 2016;90:3&#8211;8. doi: 10.1016/j.maturitas.2016.05.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2016.05.001</ArticleId>
+            <ArticleId IdType="pubmed">27282787</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Kopenhager T, Guidozzi F. Working Women and the Menopause. Climacteric. 2015;18(3):372&#8211;375. doi: 10.3109/13697137.2015.1020483.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2015.1020483</ArticleId>
+            <ArticleId IdType="pubmed">25830628</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jack G, Riach K, Bariola E, Pitts M, Schapper J, Sarrel P. Menopause in the Workplace: What Employers Should be Doing. Maturitas. 2016;85:88&#8211;95. doi: 10.1016/j.maturitas.2015.12.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2015.12.006</ArticleId>
+            <ArticleId IdType="pubmed">26857886</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>D'Angelo S, Bevilacqua G, Hammond J, Zaballa E, Dennison EM, Walker-Bone K. Impact of Menopausal Symptoms on Work: Findings from Women in the Health and Employment after Fifty (HEAF) Study. Int J Environ Res Public Health. 2022;20(1):295&#8211;295. doi: 10.3390/ijerph20010295.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3390/ijerph20010295</ArticleId>
+            <ArticleId IdType="pmc">PMC9819903</ArticleId>
+            <ArticleId IdType="pubmed">36612616</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Putnam L, Bochanti J. Gendered Bodies: Negotiating Normalcy and Support. Negot Confl Manag Res. 2009;2(1):57&#8211;73. doi: 10.34891/kye3-2d02.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.34891/kye3-2d02</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Reynolds F. Distress and Coping with Hot Flushes at Work: Implications for Counsellors in Occupational Settings. Couns Psychol Q. 1999;12(4):353&#8211;361.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Faubion SS, Enders F, Hedges MS, Chaudhry R, Kling JM, Shufelt CL, et al. Impact of Menopause Symptoms on Women in the Workplace. Mayo Clin Proc. 2023;98(6):833&#8211;845. doi: 10.1016/j.mayocp.2023.02.025.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mayocp.2023.02.025</ArticleId>
+            <ArticleId IdType="pubmed">37115119</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Guitarrara P.  Am&#233;rica Latina [Internet] S&#227;o Paulo: Brasil Escola; 2023.  [cited 2023 Dec 11].  Available from:  https://brasilescola.uol.com.br/geografia/america-latina.htm
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Wikip&#233;dia  . Am&#233;rica Latina [Internet] S&#227;o Francisco: Wikiip&#233;dia; 2023.  [cited 2023 Dec 11].  Available from:  https://pt.wikipedia.org/wiki/America_Latina
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Statista Inc  . Total Population in Latin America and the Caribbean from 2008 to 2022, by Gender (In Million Inhabitants) [Internet] New York: Statista Inc;  [cited 2023 Dec 11].  Available from:  https://www.statista.com/statistics/788405/population-total-gender-latin-america/.
+</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Bilal U, Hessel P, Perez-Ferrer C, Michael YL, Alfaro T, Tenorio-Mucha J, et al. Life Expectancy and Mortality in 363 Cities of Latin America. Nat Med. 2021;27(3):463&#8211;470. doi: 10.1038/s41591-020-01214-4.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1038/s41591-020-01214-4</ArticleId>
+            <ArticleId IdType="pmc">PMC7960508</ArticleId>
+            <ArticleId IdType="pubmed">33495602</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>World Health Organization  . Menopause [Internet] Geneva: WHO; 2023.  [cited 2023 Dec 11].  Available from:  https://www.who.int/news-room/fact-sheets/detail/menopause
+.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Carter AE, Merriam S. Menopause. Med Clin North Am. 2023;107(2):199&#8211;212. doi: 10.1016/j.mcna.2022.10.003.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.mcna.2022.10.003</ArticleId>
+            <ArticleId IdType="pubmed">36759091</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Maas AHEM, Rosano G, Cifkova R, Chieffo A, van Dijken D, Hamoda H, et al. Cardiovascular Health after Menopause Transition, Pregnancy Disorders, and Other Gynaecologic Conditions: A Consensus Document from European Cardiologists, Gynaecologists, and Endocrinologists. Eur Heart J. 2021;42(10):967&#8211;984. doi: 10.1093/eurheartj/ehaa1044.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/eurheartj/ehaa1044</ArticleId>
+            <ArticleId IdType="pmc">PMC7947184</ArticleId>
+            <ArticleId IdType="pubmed">33495787</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Leone T, Brown L, Gemmill A. Secular Trends in Premature and Early Menopause in Low-Income and Middle-Income Countries. BMJ Glob Health. 2023;8(6):e012312. doi: 10.1136/bmjgh-2023-012312.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1136/bmjgh-2023-012312</ArticleId>
+            <ArticleId IdType="pmc">PMC10277122</ArticleId>
+            <ArticleId IdType="pubmed">37308265</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Castelo-Branco C, Bl&#252;mel JE, Chedraui P, Calle A, Bocanera R, Depiano E, et al. Age at Menopause in Latin America. Menopause. 2006;13(4):706&#8211;712. doi: 10.1097/01.gme.0000227338.73738.2d.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/01.gme.0000227338.73738.2d</ArticleId>
+            <ArticleId IdType="pubmed">16837893</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schoenaker DA, Jackson CA, Rowlands JV, Mishra GD. Socioeconomic Position, Lifestyle Factors and Age at Natural Menopause: A Systematic Review and Meta-Analyses of Studies Across Six Continents. Int J Epidemiol. 2014;43(5):1542&#8211;1562. doi: 10.1093/ije/dyu094.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1093/ije/dyu094</ArticleId>
+            <ArticleId IdType="pmc">PMC4190515</ArticleId>
+            <ArticleId IdType="pubmed">24771324</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>American Association of Neurological Surgeons (AANS), American Society of Neuroradiology (ASNR), Cardiovascular and Interventional Radiology Society of Europe (CIRSE), Canadian Interventional Radiology Association (CIRA), Congress of Neurological Surgeons (CNS), European Society of Minimally Invasive Neurological Therapy (ESMINT) et al. Multisociety Consensus Quality Improvement Revised Consensus Statement for Endovascular Therapy of Acute Ischemic Stroke. Int J Stroke. 2018;13(6):612&#8211;632. doi: 10.1177/1747493018778713.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/1747493018778713</ArticleId>
+            <ArticleId IdType="pubmed">29786478</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Palacios S, Henderson VW, Siseles N, Tan D, Villaseca P. Age of Menopause and Impact of Climacteric Symptoms by Geographical Region. Climacteric. 2010;13(5):419&#8211;428. doi: 10.3109/13697137.2010.507886.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2010.507886</ArticleId>
+            <ArticleId IdType="pubmed">20690868</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Chedraui P, Baron G, Belzares E, Bencosme A, Calle A, et al. A Large Multinational Study of Vasomotor Symptom Prevalence, Duration, and Impact on Quality of Life in Middle-Aged Women. Menopause. 2011;18(7):778&#8211;785. doi: 10.1097/gme.0b013e318207851d.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e318207851d</ArticleId>
+            <ArticleId IdType="pubmed">21407137</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>S&#225;nchez-Zarza SC, Armeni AK, Chedraui P, P&#233;rez-L&#243;pez FR, Gavilanes AWD. Prevalence of Menopausal Symptoms and Severity Related Factors among Mid-Aged Paraguayan Women as Measured with the 10-item Cervantes Scale. Gynecol Endocrinol. 2023;39(1):2235427&#8211;2235427. doi: 10.1080/09513590.2023.2235427.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/09513590.2023.2235427</ArticleId>
+            <ArticleId IdType="pubmed">37478894</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Pompei LM, Bonassi-Machado R, Steiner ML, Pompei IM, Melo NR, Nappi RE, et al. Profile of Brazilian Climacteric Women: Results from the Brazilian Menopause Study. Climacteric. 2022;25(5):523&#8211;529. doi: 10.1080/13697137.2022.2088276.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2022.2088276</ArticleId>
+            <ArticleId IdType="pubmed">35801642</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Todorova L, Bonassi R, Carre&#241;o FJG, Hirschberg AL, Yuksel N, Rea C, et al. Prevalence and Impact of Vasomotor Symptoms due to Menopause among Women in Brazil, Canada, Mexico, and Nordic Europe: A Cross-Sectional Survey. Menopause. 2023;30(12):1179&#8211;1189. doi: 10.1097/GME.0000000000002265.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000002265</ArticleId>
+            <ArticleId IdType="pmc">PMC11805475</ArticleId>
+            <ArticleId IdType="pubmed">37847872</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Cano A, Mezones-Holgu&#237;n E, Bar&#243;n G, Bencosme A, Ben&#237;tez Z, et al. A Multinational Study of Sleep Disorders during Female Mid-Life. Maturitas. 2012;72(4):359&#8211;366. doi: 10.1016/j.maturitas.2012.05.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2012.05.011</ArticleId>
+            <ArticleId IdType="pubmed">22717489</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Chedraui P, Baron G, Belzares E, Bencosme A, Calle A, et al. Menopause Could be Involved in the Pathogenesis of Muscle and Joint Aches in Mid-Aged Women. Maturitas. 2013;75(1):94&#8211;100. doi: 10.1016/j.maturitas.2013.02.012.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2013.02.012</ArticleId>
+            <ArticleId IdType="pubmed">23528735</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Chedraui P, Baron G, Belzares E, Bencosme A, Calle A, et al. Sexual Dysfunction in Middle-Aged Women: A Multicenter Latin American Study Using the Female Sexual Function Index. Menopause. 2009;16(6):1139&#8211;1148. doi: 10.1097/gme.0b013e3181a4e317.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/gme.0b013e3181a4e317</ArticleId>
+            <ArticleId IdType="pubmed">19458559</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cruz EF, Nina VJ, Figuer&#234;do ED. Climacteric Symptoms and Sexual Dysfunction: Association between the Blatt-Kupperman Index and the Female Sexual Function Index. Rev Bras Ginecol Obstet. 2017;39(2):66&#8211;71. doi: 10.1055/s-0037-1598603.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1055/s-0037-1598603</ArticleId>
+            <ArticleId IdType="pmc">PMC10309353</ArticleId>
+            <ArticleId IdType="pubmed">28257589</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chedraui P, Bl&#252;mel JE, Baron G, Belzares E, Bencosme A, Calle A, et al. Impaired Quality of Life among Middle Aged Women: A Multicentre Latin American Study. Maturitas. 2008;61(4):323&#8211;329. doi: 10.1016/j.maturitas.2008.09.026.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2008.09.026</ArticleId>
+            <ArticleId IdType="pubmed">19010618</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Tserotas K, Bl&#252;mel JE. Menopause Research in Latin America. Climacteric. 2019;22(1):17&#8211;21. doi: 10.1080/13697137.2018.1540565.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2018.1540565</ArticleId>
+            <ArticleId IdType="pubmed">30572731</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Fica J, Chedraui P, Mezones-Holgu&#237;n E, Zu&#241;iga MC, Witis S, et al. Sedentary Lifestyle in Middle-Aged Women is Associated with Severe Menopausal Symptoms and Obesity. Menopause. 2016;23(5):488&#8211;493. doi: 10.1097/GME.0000000000000575.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1097/GME.0000000000000575</ArticleId>
+            <ArticleId IdType="pubmed">26818013</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Chedraui P, Aedo S, Fica J, Mezones-Holgu&#237;n E, Bar&#243;n G, et al. Obesity and its Relation to Depressive Symptoms and Sedentary Lifestyle in Middle-Aged Women. Maturitas. 2015;80(1):100&#8211;105. doi: 10.1016/j.maturitas.2014.10.007.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2014.10.007</ArticleId>
+            <ArticleId IdType="pubmed">25459364</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Royer M, Castelo-Branco C, Bl&#252;mel JE, Chedraui PA, Danckers L, Bencosme A, et al. The US National Cholesterol Education Programme Adult Treatment Panel III (NCEP ATP III): Prevalence of the Metabolic Syndrome in Postmenopausal Latin American Women. Climacteric. 2007;10(2):164&#8211;170. doi: 10.1080/13697130701258895.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697130701258895</ArticleId>
+            <ArticleId IdType="pubmed">17453865</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Del Sueldo M, Mendon&#231;a-Rivera MA, S&#225;nchez-Zambrano MB, Zilberman J, M&#250;nera-Echevveri A. Paniagua M, et al. Gu&#237;a de Pr&#225;ctica Cl&#237;nica de la Sociedad Interamericana de Cardiolog&#237;a Sobre Prevenci&#243;n Primaria de Enfermedad Cardiovascular en la Mujer. Arch Cardiol Mex. 2022;92(Supl 2):1665&#8211;1731. doi: 10.24875/acm.22000071.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.24875/acm.22000071</ArticleId>
+            <ArticleId IdType="pmc">PMC9290436</ArticleId>
+            <ArticleId IdType="pubmed">35666723</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Rivera MAM. Por que se faz necess&#225;rio o reconhecimento de uma "Cardiologia da Mulher?". Rev Norte Nordeste Cardiol. 2023;12(1):3&#8211;7.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Rivera MAM, Rivera IR, &#193;vila W, Marques-Santos C, Costa FA, Ferro CR, et al. Depression and Cardiovascular Disease in Women. Int J Cardiovasc Sci. 2022;35(4):537&#8211;545. doi: 10.36660/ijcs.20200416.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.36660/ijcs.20200416</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bl&#252;mel JE, Chedraui P, Bar&#243;n G, Ben&#237;tez Z, Flores D, Espinoza MT, et al. A Multicentric Study Regarding the Use of Hormone Therapy During Female Mid-Age (REDLINC VI) Climacteric. 2014;17(4):433&#8211;441. doi: 10.3109/13697137.2014.882305.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3109/13697137.2014.882305</ArticleId>
+            <ArticleId IdType="pubmed">24443950</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Danckers L, Bl&#252;mel JE, Witis S, Vallejo MS, Tserotas K, S&#225;nchez H, et al. Personal and Professional Use of Menopausal Hormone Therapy among Gynecologists: A Multinational Study (REDLINC VII) Maturitas. 2016;87:67&#8211;71. doi: 10.1016/j.maturitas.2016.02.015.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2016.02.015</ArticleId>
+            <ArticleId IdType="pubmed">27013290</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Vallejo MS, Witis S, Ojeda E, Mostajo D, Morera F, Meruvia N, et al. Does the Menopausal Status of Female Gynecologists affect their Prescription of Menopausal Hormone Therapy? Climacteric. 2016;19(4):387&#8211;392. doi: 10.1080/13697137.2016.1191460.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1080/13697137.2016.1191460</ArticleId>
+            <ArticleId IdType="pubmed">27327136</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Johnson A, Roberts L, Elkins G. Complementary and Alternative Medicine for Menopause. J Evid Based Integr Med. 2019;24:2515690&#215;19829380. doi: 10.1177/2515690&#215;19829380.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/2515690&#215;19829380</ArticleId>
+            <ArticleId IdType="pmc">PMC6419242</ArticleId>
+            <ArticleId IdType="pubmed">30868921</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Locklear TD, Doyle BJ, Perez AL, Wicks SM, Mahady GB. Menopause in Latin America: Symptoms, attitudes, treatments and future directions in Costa Rica. Maturitas. 2017;104:84&#8211;89. doi: 10.1016/j.maturitas.2017.07.008.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/j.maturitas.2017.07.008</ArticleId>
+            <ArticleId IdType="pmc">PMC5616184</ArticleId>
+            <ArticleId IdType="pubmed">28923180</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Hulley S, Grady D, Bush T, Furberg C, Herrington D, Riggs B, et al. Randomized Trial of Estrogen Plus Progestin for Secondary Prevention of Coronary Heart Disease in Postmenopausal Women. Heart and Estrogen/Progestin Replacement Study (HERS) Research Group. JAMA. 1998;280(7):605&#8211;613. doi: 10.1001/jama.280.7.605.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1001/jama.280.7.605</ArticleId>
+            <ArticleId IdType="pubmed">9718051</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39607518.xml
+++ b/tests/fixtures/pmid_xml/39607518.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="In-Process" Owner="NLM">
+      <PMID Version="1">39607518</PMID>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>11</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Print-Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1439-0981</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>36</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Operative Orthopadie und Traumatologie</Title>
+          <ISOAbbreviation>Oper Orthop Traumatol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Microsurgery].</ArticleTitle>
+        <Pagination>
+          <StartPage>305</StartPage>
+          <EndPage>306</EndPage>
+          <MedlinePgn>305-306</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1007/s00064-024-00870-w</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Arkudas</LastName>
+            <ForeName>Andreas</ForeName>
+            <Initials>A</Initials>
+            <AffiliationInfo>
+              <Affiliation>Plastisch- und Handchirurgische Klinik, Universit&#228;tsklinik Erlangen, Krankenhausstr.&#160;12, 91054, Erlangen, Deutschland. andreas.arkudas@uk-erlangen.de.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Unglaub</LastName>
+            <ForeName>F</ForeName>
+            <Initials>F</Initials>
+            <AffiliationInfo>
+              <Affiliation>Handchirurgie, Vulpius Klinik GmbH Bad Rappenau, Bad Rappenau, Deutschland.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Orthop&#228;disch-Unfallchirurgisches Zentrum, Universit&#228;tsklinikum Mannheim, Medizinische Fakult&#228;t Mannheim, Universit&#228;t Heidelberg, Mannheim, Deutschland.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Horch</LastName>
+            <ForeName>R E</ForeName>
+            <Initials>RE</Initials>
+            <AffiliationInfo>
+              <Affiliation>Plastisch- und Handchirurgische Klinik, Universit&#228;tsklinik Erlangen, Krankenhausstr.&#160;12, 91054, Erlangen, Deutschland.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ger</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Mikrochirurgie.</VernacularTitle>
+        <ArticleDate DateType="Electronic">
+          <Year>2024</Year>
+          <Month>11</Month>
+          <Day>28</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Germany</Country>
+        <MedlineTA>Oper Orthop Traumatol</MedlineTA>
+        <NlmUniqueID>9604937</NlmUniqueID>
+        <ISSNLinking>0934-6694</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <CoiStatement>Interessenkonflikt: A.&#160;Arkudas, F.&#160;Unglaub und R.E.&#160;Horch geben an, dass kein Interessenkonflikt besteht.</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="accepted">
+          <Year>2024</Year>
+          <Month>10</Month>
+          <Day>16</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>11</Month>
+          <Day>28</Day>
+          <Hour>12</Hour>
+          <Minute>19</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>11</Month>
+          <Day>28</Day>
+          <Hour>12</Hour>
+          <Minute>19</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>11</Month>
+          <Day>28</Day>
+          <Hour>11</Hour>
+          <Minute>15</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39607518</ArticleId>
+        <ArticleId IdType="doi">10.1007/s00064-024-00870-w</ArticleId>
+        <ArticleId IdType="pii">10.1007/s00064-024-00870-w</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39630833.xml
+++ b/tests/fixtures/pmid_xml/39630833.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="PubMed-not-MEDLINE" Owner="NLM">
+      <PMID Version="1">39630833</PMID>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>02</Month>
+        <Day>13</Day>
+      </DateRevised>
+      <Article PubModel="Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">2965-2774</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>36</Volume>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+              <Day>02</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Critical care science</Title>
+          <ISOAbbreviation>Crit Care Sci</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>ERRATUM.</ArticleTitle>
+        <Pagination>
+          <StartPage>e20240066enerr</StartPage>
+          <MedlinePgn>e20240066enerr</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="pii" ValidYN="Y">e20240066enerr</ELocationID>
+        <ELocationID EIdType="doi" ValidYN="Y">10.62675/2965-2774.20240066-enerr</ELocationID>
+        <ELocationID EIdType="pii" ValidYN="Y">S2965-27742024000101500</ELocationID>
+        <Abstract>
+          <AbstractText>[This corrects the article doi: 10.62675/2965-2774.20240066-en] [This corrects the article doi: 10.62675/2965-2774.20240066-pt].</AbstractText>
+        </Abstract>
+        <Language>eng</Language>
+        <Language>por</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016425">Published Erratum</PublicationType>
+        </PublicationTypeList>
+        <ArticleDate DateType="Electronic">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>02</Day>
+        </ArticleDate>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Brazil</Country>
+        <MedlineTA>Crit Care Sci</MedlineTA>
+        <NlmUniqueID>9918627781706676</NlmUniqueID>
+        <ISSNLinking>2965-2774</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <CommentsCorrectionsList>
+        <CommentsCorrections RefType="ErratumFor">
+          <RefSource>Crit Care Sci. 2024 Sep 23;36:e20240066en. doi: 10.62675/2965-2774.20240066-en.</RefSource>
+          <PMID Version="1">39319920</PMID>
+        </CommentsCorrections>
+      </CommentsCorrectionsList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>4</Day>
+          <Hour>18</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>4</Day>
+          <Hour>18</Hour>
+          <Minute>22</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>4</Day>
+          <Hour>13</Hour>
+          <Minute>45</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2024</Year>
+          <Month>11</Month>
+          <Day>11</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>epublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39630833</ArticleId>
+        <ArticleId IdType="pmc">PMC11812949</ArticleId>
+        <ArticleId IdType="doi">10.62675/2965-2774.20240066-enerr</ArticleId>
+        <ArticleId IdType="pii">S2965-27742024000101500</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39653886.xml
+++ b/tests/fixtures/pmid_xml/39653886.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="In-Process" Owner="NLM">
+      <PMID Version="1">39653886</PMID>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>02</Month>
+        <Day>18</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1613-3560</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>166</Volume>
+            <Issue>21-22</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>MMW Fortschritte der Medizin</Title>
+          <ISOAbbreviation>MMW Fortschr Med</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>5</StartPage>
+          <MedlinePgn>5</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1007/s15006-024-4251-2</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>von Eisenhart-Rothe</LastName>
+            <ForeName>R&#252;diger</ForeName>
+            <Initials>R</Initials>
+            <AffiliationInfo>
+              <Affiliation>Klinik und Poliklinik f&#252;r Orthop&#228;die und Sportorthop&#228;die, Klinikum rechts der Isar, Technische Universit&#228;t M&#252;nchen, Ismaninger Str. 22, 81675, M&#252;nchen, Deutschland. eisenhart@tum.de.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ger</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Was bei Knieschmerzen wirklich hilft.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Germany</Country>
+        <MedlineTA>MMW Fortschr Med</MedlineTA>
+        <NlmUniqueID>100893959</NlmUniqueID>
+        <ISSNLinking>1438-3276</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>10</Day>
+          <Hour>0</Hour>
+          <Minute>22</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>10</Day>
+          <Hour>0</Hour>
+          <Minute>22</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>9</Day>
+          <Hour>23</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39653886</ArticleId>
+        <ArticleId IdType="doi">10.1007/s15006-024-4251-2</ArticleId>
+        <ArticleId IdType="pii">10.1007/s15006-024-4251-2</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39656565.xml
+++ b/tests/fixtures/pmid_xml/39656565.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="In-Process" Owner="NLM">
+      <PMID Version="1">39656565</PMID>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>12</Month>
+        <Day>10</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Electronic">1708-3923</ISSN>
+          <JournalIssue CitedMedium="Internet">
+            <Volume>49</Volume>
+            <Issue>2</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Season>Fall</Season>
+            </PubDate>
+          </JournalIssue>
+          <Title>Sante mentale au Quebec</Title>
+          <ISOAbbreviation>Sante Ment Que</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>11</StartPage>
+          <EndPage>12</EndPage>
+          <MedlinePgn>11-12</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Cossette</LastName>
+            <ForeName>Patrick</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>Facult&#233; de m&#233;decine de l'Universit&#233; de Montr&#233;al, Qu&#233;bec, Canada.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>fre</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>L&#8217;IUSMM et l&#8217;Universit&#233; de Montr&#233;al : 150 ans de synergie au service de la sant&#233; mentale.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Canada</Country>
+        <MedlineTA>Sante Ment Que</MedlineTA>
+        <NlmUniqueID>9424773</NlmUniqueID>
+        <ISSNLinking>0383-6320</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>15</Day>
+          <Hour>19</Hour>
+          <Minute>30</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>15</Day>
+          <Hour>19</Hour>
+          <Minute>30</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>10</Day>
+          <Hour>12</Hour>
+          <Minute>33</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39656565</ArticleId>
+        <ArticleId IdType="pii">1114400ar</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39663965.xml
+++ b/tests/fixtures/pmid_xml/39663965.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="In-Process" Owner="NLM">
+      <PMID Version="1">39663965</PMID>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>12</Month>
+        <Day>12</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1660-9379</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>20</Volume>
+            <Issue>898-2</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+              <Day>11</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Revue medicale suisse</Title>
+          <ISOAbbreviation>Rev Med Suisse</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Not Available].</ArticleTitle>
+        <Pagination>
+          <StartPage>2323</StartPage>
+          <EndPage>2324</EndPage>
+          <MedlinePgn>2323-2324</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.53738/REVMED.2024.20.898-2.2323</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Gentizon</LastName>
+            <ForeName>Jenny</ForeName>
+            <Initials>J</Initials>
+            <AffiliationInfo>
+              <Affiliation>Direction du D&#233;partement de m&#233;decine, CHUV, 1011 Lausanne.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Colomer-Lahiguera</LastName>
+            <ForeName>Sara</ForeName>
+            <Initials>S</Initials>
+            <AffiliationInfo>
+              <Affiliation>Institut universitaire de formation et recherche en soins, Facult&#233; de biologie et m&#233;decine, Universit&#233; de Lausanne et Centre hospitalier universitaire vaudois, 1010 Lausanne.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Mabire</LastName>
+            <ForeName>C&#233;dric</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Facult&#233; de biologie et m&#233;decine, Universit&#233; de Lausanne, Institut universitaire de formation et de recherche en soins, 1010 Lausanne.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Eicher</LastName>
+            <ForeName>Manuela</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Institut universitaire de formation et de recherche en soins.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Robatto</LastName>
+            <ForeName>Laurence</ForeName>
+            <Initials>L</Initials>
+            <AffiliationInfo>
+              <Affiliation>Facult&#233; de biologie et de m&#233;decine, Centre hospitalier universitaire vaudois et Universit&#233; de Lausanne.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Peguet</LastName>
+            <ForeName>Coralie</ForeName>
+            <Initials>C</Initials>
+            <AffiliationInfo>
+              <Affiliation>Facult&#233; de biologie et de m&#233;decine, Centre hospitalier universitaire vaudois et Universit&#233; de Lausanne.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>fre</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>La pratique infirmi&#232;re avanc&#233;e : une r&#233;ponse aux d&#233;fis du syst&#232;me de sant&#233;.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Switzerland</Country>
+        <MedlineTA>Rev Med Suisse</MedlineTA>
+        <NlmUniqueID>101219148</NlmUniqueID>
+        <ISSNLinking>1660-9379</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>12</Day>
+          <Hour>6</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>12</Day>
+          <Hour>6</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>12</Day>
+          <Hour>4</Hour>
+          <Minute>23</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39663965</ArticleId>
+        <ArticleId IdType="doi">10.53738/REVMED.2024.20.898-2.2323</ArticleId>
+        <ArticleId IdType="pii">RMS0898-2-001</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39731248.xml
+++ b/tests/fixtures/pmid_xml/39731248.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">39731248</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>12</Month>
+        <Day>28</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2024</Year>
+        <Month>12</Month>
+        <Day>28</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0042-465X</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>140</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>2024</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Vestnik oftalmologii</Title>
+          <ISOAbbreviation>Vestn Oftalmol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Peripapillary pachychoroid syndrome].</ArticleTitle>
+        <Pagination>
+          <StartPage>138</StartPage>
+          <EndPage>144</EndPage>
+          <MedlinePgn>138-144</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.17116/oftalma2024140061138</ELocationID>
+        <Abstract>
+          <AbstractText>Peripapillary pachychoroid syndrome (PPS) is a recently described condition, classified within the pachychoroid disease spectrum characterized by focal or diffuse thickening of the choroid due to dilation of choroidal vessels in the Haller's layer (pachyvessels), thinning of the choriocapillaris and the Sattler's layer, and accompanied by increased choroidal permeability and damage to the retinal pigment epithelium. Unlike other pachychoroid diseases that involve changes in the central retina, PPS presents with choroidal thickening and intra- or subretinal fluid located nasally in the macular region, near the optic disc. This review aims to summarize and analyze current data on the clinical features, pathogenesis, and treatment options for PPS found in the literature. Differentiating PPS is crucial, as its similarity to other conditions with overlapping features may lead to misdiagnosis and ineffective or inappropriate treatment.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Andreeva</LastName>
+            <ForeName>N A</ForeName>
+            <Initials>NA</Initials>
+            <Identifier Source="ORCID">0000-0001-7329-5725</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Krasnov Research Institute of Eye Diseases, Moscow, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Sheremet</LastName>
+            <ForeName>N L</ForeName>
+            <Initials>NL</Initials>
+            <Identifier Source="ORCID">0000-0003-4597-4987</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Krasnov Research Institute of Eye Diseases, Moscow, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>rus</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Peripapillyarnyi pakhikhorioidal'nyi sindrom.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Russia (Federation)</Country>
+        <MedlineTA>Vestn Oftalmol</MedlineTA>
+        <NlmUniqueID>0415216</NlmUniqueID>
+        <ISSNLinking>0042-465X</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002829" MajorTopicYN="Y">Choroid</DescriptorName>
+          <QualifierName UI="Q000000981" MajorTopicYN="N">diagnostic imaging</QualifierName>
+          <QualifierName UI="Q000098" MajorTopicYN="N">blood supply</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015862" MajorTopicYN="Y">Choroid Diseases</DescriptorName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003937" MajorTopicYN="N">Diagnosis, Differential</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013577" MajorTopicYN="N">Syndrome</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D041623" MajorTopicYN="N">Tomography, Optical Coherence</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005451" MajorTopicYN="N">Fluorescein Angiography</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009898" MajorTopicYN="N">Optic Disk</DescriptorName>
+          <QualifierName UI="Q000000981" MajorTopicYN="N">diagnostic imaging</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="rus">
+        <AbstractText>&#1055;&#1077;&#1088;&#1080;&#1087;&#1072;&#1087;&#1080;&#1083;&#1083;&#1103;&#1088;&#1085;&#1099;&#1081; &#1087;&#1072;&#1093;&#1080;&#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1072;&#1083;&#1100;&#1085;&#1099;&#1081; &#1089;&#1080;&#1085;&#1076;&#1088;&#1086;&#1084; (&#1055;&#1055;&#1057;) &#8212; &#1085;&#1077;&#1076;&#1072;&#1074;&#1085;&#1086; &#1086;&#1087;&#1080;&#1089;&#1072;&#1085;&#1085;&#1086;&#1077; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1077;, &#1082;&#1086;&#1090;&#1086;&#1088;&#1086;&#1077; &#1086;&#1090;&#1085;&#1086;&#1089;&#1103;&#1090; &#1082; &#1075;&#1088;&#1091;&#1087;&#1087;&#1077; &#1087;&#1072;&#1093;&#1080;&#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1072;&#1083;&#1100;&#1085;&#1099;&#1093; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1081;, &#1093;&#1072;&#1088;&#1072;&#1082;&#1090;&#1077;&#1088;&#1080;&#1079;&#1091;&#1102;&#1097;&#1080;&#1093;&#1089;&#1103; &#1086;&#1095;&#1072;&#1075;&#1086;&#1074;&#1099;&#1084; &#1080;&#1083;&#1080; &#1076;&#1080;&#1092;&#1092;&#1091;&#1079;&#1085;&#1099;&#1084; &#1091;&#1074;&#1077;&#1083;&#1080;&#1095;&#1077;&#1085;&#1080;&#1077;&#1084; &#1090;&#1086;&#1083;&#1097;&#1080;&#1085;&#1099; &#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1077;&#1080;, &#1086;&#1073;&#1091;&#1089;&#1083;&#1086;&#1074;&#1083;&#1077;&#1085;&#1085;&#1099;&#1084; &#1076;&#1080;&#1083;&#1072;&#1090;&#1072;&#1094;&#1080;&#1077;&#1081; &#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1072;&#1083;&#1100;&#1085;&#1099;&#1093; &#1089;&#1086;&#1089;&#1091;&#1076;&#1086;&#1074; &#1074; &#1089;&#1083;&#1086;&#1077; &#1043;&#1072;&#1083;&#1083;&#1077;&#1088;&#1072; (&#1087;&#1072;&#1093;&#1080;&#1089;&#1086;&#1089;&#1091;&#1076;&#1099;), &#1080;&#1089;&#1090;&#1086;&#1085;&#1095;&#1077;&#1085;&#1080;&#1077;&#1084; &#1093;&#1086;&#1088;&#1080;&#1086;&#1082;&#1072;&#1087;&#1080;&#1083;&#1083;&#1103;&#1088;&#1086;&#1074; &#1080; &#1089;&#1083;&#1086;&#1103; &#1057;&#1072;&#1090;&#1090;&#1083;&#1077;&#1088;&#1072;, &#1089;&#1086;&#1087;&#1088;&#1086;&#1074;&#1086;&#1078;&#1076;&#1072;&#1102;&#1097;&#1077;&#1077;&#1089;&#1103; &#1087;&#1086;&#1074;&#1099;&#1096;&#1077;&#1085;&#1085;&#1086;&#1081; &#1087;&#1088;&#1086;&#1085;&#1080;&#1094;&#1072;&#1077;&#1084;&#1086;&#1089;&#1090;&#1100;&#1102; &#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1077;&#1080; &#1080; &#1087;&#1086;&#1074;&#1088;&#1077;&#1078;&#1076;&#1077;&#1085;&#1080;&#1077;&#1084; &#1088;&#1077;&#1090;&#1080;&#1085;&#1072;&#1083;&#1100;&#1085;&#1086;&#1075;&#1086; &#1087;&#1080;&#1075;&#1084;&#1077;&#1085;&#1090;&#1085;&#1086;&#1075;&#1086; &#1101;&#1087;&#1080;&#1090;&#1077;&#1083;&#1080;&#1103;. &#1059; &#1087;&#1072;&#1094;&#1080;&#1077;&#1085;&#1090;&#1086;&#1074; &#1089; &#1055;&#1055;&#1057; &#1074; &#1086;&#1090;&#1083;&#1080;&#1095;&#1080;&#1077; &#1086;&#1090; &#1076;&#1088;&#1091;&#1075;&#1080;&#1093; &#1087;&#1072;&#1093;&#1080;&#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1072;&#1083;&#1100;&#1085;&#1099;&#1093; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1081; &#1089; &#1080;&#1079;&#1084;&#1077;&#1085;&#1077;&#1085;&#1080;&#1103;&#1084;&#1080; &#1074; &#1094;&#1077;&#1085;&#1090;&#1088;&#1072;&#1083;&#1100;&#1085;&#1086;&#1081; &#1079;&#1086;&#1085;&#1077; &#1089;&#1077;&#1090;&#1095;&#1072;&#1090;&#1082;&#1080; &#1091;&#1090;&#1086;&#1083;&#1097;&#1077;&#1085;&#1080;&#1077; &#1093;&#1086;&#1088;&#1080;&#1086;&#1080;&#1076;&#1077;&#1080;, &#1085;&#1072;&#1083;&#1080;&#1095;&#1080;&#1077; &#1080;&#1085;&#1090;&#1088;&#1072;- &#1080;&#1083;&#1080; &#1089;&#1091;&#1073;&#1088;&#1077;&#1090;&#1080;&#1085;&#1072;&#1083;&#1100;&#1085;&#1086;&#1081; &#1078;&#1080;&#1076;&#1082;&#1086;&#1089;&#1090;&#1080; &#1085;&#1072;&#1073;&#1083;&#1102;&#1076;&#1072;&#1102;&#1090;&#1089;&#1103; &#1074; &#1085;&#1086;&#1089;&#1086;&#1074;&#1086;&#1081; &#1095;&#1072;&#1089;&#1090;&#1080; &#1084;&#1072;&#1082;&#1091;&#1083;&#1103;&#1088;&#1085;&#1086;&#1081; &#1079;&#1086;&#1085;&#1099;, &#1074;&#1073;&#1083;&#1080;&#1079;&#1080; &#1076;&#1080;&#1089;&#1082;&#1072; &#1079;&#1088;&#1080;&#1090;&#1077;&#1083;&#1100;&#1085;&#1086;&#1075;&#1086; &#1085;&#1077;&#1088;&#1074;&#1072;. &#1062;&#1077;&#1083;&#1100;&#1102; &#1101;&#1090;&#1086;&#1075;&#1086; &#1086;&#1073;&#1079;&#1086;&#1088;&#1072; &#1103;&#1074;&#1083;&#1103;&#1077;&#1090;&#1089;&#1103; &#1086;&#1073;&#1086;&#1073;&#1097;&#1077;&#1085;&#1080;&#1077; &#1080; &#1072;&#1085;&#1072;&#1083;&#1080;&#1079; &#1076;&#1072;&#1085;&#1085;&#1099;&#1093; &#1082;&#1083;&#1080;&#1085;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1082;&#1072;&#1088;&#1090;&#1080;&#1085;&#1099;, &#1087;&#1072;&#1090;&#1086;&#1075;&#1077;&#1085;&#1077;&#1079;&#1072; &#1080; &#1074;&#1086;&#1079;&#1084;&#1086;&#1078;&#1085;&#1086;&#1089;&#1090;&#1077;&#1081; &#1083;&#1077;&#1095;&#1077;&#1085;&#1080;&#1103; &#1055;&#1055;&#1057;, &#1087;&#1088;&#1077;&#1076;&#1089;&#1090;&#1072;&#1074;&#1083;&#1077;&#1085;&#1085;&#1099;&#1093; &#1074; &#1083;&#1080;&#1090;&#1077;&#1088;&#1072;&#1090;&#1091;&#1088;&#1077;. &#1042;&#1072;&#1078;&#1085;&#1086; &#1091;&#1084;&#1077;&#1090;&#1100; &#1076;&#1080;&#1092;&#1092;&#1077;&#1088;&#1077;&#1085;&#1094;&#1080;&#1088;&#1086;&#1074;&#1072;&#1090;&#1100; &#1055;&#1055;&#1057;, &#1087;&#1086;&#1089;&#1082;&#1086;&#1083;&#1100;&#1082;&#1091; &#1077;&#1075;&#1086; &#1089;&#1093;&#1086;&#1076;&#1089;&#1090;&#1074;&#1086; &#1089; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1103;&#1084;&#1080; &#1089; &#1087;&#1086;&#1093;&#1086;&#1078;&#1080;&#1084;&#1080; &#1093;&#1072;&#1088;&#1072;&#1082;&#1090;&#1077;&#1088;&#1080;&#1089;&#1090;&#1080;&#1082;&#1072;&#1084;&#1080; &#1084;&#1086;&#1078;&#1077;&#1090; &#1087;&#1088;&#1080;&#1074;&#1077;&#1089;&#1090;&#1080; &#1082; &#1086;&#1096;&#1080;&#1073;&#1086;&#1095;&#1085;&#1086;&#1084;&#1091; &#1076;&#1080;&#1072;&#1075;&#1085;&#1086;&#1079;&#1091; &#1080; &#1085;&#1077;&#1101;&#1092;&#1092;&#1077;&#1082;&#1090;&#1080;&#1074;&#1085;&#1099;&#1084; &#1080;&#1083;&#1080; &#1085;&#1077;&#1074;&#1077;&#1088;&#1085;&#1086; &#1085;&#1072;&#1079;&#1085;&#1072;&#1095;&#1077;&#1085;&#1085;&#1099;&#1084; &#1084;&#1077;&#1090;&#1086;&#1076;&#1072;&#1084; &#1083;&#1077;&#1095;&#1077;&#1085;&#1080;&#1103;.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">choroid</Keyword>
+        <Keyword MajorTopicYN="N">pachychoroid</Keyword>
+        <Keyword MajorTopicYN="N">pachychoroid diseases</Keyword>
+        <Keyword MajorTopicYN="N">peripapillary pachychoroid syndrome</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>11</Hour>
+          <Minute>43</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>11</Hour>
+          <Minute>42</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>0</Hour>
+          <Minute>50</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39731248</ArticleId>
+        <ArticleId IdType="doi">10.17116/oftalma2024140061138</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39731387.xml
+++ b/tests/fixtures/pmid_xml/39731387.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">39731387</PMID>
+      <DateCompleted>
+        <Year>2024</Year>
+        <Month>12</Month>
+        <Day>28</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>01</Month>
+        <Day>06</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1997-7298</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>124</Volume>
+            <Issue>12</Issue>
+            <PubDate>
+              <Year>2024</Year>
+            </PubDate>
+          </JournalIssue>
+          <Title>Zhurnal nevrologii i psikhiatrii imeni S.S. Korsakova</Title>
+          <ISOAbbreviation>Zh Nevrol Psikhiatr Im S S Korsakova</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Paraneoplastic opsoclonus-myoclonus syndrome].</ArticleTitle>
+        <Pagination>
+          <StartPage>165</StartPage>
+          <EndPage>170</EndPage>
+          <MedlinePgn>165-170</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.17116/jnevro2024124121165</ELocationID>
+        <Abstract>
+          <AbstractText>Opsoclonus-myoclonus syndrome (OMS) is a rare neurological disorder characterized by a combination of main symptoms: opsoclonus, myoclonus, ataxia, psychoemotional and behavioral disturbances. OMS can develop in children as a result of immunopathological processes against the background of infectious or oncological pathology and lead to persistent neurological deficit. A case of ten-year observation of paraneoplastic OMS associated with neuroblastoma in a child is presented. Within 6 months, the clinical picture of OMS was not full and manifested by recurrent cerebellar ataxia and psychoemotional disorders. The appearance of opsoclonus against the background of increased disturbances in statics and coordination made it possible to diagnose OMS and suggest its paraneoplastic genesis. The peculiarity of the case is the combination of opsoclonus with the development of a symptomatic epileptiform ictus. Surgical treatment of neuroblastoma, immunosuppressive therapy in combination with nootropic and symptomatic anticonvulsant therapy have shown effectiveness and led to stabilization of the condition, regression of cerebellar symptoms and restoration of the rate of mental development. The long course of OMS with the gradual formation of a complete symptom complex complicates timely diagnosis of the underlying disease. Cases of cerebellar ataxia, myoclonus and abnormal eye movements, regardless of the severity and sequence of development of the clinical picture, require an interdisciplinary diagnostic approach and consideration of oncological pathology in a differential diagnostic aspect.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Fedoseeva</LastName>
+            <ForeName>I F</ForeName>
+            <Initials>IF</Initials>
+            <Identifier Source="ORCID">0000-0003-3692-5673</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Kemerovo State Medical University, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Goncharenko</LastName>
+            <ForeName>A V</ForeName>
+            <Initials>AV</Initials>
+            <Identifier Source="ORCID">0009-0008-8805-6784</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Kemerovo State Medical University, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Poponnikova</LastName>
+            <ForeName>T V</ForeName>
+            <Initials>TV</Initials>
+            <Identifier Source="ORCID">0000-0003-2894-3062</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Kemerovo State Medical University, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Glebova</LastName>
+            <ForeName>I V</ForeName>
+            <Initials>IV</Initials>
+            <Identifier Source="ORCID">0009-0009-0525-3043</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Belyaev Kuzbass Regional Clinical Hospital, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Pinevich</LastName>
+            <ForeName>O S</ForeName>
+            <Initials>OS</Initials>
+            <Identifier Source="ORCID">0009-0006-7778-2540</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Belyaev Kuzbass Regional Clinical Hospital, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Goncharenko</LastName>
+            <ForeName>V A</ForeName>
+            <Initials>VA</Initials>
+            <Identifier Source="ORCID">0000-0003-0641-0468</Identifier>
+            <AffiliationInfo>
+              <Affiliation>Kemerovo State Medical University, Kemerovo, Russia.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>rus</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D002363">Case Reports</PublicationType>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Paraneoplasticheskii opsoklonus-mioklonus-sindrom.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Russia (Federation)</Country>
+        <MedlineTA>Zh Nevrol Psikhiatr Im S S Korsakova</MedlineTA>
+        <NlmUniqueID>9712194</NlmUniqueID>
+        <ISSNLinking>1997-7298</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000927">Anticonvulsants</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000927" MajorTopicYN="N">Anticonvulsants</DescriptorName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009447" MajorTopicYN="Y">Neuroblastoma</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D053578" MajorTopicYN="Y">Opsoclonus-Myoclonus Syndrome</DescriptorName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000209" MajorTopicYN="N">etiology</QualifierName>
+          <QualifierName UI="Q000188" MajorTopicYN="N">drug therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002648" MajorTopicYN="N">Child</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="rus">
+        <AbstractText>&#1054;&#1087;&#1089;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;-&#1084;&#1080;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;-&#1089;&#1080;&#1085;&#1076;&#1088;&#1086;&#1084; (&#1054;&#1052;&#1057;) &#8212; &#1088;&#1077;&#1076;&#1082;&#1086;&#1077; &#1085;&#1077;&#1074;&#1088;&#1086;&#1083;&#1086;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1077; &#1088;&#1072;&#1089;&#1089;&#1090;&#1088;&#1086;&#1081;&#1089;&#1090;&#1074;&#1086;, &#1093;&#1072;&#1088;&#1072;&#1082;&#1090;&#1077;&#1088;&#1080;&#1079;&#1091;&#1102;&#1097;&#1077;&#1077;&#1089;&#1103; &#1089;&#1086;&#1095;&#1077;&#1090;&#1072;&#1085;&#1080;&#1077;&#1084; &#1086;&#1089;&#1085;&#1086;&#1074;&#1085;&#1099;&#1093; &#1089;&#1080;&#1084;&#1087;&#1090;&#1086;&#1084;&#1086;&#1074;: &#1086;&#1087;&#1089;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;, &#1084;&#1080;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;, &#1072;&#1090;&#1072;&#1082;&#1089;&#1080;&#1103;, &#1087;&#1089;&#1080;&#1093;&#1086;&#1101;&#1084;&#1086;&#1094;&#1080;&#1086;&#1085;&#1072;&#1083;&#1100;&#1085;&#1099;&#1077; &#1080; &#1087;&#1086;&#1074;&#1077;&#1076;&#1077;&#1085;&#1095;&#1077;&#1089;&#1082;&#1080;&#1077; &#1085;&#1072;&#1088;&#1091;&#1096;&#1077;&#1085;&#1080;&#1103;. &#1054;&#1052;&#1057; &#1084;&#1086;&#1078;&#1077;&#1090; &#1088;&#1072;&#1079;&#1074;&#1080;&#1074;&#1072;&#1090;&#1100;&#1089;&#1103; &#1091; &#1076;&#1077;&#1090;&#1077;&#1081; &#1074;&#1089;&#1083;&#1077;&#1076;&#1089;&#1090;&#1074;&#1080;&#1077; &#1080;&#1084;&#1084;&#1091;&#1085;&#1086;&#1087;&#1072;&#1090;&#1086;&#1083;&#1086;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1080;&#1093; &#1087;&#1088;&#1086;&#1094;&#1077;&#1089;&#1089;&#1086;&#1074; &#1085;&#1072; &#1092;&#1086;&#1085;&#1077; &#1080;&#1085;&#1092;&#1077;&#1082;&#1094;&#1080;&#1086;&#1085;&#1085;&#1086;&#1081; &#1080;&#1083;&#1080; &#1086;&#1085;&#1082;&#1086;&#1083;&#1086;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1087;&#1072;&#1090;&#1086;&#1083;&#1086;&#1075;&#1080;&#1080; &#1080; &#1087;&#1088;&#1080;&#1074;&#1086;&#1076;&#1080;&#1090;&#1100; &#1082; &#1089;&#1090;&#1086;&#1081;&#1082;&#1086;&#1084;&#1091; &#1085;&#1077;&#1074;&#1088;&#1086;&#1083;&#1086;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1084;&#1091; &#1076;&#1077;&#1092;&#1080;&#1094;&#1080;&#1090;&#1091;. &#1055;&#1088;&#1077;&#1076;&#1089;&#1090;&#1072;&#1074;&#1083;&#1077;&#1085; &#1089;&#1083;&#1091;&#1095;&#1072;&#1081; &#1076;&#1077;&#1089;&#1103;&#1090;&#1080;&#1083;&#1077;&#1090;&#1085;&#1077;&#1075;&#1086; &#1085;&#1072;&#1073;&#1083;&#1102;&#1076;&#1077;&#1085;&#1080;&#1103; &#1087;&#1072;&#1088;&#1072;&#1085;&#1077;&#1086;&#1087;&#1083;&#1072;&#1089;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1075;&#1086; &#1054;&#1052;&#1057;, &#1072;&#1089;&#1089;&#1086;&#1094;&#1080;&#1080;&#1088;&#1086;&#1074;&#1072;&#1085;&#1085;&#1086;&#1075;&#1086; &#1089; &#1085;&#1077;&#1081;&#1088;&#1086;&#1073;&#1083;&#1072;&#1089;&#1090;&#1086;&#1084;&#1086;&#1081;, &#1091; &#1088;&#1077;&#1073;&#1077;&#1085;&#1082;&#1072;. &#1042; &#1090;&#1077;&#1095;&#1077;&#1085;&#1080;&#1077; 6 &#1084;&#1077;&#1089;. &#1082;&#1083;&#1080;&#1085;&#1080;&#1095;&#1077;&#1089;&#1082;&#1072;&#1103; &#1082;&#1072;&#1088;&#1090;&#1080;&#1085;&#1072; &#1054;&#1052;&#1057; &#1073;&#1099;&#1083;&#1072; &#1088;&#1077;&#1076;&#1091;&#1094;&#1080;&#1088;&#1086;&#1074;&#1072;&#1085;&#1085;&#1086;&#1081; &#1080; &#1086;&#1075;&#1088;&#1072;&#1085;&#1080;&#1095;&#1080;&#1074;&#1072;&#1083;&#1072;&#1089;&#1100; &#1088;&#1077;&#1094;&#1080;&#1076;&#1080;&#1074;&#1080;&#1088;&#1091;&#1102;&#1097;&#1077;&#1081; &#1084;&#1086;&#1079;&#1078;&#1077;&#1095;&#1082;&#1086;&#1074;&#1086;&#1081; &#1072;&#1090;&#1072;&#1082;&#1089;&#1080;&#1077;&#1081; &#1080; &#1087;&#1089;&#1080;&#1093;&#1086;&#1101;&#1084;&#1086;&#1094;&#1080;&#1086;&#1085;&#1072;&#1083;&#1100;&#1085;&#1099;&#1084;&#1080; &#1085;&#1072;&#1088;&#1091;&#1096;&#1077;&#1085;&#1080;&#1103;&#1084;&#1080;. &#1055;&#1086;&#1103;&#1074;&#1083;&#1077;&#1085;&#1080;&#1077; &#1086;&#1087;&#1089;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;&#1072; &#1085;&#1072; &#1092;&#1086;&#1085;&#1077; &#1091;&#1089;&#1080;&#1083;&#1077;&#1085;&#1080;&#1103; &#1085;&#1072;&#1088;&#1091;&#1096;&#1077;&#1085;&#1080;&#1081; &#1089;&#1090;&#1072;&#1090;&#1080;&#1082;&#1080; &#1080; &#1082;&#1086;&#1086;&#1088;&#1076;&#1080;&#1085;&#1072;&#1094;&#1080;&#1080; &#1087;&#1086;&#1079;&#1074;&#1086;&#1083;&#1080;&#1083;&#1086; &#1076;&#1080;&#1072;&#1075;&#1085;&#1086;&#1089;&#1090;&#1080;&#1088;&#1086;&#1074;&#1072;&#1090;&#1100; &#1054;&#1052;&#1057; &#1080; &#1087;&#1088;&#1077;&#1076;&#1087;&#1086;&#1083;&#1086;&#1078;&#1080;&#1090;&#1100; &#1077;&#1075;&#1086; &#1087;&#1072;&#1088;&#1072;&#1085;&#1077;&#1086;&#1087;&#1083;&#1072;&#1089;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1080;&#1081; &#1075;&#1077;&#1085;&#1077;&#1079;. &#1054;&#1089;&#1086;&#1073;&#1077;&#1085;&#1085;&#1086;&#1089;&#1090;&#1100; &#1089;&#1083;&#1091;&#1095;&#1072;&#1103; &#1079;&#1072;&#1082;&#1083;&#1102;&#1095;&#1072;&#1077;&#1090;&#1089;&#1103; &#1074; &#1089;&#1086;&#1095;&#1077;&#1090;&#1072;&#1085;&#1080;&#1080; &#1086;&#1087;&#1089;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;&#1072; &#1089; &#1088;&#1072;&#1079;&#1074;&#1080;&#1090;&#1080;&#1077;&#1084; &#1089;&#1080;&#1084;&#1087;&#1090;&#1086;&#1084;&#1072;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1075;&#1086; &#1101;&#1087;&#1080;&#1083;&#1077;&#1087;&#1090;&#1080;&#1092;&#1086;&#1088;&#1084;&#1085;&#1086;&#1075;&#1086; &#1087;&#1072;&#1088;&#1086;&#1082;&#1089;&#1080;&#1079;&#1084;&#1072;. &#1061;&#1080;&#1088;&#1091;&#1088;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1077; &#1083;&#1077;&#1095;&#1077;&#1085;&#1080;&#1077; &#1085;&#1077;&#1081;&#1088;&#1086;&#1073;&#1083;&#1072;&#1089;&#1090;&#1086;&#1084;&#1099;, &#1080;&#1084;&#1084;&#1091;&#1085;&#1086;&#1089;&#1091;&#1087;&#1088;&#1077;&#1089;&#1089;&#1080;&#1074;&#1085;&#1072;&#1103; &#1090;&#1077;&#1088;&#1072;&#1087;&#1080;&#1103; &#1074; &#1089;&#1086;&#1095;&#1077;&#1090;&#1072;&#1085;&#1080;&#1080; &#1089; &#1085;&#1086;&#1086;&#1090;&#1088;&#1086;&#1087;&#1085;&#1086;&#1081; &#1080; &#1089;&#1080;&#1084;&#1087;&#1090;&#1086;&#1084;&#1072;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1087;&#1088;&#1086;&#1090;&#1080;&#1074;&#1086;&#1089;&#1091;&#1076;&#1086;&#1088;&#1086;&#1078;&#1085;&#1086;&#1081; &#1090;&#1077;&#1088;&#1072;&#1087;&#1080;&#1077;&#1081; &#1087;&#1086;&#1082;&#1072;&#1079;&#1072;&#1083;&#1080; &#1101;&#1092;&#1092;&#1077;&#1082;&#1090;&#1080;&#1074;&#1085;&#1086;&#1089;&#1090;&#1100; &#1080; &#1087;&#1088;&#1080;&#1074;&#1077;&#1083;&#1080; &#1082; &#1089;&#1090;&#1072;&#1073;&#1080;&#1083;&#1080;&#1079;&#1072;&#1094;&#1080;&#1080; &#1089;&#1086;&#1089;&#1090;&#1086;&#1103;&#1085;&#1080;&#1103;, &#1088;&#1077;&#1075;&#1088;&#1077;&#1089;&#1089;&#1091; &#1084;&#1086;&#1079;&#1078;&#1077;&#1095;&#1082;&#1086;&#1074;&#1086;&#1081; &#1089;&#1080;&#1084;&#1087;&#1090;&#1086;&#1084;&#1072;&#1090;&#1080;&#1082;&#1080; &#1080; &#1074;&#1086;&#1089;&#1089;&#1090;&#1072;&#1085;&#1086;&#1074;&#1083;&#1077;&#1085;&#1080;&#1102; &#1090;&#1077;&#1084;&#1087;&#1086;&#1074; &#1087;&#1089;&#1080;&#1093;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1075;&#1086; &#1088;&#1072;&#1079;&#1074;&#1080;&#1090;&#1080;&#1103;. &#1044;&#1083;&#1080;&#1090;&#1077;&#1083;&#1100;&#1085;&#1086;&#1077; &#1090;&#1077;&#1095;&#1077;&#1085;&#1080;&#1077; &#1054;&#1052;&#1057; &#1089; &#1087;&#1086;&#1089;&#1090;&#1077;&#1087;&#1077;&#1085;&#1085;&#1099;&#1084; &#1092;&#1086;&#1088;&#1084;&#1080;&#1088;&#1086;&#1074;&#1072;&#1085;&#1080;&#1077;&#1084; &#1087;&#1086;&#1083;&#1085;&#1086;&#1075;&#1086; &#1089;&#1080;&#1084;&#1087;&#1090;&#1086;&#1084;&#1086;&#1082;&#1086;&#1084;&#1087;&#1083;&#1077;&#1082;&#1089;&#1072; &#1079;&#1072;&#1090;&#1088;&#1091;&#1076;&#1085;&#1103;&#1077;&#1090; &#1089;&#1074;&#1086;&#1077;&#1074;&#1088;&#1077;&#1084;&#1077;&#1085;&#1085;&#1091;&#1102; &#1076;&#1080;&#1072;&#1075;&#1085;&#1086;&#1089;&#1090;&#1080;&#1082;&#1091; &#1086;&#1089;&#1085;&#1086;&#1074;&#1085;&#1086;&#1075;&#1086; &#1079;&#1072;&#1073;&#1086;&#1083;&#1077;&#1074;&#1072;&#1085;&#1080;&#1103;. &#1057;&#1083;&#1091;&#1095;&#1072;&#1080; &#1084;&#1086;&#1079;&#1078;&#1077;&#1095;&#1082;&#1086;&#1074;&#1086;&#1081; &#1072;&#1090;&#1072;&#1082;&#1089;&#1080;&#1080;, &#1084;&#1080;&#1086;&#1082;&#1083;&#1086;&#1085;&#1091;&#1089;&#1072; &#1080; &#1072;&#1085;&#1086;&#1084;&#1072;&#1083;&#1100;&#1085;&#1099;&#1093; &#1076;&#1074;&#1080;&#1078;&#1077;&#1085;&#1080;&#1081; &#1075;&#1083;&#1072;&#1079; &#1085;&#1077;&#1079;&#1072;&#1074;&#1080;&#1089;&#1080;&#1084;&#1086; &#1086;&#1090; &#1074;&#1099;&#1088;&#1072;&#1078;&#1077;&#1085;&#1085;&#1086;&#1089;&#1090;&#1080; &#1080; &#1087;&#1086;&#1089;&#1083;&#1077;&#1076;&#1086;&#1074;&#1072;&#1090;&#1077;&#1083;&#1100;&#1085;&#1086;&#1089;&#1090;&#1080; &#1088;&#1072;&#1079;&#1074;&#1080;&#1090;&#1080;&#1103; &#1082;&#1083;&#1080;&#1085;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1082;&#1072;&#1088;&#1090;&#1080;&#1085;&#1099; &#1090;&#1088;&#1077;&#1073;&#1091;&#1102;&#1090; &#1084;&#1077;&#1078;&#1076;&#1080;&#1089;&#1094;&#1080;&#1087;&#1083;&#1080;&#1085;&#1072;&#1088;&#1085;&#1086;&#1075;&#1086; &#1076;&#1080;&#1072;&#1075;&#1085;&#1086;&#1089;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1075;&#1086; &#1087;&#1086;&#1076;&#1093;&#1086;&#1076;&#1072; &#1080; &#1088;&#1072;&#1089;&#1089;&#1084;&#1086;&#1090;&#1088;&#1077;&#1085;&#1080;&#1103; &#1086;&#1085;&#1082;&#1086;&#1083;&#1086;&#1075;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1081; &#1087;&#1072;&#1090;&#1086;&#1083;&#1086;&#1075;&#1080;&#1080; &#1074; &#1076;&#1080;&#1092;&#1092;&#1077;&#1088;&#1077;&#1085;&#1094;&#1080;&#1072;&#1083;&#1100;&#1085;&#1086;-&#1076;&#1080;&#1072;&#1075;&#1085;&#1086;&#1089;&#1090;&#1080;&#1095;&#1077;&#1089;&#1082;&#1086;&#1084; &#1072;&#1089;&#1087;&#1077;&#1082;&#1090;&#1077;.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">Kinsbourne encephalopathy</Keyword>
+        <Keyword MajorTopicYN="N">cerebellar ataxia</Keyword>
+        <Keyword MajorTopicYN="N">opsoclonus-myoclonus syndrome</Keyword>
+      </KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>11</Hour>
+          <Minute>45</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>11</Hour>
+          <Minute>44</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+          <Hour>3</Hour>
+          <Minute>45</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39731387</ArticleId>
+        <ArticleId IdType="doi">10.17116/jnevro2024124121165</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/39971531.xml
+++ b/tests/fixtures/pmid_xml/39971531.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">39971531</PMID>
+      <DateCompleted>
+        <Year>2025</Year>
+        <Month>03</Month>
+        <Day>03</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2026</Year>
+        <Month>03</Month>
+        <Day>12</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1007-3418</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>32</Volume>
+            <Issue>S2</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+              <Day>30</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Zhonghua gan zang bing za zhi = Zhonghua ganzangbing zazhi = Chinese journal of hepatology</Title>
+          <ISOAbbreviation>Zhonghua Gan Zang Bing Za Zhi</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Emphasis on scientific research related to viral hepatitis].</ArticleTitle>
+        <Pagination>
+          <StartPage>1</StartPage>
+          <EndPage>2</EndPage>
+          <MedlinePgn>1-2</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.3760/cma.j.cn501113-20241127-00600</ELocationID>
+        <Abstract>
+          <AbstractText>The Chinese Journal of Hepatology second supplementary issue in 2024 focused on viral hepatitis. The context of hepatitis B and C encompassed the exploration of expanding treatment advantages, research on the treatment of special populations, the clinical cure concept, and the regional and special population genotyping, treatment of patients who failed to receive direct-acting antiviral drugs, and medical prevention and elimination fusion models. The supplement's findings reflect the current trends in prevention and treatment, such as epidemiology, clinical practice, and elimination models, and serve as references for exploring antiviral treatment plans and hepatitis elimination models, assisting readers to experience the academic dynamism of liver disease, address elimination challenges, and facilitate goal attainment.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Ren</LastName>
+            <ForeName>H</ForeName>
+            <Initials>H</Initials>
+            <AffiliationInfo>
+              <Affiliation>Institute of Viral Hepatitis, Chongqing Medical University, Affiliated Second Hospital, Chongqing Medical University, Chongqing 401336, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Hu</LastName>
+            <ForeName>P</ForeName>
+            <Initials>P</Initials>
+            <AffiliationInfo>
+              <Affiliation>The First Affiliated Hospital of Chongqing Medical University, Chongqing 400016, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>chi</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D054711">Introductory Journal Article</PublicationType>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>China</Country>
+        <MedlineTA>Zhonghua Gan Zang Bing Za Zhi</MedlineTA>
+        <NlmUniqueID>9710009</NlmUniqueID>
+        <ISSNLinking>1007-3418</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000998">Antiviral Agents</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>WJ6CA3ZU8B</RegistryNumber>
+          <NameOfSubstance UI="D000069474">Sofosbuvir</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006509" MajorTopicYN="Y">Hepatitis B</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="N">drug therapy</QualifierName>
+          <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+          <QualifierName UI="Q000517" MajorTopicYN="N">prevention &amp; control</QualifierName>
+          <QualifierName UI="Q000821" MajorTopicYN="N">virology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006526" MajorTopicYN="Y">Hepatitis C</DescriptorName>
+          <QualifierName UI="Q000188" MajorTopicYN="N">drug therapy</QualifierName>
+          <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+          <QualifierName UI="Q000517" MajorTopicYN="N">prevention &amp; control</QualifierName>
+          <QualifierName UI="Q000821" MajorTopicYN="N">virology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D060005" MajorTopicYN="N">Genotyping Techniques</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000998" MajorTopicYN="Y">Antiviral Agents</DescriptorName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D060740" MajorTopicYN="N">Disease Eradication</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006515" MajorTopicYN="N">Hepatitis B virus</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000302" MajorTopicYN="N">isolation &amp; purification</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016174" MajorTopicYN="N">Hepacivirus</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000302" MajorTopicYN="N">isolation &amp; purification</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000069474" MajorTopicYN="N">Sofosbuvir</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="N">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000627" MajorTopicYN="N">therapeutic use</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016896" MajorTopicYN="N">Treatment Outcome</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002681" MajorTopicYN="N" Type="Geographic">China</DescriptorName>
+          <QualifierName UI="Q000453" MajorTopicYN="N">epidemiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="chi">
+        <AbstractText>&#26412;&#26399;&#12298;&#20013;&#21326;&#32925;&#33039;&#30149;&#26434;&#24535;&#12299;&#32858;&#28966;&#30149;&#27602;&#24615;&#32925;&#28814;&#30456;&#20851;&#30340;&#35786;&#26029;&#19982;&#27835;&#30103;&#12290;&#20057;&#22411;&#32925;&#28814;&#26041;&#38754;&#65292;&#28085;&#30422;&#20102;&#25193;&#22823;&#27835;&#30103;&#33719;&#30410;&#25506;&#35752;&#12289;&#29305;&#27530;&#20154;&#32676;&#27835;&#30103;&#30740;&#31350;&#21450;&#20020;&#24202;&#27835;&#24840;&#24605;&#36335;&#31561;&#65307;&#19993;&#22411;&#32925;&#28814;&#26041;&#38754;&#65292;&#21253;&#25324;&#21306;&#22495;&#19982;&#29305;&#27530;&#20154;&#32676;&#22522;&#22240;&#20998;&#22411;&#12289;&#30452;&#25509;&#25239;&#30149;&#27602;&#33647;&#29289;&#32463;&#27835;&#22833;&#36133;&#24739;&#32773;&#27835;&#30103;&#21450;&#21307;&#38450;&#34701;&#21512;&#28040;&#38500;&#27169;&#24335;&#31561;&#12290;&#26412;&#26399;&#21002;&#30331;&#30340;&#30740;&#31350;&#25104;&#26524;&#21453;&#26144;&#20102;&#30149;&#27602;&#24615;&#32925;&#28814;&#30340;&#38450;&#27835;&#21069;&#27839;&#21160;&#24577;&#65292;&#28041;&#21450;&#27969;&#34892;&#30149;&#23398;&#12289;&#20020;&#24202;&#23454;&#36341;&#19982;&#28040;&#38500;&#27169;&#24335;&#31561;&#65292;&#24076;&#26395;&#33021;&#20026;&#25239;&#30149;&#27602;&#27835;&#30103;&#26041;&#26696;&#21644;&#32925;&#28814;&#28040;&#38500;&#27169;&#24335;&#25506;&#32034;&#25552;&#20379;&#21442;&#32771;&#65292;&#21161;&#21147;&#35835;&#32773;&#24863;&#21463;&#32925;&#30149;&#23398;&#26415;&#27963;&#21147;&#65292;&#24212;&#23545;&#32925;&#28814;&#28040;&#38500;&#25361;&#25112;&#65292;&#25512;&#21160;&#30446;&#26631;&#23454;&#29616;&#12290;.</AbstractText>
+      </OtherAbstract>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2025</Year>
+          <Month>2</Month>
+          <Day>20</Day>
+          <Hour>0</Hour>
+          <Minute>22</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2025</Year>
+          <Month>2</Month>
+          <Day>20</Day>
+          <Hour>0</Hour>
+          <Minute>21</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2025</Year>
+          <Month>2</Month>
+          <Day>19</Day>
+          <Hour>21</Hour>
+          <Minute>13</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>30</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">39971531</ArticleId>
+        <ArticleId IdType="pmc">PMC12900453</ArticleId>
+        <ArticleId IdType="doi">10.3760/cma.j.cn501113-20241127-00600</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/40079719.xml
+++ b/tests/fixtures/pmid_xml/40079719.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Automated">
+      <PMID Version="1">40079719</PMID>
+      <DateCompleted>
+        <Year>2025</Year>
+        <Month>03</Month>
+        <Day>13</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>05</Month>
+        <Day>13</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0040-5930</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>81</Volume>
+            <Issue>7</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Therapeutische Umschau. Revue therapeutique</Title>
+          <ISOAbbreviation>Ther Umsch</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Introduction: Foot].</ArticleTitle>
+        <Pagination>
+          <StartPage>239</StartPage>
+          <MedlinePgn>239</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.23785/TU.2024.07.001</ELocationID>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Knupp</LastName>
+            <ForeName>Markus</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Mein Fusszentrum, Basel.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>markus.knupp@meinfusszentrum.ch.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>ger</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D054711">Introductory Journal Article</PublicationType>
+          <PublicationType UI="D016421">Editorial</PublicationType>
+          <PublicationType UI="D004740">English Abstract</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Einf&#252;hrung: Fuss.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Switzerland</Country>
+        <MedlineTA>Ther Umsch</MedlineTA>
+        <NlmUniqueID>0407224</NlmUniqueID>
+        <ISSNLinking>0040-5930</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005534" MajorTopicYN="Y">Foot Diseases</DescriptorName>
+          <QualifierName UI="Q000175" MajorTopicYN="N">diagnosis</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005528" MajorTopicYN="Y">Foot</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="ger">
+        <AbstractText Label="TITEL" NlmCategory="UNASSIGNED">Einf&#252;hrung: Fuss.</AbstractText>
+        <CopyrightInformation>&#169; 2024 Aerzteverlag medinfo AG.</CopyrightInformation>
+      </OtherAbstract>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2025</Year>
+          <Month>3</Month>
+          <Day>13</Day>
+          <Hour>14</Hour>
+          <Minute>8</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2025</Year>
+          <Month>3</Month>
+          <Day>13</Day>
+          <Hour>14</Hour>
+          <Minute>7</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2025</Year>
+          <Month>3</Month>
+          <Day>13</Day>
+          <Hour>9</Hour>
+          <Minute>52</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">40079719</ArticleId>
+        <ArticleId IdType="doi">10.23785/TU.2024.07.001</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/40195673.xml
+++ b/tests/fixtures/pmid_xml/40195673.xml
@@ -1,0 +1,477 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Curated">
+      <PMID Version="1">40195673</PMID>
+      <DateCompleted>
+        <Year>2025</Year>
+        <Month>04</Month>
+        <Day>08</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2025</Year>
+        <Month>04</Month>
+        <Day>17</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1672-7347</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>49</Volume>
+            <Issue>12</Issue>
+            <PubDate>
+              <Year>2024</Year>
+              <Month>Dec</Month>
+              <Day>28</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Zhong nan da xue xue bao. Yi xue ban = Journal of Central South University. Medical sciences</Title>
+          <ISOAbbreviation>Zhong Nan Da Xue Xue Bao Yi Xue Ban</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Research progress in postpartum visit competency.</ArticleTitle>
+        <Pagination>
+          <StartPage>1999</StartPage>
+          <EndPage>2004</EndPage>
+          <MedlinePgn>1999-2004</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.11817/j.issn.1672-7347.2024.240414</ELocationID>
+        <ELocationID EIdType="pii" ValidYN="Y">1672-7347(2024)12-1999-06</ELocationID>
+        <Abstract>
+          <AbstractText>Postpartum visit are maternal and child health services provided by primary care workers at the homes of postpartum women within one week after hospital discharge. However, China currently lacks detailed work guidelines and standardized protocols for such services, making it difficult to effectively assess the competency of postpartum visitors and improve service quality. This study reviewed 24 Chinese and English articles retrieved using a combination of subject and free terms, selected based on inclusion and exclusion criteria. The key components of postpartum visit competency were summarized into 3 dimensions: Health assessment, health education, and communication/coordination. While home visitors were generally capable of performing basic physical examinations and providing health education for mothers and newborns, they often lacked the ability to deliver more specialized maternal and infant care. Factors affecting the effectiveness of postpartum visit services included the personal characteristics, technical skills, and training of the visitors. Strategies to improve competencies involve reforming training methods, enhancing home visit skills, and standardizing procedures. Currently, there is a lack of comprehensive tools to assess postpartum visit competency.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Wang</LastName>
+            <ForeName>Guoqing</ForeName>
+            <Initials>G</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Maternal and Child Health, Xiangya School of Public Health, Central South University, Changsha 410013, China. 236912066@csu.edu.cn.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Li</LastName>
+            <ForeName>Xiaoyu</ForeName>
+            <Initials>X</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Maternal and Child Health, Xiangya School of Public Health, Central South University, Changsha 410013, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Xie</LastName>
+            <ForeName>Yimei</ForeName>
+            <Initials>Y</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Maternal and Child Health, Xiangya School of Public Health, Central South University, Changsha 410013, China.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Gong</LastName>
+            <ForeName>Wenjie</ForeName>
+            <Initials>W</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Maternal and Child Health, Xiangya School of Public Health, Central South University, Changsha 410013, China. gongwenjie@csu.edu.cn.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>FuRong Laboratory, Changsha 410078, China. gongwenjie@csu.edu.cn.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Institute of Applied Health Research, University of Birmingham, Birmingham B15 2TT, UK. gongwenjie@csu.edu.cn.</Affiliation>
+            </AffiliationInfo>
+            <AffiliationInfo>
+              <Affiliation>Department of Psychiatry, University of Rochester, Rochester New York 14642, USA. gongwenjie@csu.edu.cn.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <Language>chi</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>20-368</GrantID>
+            <Agency>the China Medical Board Open Competition Program, USA</Agency>
+            <Country/>
+          </Grant>
+          <Grant>
+            <GrantID>2023ZZTS0909</GrantID>
+            <Agency>the Graduate Innovation and Entrepreneurship Project, Central South University, China</Agency>
+            <Country/>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>&#20135;&#21518;&#35775;&#35270;&#33021;&#21147;&#30340;&#30740;&#31350;&#36827;&#23637;.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>China</Country>
+        <MedlineTA>Zhong Nan Da Xue Xue Bao Yi Xue Ban</MedlineTA>
+        <NlmUniqueID>101230586</NlmUniqueID>
+        <ISSNLinking>1672-7347</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011181" MajorTopicYN="Y">Postnatal Care</DescriptorName>
+          <QualifierName UI="Q000592" MajorTopicYN="N">standards</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006792" MajorTopicYN="Y">House Calls</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002681" MajorTopicYN="N" Type="Geographic">China</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D049590" MajorTopicYN="N">Postpartum Period</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007231" MajorTopicYN="N">Infant, Newborn</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011247" MajorTopicYN="N">Pregnancy</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <OtherAbstract Type="Publisher" Language="chi">
+        <AbstractText>&#20135;&#21518;&#35775;&#35270;&#26159;&#22522;&#23618;&#22919;&#24188;&#20445;&#20581;&#20154;&#21592;&#22312;&#20135;&#22919;&#20986;&#38498;&#21518;1&#21608;&#20869;&#21040;&#20854;&#23478;&#20013;&#36827;&#34892;&#30340;&#20445;&#20581;&#26381;&#21153;&#12290;&#28982;&#32780;&#65292;&#20013;&#22269;&#23545;&#27492;&#32570;&#20047;&#20855;&#20307;&#24037;&#20316;&#32454;&#21017;&#21644;&#26631;&#20934;&#65292;&#38590;&#20197;&#26377;&#25928;&#35780;&#20272;&#20135;&#21518;&#35775;&#35270;&#20154;&#21592;&#33021;&#21147;&#65292;&#25552;&#39640;&#20854;&#26381;&#21153;&#36136;&#37327;&#12290;&#26412;&#25991;&#37319;&#29992;&#20027;&#39064;&#35789;&#21152;&#33258;&#30001;&#35789;&#30456;&#32467;&#21512;&#30340;&#26041;&#24335;&#26816;&#32034;&#20013;&#33521;&#25991;&#25968;&#25454;&#24211;&#65292;&#26681;&#25454;&#32435;&#20837;&#21644;&#25490;&#38500;&#26631;&#20934;&#23545;&#26816;&#32034;&#25991;&#29486;&#36827;&#34892;&#31579;&#36873;&#65292;&#32435;&#20837;24&#31687;&#25991;&#29486;&#65292;&#25552;&#21462;&#24182;&#24402;&#32435;&#20135;&#21518;&#35775;&#35270;&#33021;&#21147;&#21450;&#30456;&#20851;&#35201;&#27714;&#12290;&#20135;&#21518;&#35775;&#35270;&#33021;&#21147;&#20869;&#23481;&#21487;&#24402;&#32435;&#20026;&#20581;&#24247;&#35780;&#20272;&#12289;&#20581;&#24247;&#25945;&#32946;&#21644;&#27807;&#36890;&#21327;&#35843;3&#20010;&#32500;&#24230;&#12290;&#35775;&#35270;&#20154;&#21592;&#33021;&#22815;&#23436;&#25104;&#22522;&#26412;&#30340;&#20135;&#22919;&#21644;&#26032;&#29983;&#20799;&#30340;&#36523;&#20307;&#26816;&#26597;&#21450;&#20581;&#24247;&#23459;&#25945;&#65292;&#20294;&#22312;&#25552;&#20379;&#26356;&#20855;&#19987;&#19994;&#24615;&#30340;&#20445;&#20581;&#26381;&#21153;&#26102;&#23384;&#22312;&#19968;&#23450;&#30340;&#19981;&#36275;&#12290;&#35775;&#35270;&#20154;&#21592;&#20010;&#20154;&#29305;&#24449;&#12289;&#25216;&#26415;&#33021;&#21147;&#21450;&#22521;&#35757;&#31561;&#24433;&#21709;&#20135;&#21518;&#35775;&#35270;&#26381;&#21153;&#30340;&#20132;&#20184;&#25928;&#26524;&#12290;&#35775;&#35270;&#33021;&#21147;&#25552;&#21319;&#31574;&#30053;&#21253;&#25324;&#25945;&#23398;&#24418;&#24335;&#25913;&#38761;&#12289;&#23478;&#35775;&#25216;&#33021;&#22521;&#35757;&#12289;&#35268;&#33539;&#35775;&#35270;&#31243;&#24207;&#12290;&#30446;&#21069;&#32570;&#20047;&#20840;&#38754;&#35780;&#20272;&#20135;&#21518;&#35775;&#35270;&#33021;&#21147;&#30340;&#26041;&#27861;&#12290;.</AbstractText>
+      </OtherAbstract>
+      <OtherAbstract Type="Publisher" Language="eng">
+        <AbstractText>Postpartum visit are maternal and child health services provided by primary care workers at the homes of postpartum women within one week after hospital discharge. However, China currently lacks detailed work guidelines and standardized protocols for such services, making it difficult to effectively assess the competency of postpartum visitors and improve service quality. This study reviewed 24 Chinese and English articles retrieved using a combination of subject and free terms, selected based on inclusion and exclusion criteria. The key components of postpartum visit competency were summarized into 3 dimensions: Health assessment, health education, and communication/coordination. While home visitors were generally capable of performing basic physical examinations and providing health education for mothers and newborns, they often lacked the ability to deliver more specialized maternal and infant care. Factors affecting the effectiveness of postpartum visit services included the personal characteristics, technical skills, and training of the visitors. Strategies to improve competencies involve reforming training methods, enhancing home visit skills, and standardizing procedures. Currently, there is a lack of comprehensive tools to assess postpartum visit competency.</AbstractText>
+      </OtherAbstract>
+      <KeywordList Owner="NOTNLM">
+        <Keyword MajorTopicYN="N">competency</Keyword>
+        <Keyword MajorTopicYN="N">evaluation methods</Keyword>
+        <Keyword MajorTopicYN="N">improvement strategies</Keyword>
+        <Keyword MajorTopicYN="N">influencing factors</Keyword>
+        <Keyword MajorTopicYN="N">maternal and child health services</Keyword>
+        <Keyword MajorTopicYN="N">postpartum visit</Keyword>
+      </KeywordList>
+      <CoiStatement>&#20316;&#32773;&#22768;&#31216;&#26080;&#20219;&#20309;&#21033;&#30410;&#20914;&#31361;&#12290;</CoiStatement>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="medline">
+          <Year>2025</Year>
+          <Month>4</Month>
+          <Day>8</Day>
+          <Hour>6</Hour>
+          <Minute>25</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>2025</Year>
+          <Month>4</Month>
+          <Day>8</Day>
+          <Hour>6</Hour>
+          <Minute>24</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2025</Year>
+          <Month>4</Month>
+          <Day>8</Day>
+          <Hour>2</Hour>
+          <Minute>59</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>2024</Year>
+          <Month>12</Month>
+          <Day>28</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">40195673</ArticleId>
+        <ArticleId IdType="pmc">PMC11975525</ArticleId>
+        <ArticleId IdType="doi">10.11817/j.issn.1672-7347.2024.240414</ArticleId>
+        <ArticleId IdType="pii">1672-7347(2024)12-1999-06</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>&#22269;&#23478;&#21355;&#29983;&#35745;&#29983;&#22996; . &#22269;&#23478;&#21355;&#29983;&#35745;&#29983;&#22996;&#20851;&#20110;&#21360;&#21457;&#12298;&#22269;&#23478;&#22522;&#26412;&#20844;&#20849;&#21355;&#29983;&#26381;&#21153;&#35268;&#33539;(&#31532;&#19977;&#29256;)&#12299;&#30340;&#36890;&#30693;[J]. &#20013;&#21326;&#20154;&#27665;&#20849;&#21644;&#22269;&#22269;&#23478;&#21355;&#29983;&#21644;&#35745;&#21010;&#29983;&#32946;&#22996;&#21592;&#20250;&#20844;&#25253;, 2017(3): 21.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>National Health and Family Planning Commission . Circular of the national health and family planning commission on issuing national basic public health service standard(third edition)[J]. Gazette of the National Health and Family Planning Commission of People&#8217;s Republic of China, 2017(3): 21.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>&#21016;&#33738;&#20957;, &#29579;&#24800;&#33521;, &#40858;&#29980;, &#31561;. &#33487;&#24030;&#24066;39806&#20363;&#20135;&#21518;&#35775;&#35270;&#32467;&#26524;&#20998;&#26512;&#21450;&#23545;&#31574;[J]. &#20013;&#22269;&#22919;&#24188;&#21355;&#29983;&#26434;&#24535;, 2016, 7(1): 21-23. 10.19757/j.cnki.issn1674-7763.2016.01.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19757/j.cnki.issn1674-7763.2016.01.006</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>LIU Juning, WANG Huiying, GONG Tian, et al. Analysis of postpartum visits results among 39 806 cases in Suzhou[J]. Chinese Journal of Women and Children Health, 2016, 7(1): 21-23. 10.19757/j.cnki.issn1674-7763.2016.01.006.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19757/j.cnki.issn1674-7763.2016.01.006</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li X, Krumholz HM, Yip W, et al. Quality of primary health care in China: challenges and recommendations[J]. Lancet, 2020, 395(10239): 1802-1812. 10.1016/S0140-6736(20)30122-7.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1016/S0140-6736(20)30122-7</ArticleId>
+            <ArticleId IdType="pmc">PMC7272159</ArticleId>
+            <ArticleId IdType="pubmed">32505251</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#24352;&#20255;, &#31243;&#21195;&#26480;, &#24352;&#26519;, &#31561;. &#22522;&#20110;&#28246;&#21335;&#30465;&#31532;&#8544;&#27425;&#21355;&#29983;&#26381;&#21153;&#35843;&#26597;&#20998;&#26512;&#23381;&#20135;&#26399;&#22919;&#22899;&#20135;&#21069;&#26816;&#26597;&#21644;&#20135;&#21518;&#35775;&#35270;&#24773;&#20917;&#21450;&#20854;&#24433;&#21709;&#22240;&#32032;[J]. &#20013;&#21335;&#22823;&#23398;&#23398;&#25253;(&#21307;&#23398;&#29256;), 2016, 41(11): 1220-1225. 10.11817/j.issn.1672-7347.2016.11.018.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.11817/j.issn.1672-7347.2016.11.018</ArticleId>
+            <ArticleId IdType="pubmed">27932771</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>ZHANG Wei, CHENG Xunjie, ZHANG Lin, et al. Analysis of the status and influential factors for prenatal care and postpartum visit among pregnant women based on the First Health Service Survey in Hunan Province[J]. Journal of Central South University. Medical Science, 2016, 41(11): 1220-1225. 10.11817/j.issn.1672-7347.2016.11.018.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.11817/j.issn.1672-7347.2016.11.018</ArticleId>
+            <ArticleId IdType="pubmed">27932771</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bansal SC, Nimbalkar SM, Shah NA, et al. Evaluation of knowledge and skills of home based newborn care among Accredited Social Health Activists (ASHA)[J]. Indian Pediatr, 2016, 53(8): 689-691. 10.1007/s13312-016-0911-3.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1007/s13312-016-0911-3</ArticleId>
+            <ArticleId IdType="pubmed">27395839</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ikram S, Khandelwal N, Dubey SR. A Study to Assess Newborn Care Practices among Mothers in Bhopal so as to Determine Risk Factors for Unsafe Practices and to Assess the Knowledge and Skills of Ashas during Their Home Visits to Those Newborns and Mothers [J]. J Pathol Clin Res, 2023, 15(4): 927-31.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Phatak AG, Nimbalkar SM, Prabhughate AS, et al. Comparison of knowledge and skills of Home-Based Newborn Care (HBNC) among Accredited Social Health Activists (ASHA) and health workers (SAKHI) of Ambuja Cement Foundation[J]. J Family Med Prim Care, 2021, 10(8): 2865-2878. 10.4103/jfmpc.jfmpc_1761_20.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.4103/jfmpc.jfmpc_1761_20</ArticleId>
+            <ArticleId IdType="pmc">PMC8483107</ArticleId>
+            <ArticleId IdType="pubmed">34660419</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Henderson S. Community Child Health (CCH) nurses&#8217; experience of home visits for new mothers: a quality improvement project[J]. Contemp Nurse, 2009, 34(1): 66-76. 10.5172/conu.2009.34.1.066.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.5172/conu.2009.34.1.066</ArticleId>
+            <ArticleId IdType="pubmed">20230173</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Bradley S, Kamwendo F, Masanja H, et al. District health managers&#8217; perceptions of supervision in Malawi and Tanzania[J]. Hum Resour Health, 2013, 11: 43. 10.1186/1478-4491-11-43.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/1478-4491-11-43</ArticleId>
+            <ArticleId IdType="pmc">PMC3849462</ArticleId>
+            <ArticleId IdType="pubmed">24007354</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jahan F, Foote E, Rahman M, et al. Evaluation of community health worker&#8217;s performance at home-based newborn assessment supported by mHealth in rural Bangladesh[J]. BMC Pediatr, 2022, 22(1): 218. 10.1186/s12887-022-03282-6.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s12887-022-03282-6</ArticleId>
+            <ArticleId IdType="pmc">PMC9027479</ArticleId>
+            <ArticleId IdType="pubmed">35459113</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#26446;&#28023;&#33495;, &#26519;&#23270;&#26757;. &#20135;&#21518;&#35775;&#35270;&#20154;&#21592;&#23545;&#27597;&#20083;&#21890;&#20859;&#26680;&#24515;&#25216;&#33021;&#25484;&#25569;&#24773;&#20917;&#35843;&#26597;[J]. &#25252;&#29702;&#30740;&#31350;, 2016, 30(15): 1919-1920. 10.3969/j.issn.1009-6493.2016.15.053.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3969/j.issn.1009-6493.2016.15.053</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>LI Haimiao, LIN Changmei. Investigation on postpartum visitors&#8217; mastery of breast-feeding core skills[J]. Chinese Nursing Research, 2016, 30(15): 1919-1920. 10.3969/j.issn.1009-6493.2016.15.053.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3969/j.issn.1009-6493.2016.15.053</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#37329;&#40857;&#22969;, &#23828;&#24013;, &#26472;&#24935;&#23486;, &#31561;. &#19978;&#28023;&#24066;&#38389;&#34892;&#21306;&#20135;&#21518;&#23478;&#24237;&#35775;&#35270;&#20154;&#21592;&#36991;&#23381;&#30693;&#35782;&#21644;&#26381;&#21153;&#33021;&#21147;&#30340;&#35843;&#26597;[J]. &#20013;&#21326;&#20840;&#31185;&#21307;&#24072;&#26434;&#24535;, 2019, 18(8): 742-745. 10.3760/cma.j.issn.1671-7368.2019.08.007.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3760/cma.j.issn.1671-7368.2019.08.007</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>JIN Longmei, CUI Wei, YANG Huibin, et al. Survey on contraceptive knowledge and service ability among postpartum visitors in Shanghai Minhang district[J]. Chinese Journal of General Practitioners, 2019, 18(8): 742-745. 10.3760/cma.j.issn.1671-7368.2019.08.007.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3760/cma.j.issn.1671-7368.2019.08.007</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#39532;&#26195;&#38686;, &#30707;&#27982;&#39034;, &#38062;&#21033;&#21326;, &#31561;. &#26032;&#24418;&#21183;&#19979;&#19978;&#28023;&#31038;&#21306;&#27597;&#23156;&#20445;&#20581;&#26381;&#21153;&#24320;&#23637;&#29616;&#29366;&#30340;&#36136;&#24615;&#30740;&#31350;[J]. &#20013;&#22269;&#20840;&#31185;&#21307;&#23398;, 2024, 27(28): 3529-3534 10.12114/j.issn.1007-9572.2023.0807.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.12114/j.issn.1007-9572.2023.0807</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#35885;&#29577;&#29618;, &#40644;&#32654;&#29618;, &#37036;&#25935;&#24535;, &#31561;. &#8220;&#20114;&#32852;&#32593;+&#27597;&#23156;&#25252;&#29702;&#8221; &#31934;&#20934;&#26381;&#21153;&#27169;&#24335;&#30340;&#26500;&#24314;&#19982;&#23454;&#36341;[J]. &#25252;&#29702;&#23398;&#25253;, 2021, 28(23): 25-27. 10.16460/j.issn1008-9969.2021.23.025.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16460/j.issn1008-9969.2021.23.025</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>TAN Yuling, HUANG Meiling, WU Minzhi, et al. Construction and practice of &#8220;Internet plus maternal and child care&#8221; precision service model[J]. Journal of Nursing(China), 2021, 28(23): 25-27. 10.16460/j.issn1008-9969.2021.23.025.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16460/j.issn1008-9969.2021.23.025</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#26446;&#25991;&#20808;, &#26446;&#20912;&#33721;, &#23828;&#26790;&#26228;, &#31561;. &#19978;&#28023;&#24066;&#20135;&#22919;&#20998;&#23081;&#21518;&#26089;&#26399;&#26032;&#29983;&#20799;&#27597;&#20083;&#21890;&#20859;&#24577;&#24230;&#21450;&#20854;&#24433;&#21709;&#22240;&#32032;&#20998;&#26512;[J]. &#20013;&#21326;&#30142;&#30149;&#25511;&#21046;&#26434;&#24535;, 2022, 26(4): 423-429. 10.16462/j.cnki.zhjbkz.2022.04.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16462/j.cnki.zhjbkz.2022.04.011</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>LI Wenxian, LI Bingying, CUI Mengqing, et al. Attitude towards breast feeding and its influencing factors among postpartum women 3 days after delivery in Shanghai[J]. Chinese Journal of Disease Control &amp; Prevention, 2022, 26(4): 423-429. 10.16462/j.cnki.zhjbkz.2022.04.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16462/j.cnki.zhjbkz.2022.04.011</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#38047;&#32701;&#35199;, &#38472;&#24565;&#22969;, &#21016;&#22025;, &#31561;. &#19978;&#28023;&#24066;&#26222;&#38464;&#21306;&#20135;&#22919;&#20135;&#21518;&#35775;&#35270;&#30340;&#38656;&#27714;&#21450;&#28385;&#24847;&#24230;[J]. &#19978;&#28023;&#39044;&#38450;&#21307;&#23398;, 2020, 32(5): 421-424. 10.19428/j.cnki.sjpm.2020.18988.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19428/j.cnki.sjpm.2020.18988</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>ZHONG Yuxi, CHEN Nianmei, LIU Jia, et al. Needs and satisfaction of parturients for postpartum visits in Putuo District, Shanghai[J]. Shanghai Journal of Preventive Medicine, 2020, 32(5): 421-424. 10.19428/j.cnki.sjpm.2020.18988.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19428/j.cnki.sjpm.2020.18988</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#26446;&#34122;, &#30000;&#31574;, &#39532;&#33391;&#22372;, &#31561;. &#38498;&#20869;&#22806;&#22242;&#38431;&#21327;&#20316;&#20837;&#25143;&#23545;&#20135;&#22919;&#23454;&#26045;&#27597;&#20083;&#21890;&#20859;&#19982;&#20135;&#35109;&#26399;&#29031;&#25252;&#25903;&#25345;&#30740;&#31350;[J]. &#25252;&#29702;&#23398;&#26434;&#24535;, 2022, 37(14): 1-4. 10.3870/j.issn.1001-4152.2022.14.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2022.14.001</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>LI Rui, TIAN Ce, MA Liangkun, et al. In-home breastfeeding and puerperal care support by in- and out-of-hospital teams[J]. Journal of Nursing Science, 2022, 37(14): 1-4. 10.3870/j.issn.1001-4152.2022.14.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2022.14.001</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Laurenzi CA, Gordon S, Skeen S, et al. The home visit communication skills inventory: Piloting a tool to measure community health worker fidelity to training in rural South Africa[J]. Res Nurs Health, 2020, 43(1): 122-133. 10.1002/nur.22000.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/nur.22000</ArticleId>
+            <ArticleId IdType="pubmed">31793678</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dana SN, Wambach KA. Patient satisfaction with an early discharge home visit program[J]. J Obstet Gynecol Neonatal Nurs, 2003, 32(2): 190-198. 10.1177/0884217503251733.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1177/0884217503251733</ArticleId>
+            <ArticleId IdType="pubmed">12685670</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Li C, Wu Q, van Velthoven MH, et al. Coverage, quality of and barriers to postnatal care in rural Hebei, China: a mixed method study[J]. BMC Pregnancy Childbirth, 2014, 14: 31. 10.1186/1471-2393-14-31.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/1471-2393-14-31</ArticleId>
+            <ArticleId IdType="pmc">PMC3898028</ArticleId>
+            <ArticleId IdType="pubmed">24438644</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gebretsadik A, Melaku N, Haji Y. Community acceptance and utilization of maternal and community-based neonatal care services provided by health extension workers in rural Sidama zone: barriers and enablers: a qualitative study[J]. Pediatric Health Med Ther, 2020, 11: 203-217. 10.2147/PHMT.S254409.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.2147/PHMT.S254409</ArticleId>
+            <ArticleId IdType="pmc">PMC7335842</ArticleId>
+            <ArticleId IdType="pubmed">32669919</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#29579;&#29756;, &#26472;&#21147;, &#27611;&#39062;, &#31561;. &#20113;&#21335;&#30465;&#23381;&#20135;&#22919;&#20581;&#24247;&#31649;&#29702;&#26381;&#21153;&#29616;&#29366;&#20998;&#26512;[J]. &#20013;&#22269;&#22919;&#24188;&#20445;&#20581;, 2016, 31(18): 3655-3657.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>WANG Qiong, YANG Li, MAO Ying, et al. Analysis on the current situation of maternal health management services in Yunnan Province[J]. Maternal and Child Health Care of China, 2016, 31(18): 3655-3657.</Citation>
+        </Reference>
+        <Reference>
+          <Citation>Balakrishnan R, Gopichandran V, Chaturvedi S, et al. Continuum of Care Services for Maternal and Child Health using mobile technology-a health system strengthening strategy in low and middle income countries[J]. BMC Med Inform Decis Mak, 2016, 16: 84. 10.1186/s12911-016-0326-z.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1186/s12911-016-0326-z</ArticleId>
+            <ArticleId IdType="pmc">PMC4937606</ArticleId>
+            <ArticleId IdType="pubmed">27387548</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#30000;&#26397;&#38686;, &#26446;&#32418;&#26757;, &#36213;&#25935;, &#31561;. &#26412;&#31185;&#21161;&#20135;&#32508;&#21512;&#23454;&#35757;&#35838;&#31243;&#24605;&#25919;&#30340;&#25945;&#23398;&#35774;&#35745;&#19982;&#23454;&#36341;[J]. &#20013;&#21326;&#25252;&#29702;&#25945;&#32946;, 2024, 21(1): 27-31. 10.3761/j.issn.1672-9234.2024.01.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3761/j.issn.1672-9234.2024.01.004</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>TIAN Zhaoxia, LI Hongmei, ZHAO Min, et al. Teaching design and practice of Ideological and Political Theory Education in Comprehensive Training Course for undergraduate midwifery major[J]. Chinese Journal of Nursing Education, 2024, 21(1): 27-31. 10.3761/j.issn.1672-9234.2024.01.004.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3761/j.issn.1672-9234.2024.01.004</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#33883;&#22278;, &#37011;&#26376;&#26690;, &#38889;&#21494;&#33452;. &#34394;&#23454;&#20223;&#30495;&#32508;&#21512;&#23454;&#35757;&#23545;&#25252;&#29702;&#26412;&#31185;&#29983;&#27597;&#23156;&#25252;&#29702;&#23703;&#20301;&#32988;&#20219;&#21147;&#30340;&#24433;&#21709;[J]. &#25252;&#29702;&#23398;&#26434;&#24535;, 2021, 36(15): 50-53. 10.3870/j.issn.1001-4152.2021.15.050.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2021.15.050</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>GE Yuan, DENG Yuegui, HAN Yefen. Effect of virtual simulation based lab teaching on maternal-infant care core competence of nursing undergraduates[J]. Journal of Nursing Science, 2021, 36(15): 50-53. 10.3870/j.issn.1001-4152.2021.15.050.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2021.15.050</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#38472;&#20025;&#20025;, &#21608;&#20020;, &#24352;&#26230;, &#31561;. &#20135;&#22919;&#23545;&#20197;&#23478;&#24237;&#20026;&#20013;&#24515;&#30340;&#32676;&#32452;&#24335;&#22260;&#29983;&#26399;&#20445;&#20581;&#30340;&#20307;&#39564;[J]. &#25252;&#29702;&#23398;&#26434;&#24535;, 2022, 37(14): 9-12. 10.3870/j.issn.1001-4152.2022.14.009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2022.14.009</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>CHEN Dandan, ZHOU Lin, ZHANG Jing, et al. Postpartum women&#8217;s experiences of family-centered group-based perinatal care[J]. Journal of Nursing Science, 2022, 37(14): 9-12. 10.3870/j.issn.1001-4152.2022.14.009.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3870/j.issn.1001-4152.2022.14.009</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#38047;&#23068;, &#32993;&#29756;&#29141;, &#26753;&#26093;&#38686;, &#31561;. &#21307;&#38498;-&#31038;&#21306;&#27597;&#20083;&#21890;&#20859;&#38142;&#24335;&#31649;&#29702;&#27169;&#24335;&#30340;&#24212;&#29992;&#21450;&#25928;&#26524;&#35780;&#20215;[J]. &#20013;&#21326;&#25252;&#29702;&#26434;&#24535;, 2022, 57(14): 1669-1675. 10.3761/j.issn.0254-1769.2022.14.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3761/j.issn.0254-1769.2022.14.001</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>ZHONG Na, HU Qiongyan, LIANG Xuxia, et al. Application and effect evaluation of a hospital-community breastfeeding chain management model[J]. Chinese Journal of Nursing, 2022, 57(14): 1669-1675. 10.3761/j.issn.0254-1769.2022.14.001.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.3761/j.issn.0254-1769.2022.14.001</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Schultz DA, Schacht RL, Shanty LM, et al. The development and evaluation of a statewide training center for home visitors and supervisors[J]. Am J Community Psychol, 2019, 63(3/4): 418-429. 10.1002/ajcp.12320.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.1002/ajcp.12320</ArticleId>
+            <ArticleId IdType="pubmed">30851132</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#29579;&#28322;, &#22799;&#32463;&#28828;, &#34203;&#29736;. 2018&#8212;2019&#24180;&#19978;&#28023;&#24066;&#40644;&#28006;&#21306;&#20135;&#21518;&#22919;&#22899;&#27597;&#23156;&#20581;&#24247;&#32032;&#20859;&#27700;&#24179;&#35843;&#26597;&#20998;&#26512;[J]. &#20013;&#22269;&#20581;&#24247;&#25945;&#32946;, 2021, 37(6): 531-535. 10.16168/j.cnki.issn.1002-9982.2021.06.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16168/j.cnki.issn.1002-9982.2021.06.011</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>WANG Yi, XIA Jingwei, XUE Kun. Analysis of health literacy on maternal and infant health among postpartum women in Huangpu District, Shanghai from 2018 to 2019[J]. Chinese Journal of Health Education, 2021, 37(6): 531-535. 10.16168/j.cnki.issn.1002-9982.2021.06.011.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.16168/j.cnki.issn.1002-9982.2021.06.011</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>&#24352;&#33993;, &#38047;&#32701;&#35199;, &#38472;&#24565;&#22969;, &#31561;. &#24320;&#23637;&#35268;&#33539;&#21270;&#22521;&#35757;&#23545;&#31038;&#21306;&#20135;&#21518;&#35775;&#35270;&#36136;&#37327;&#30340;&#24433;&#21709;[J]. &#20013;&#22269;&#22919;&#24188;&#20445;&#20581;, 2020, 35(7): 1186-1188. 10.19829/j.zgfybj.issn.1001-4411.2020.07.005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19829/j.zgfybj.issn.1001-4411.2020.07.005</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>ZHANG Rong, ZHONG Yuxi, CHEN Nianmei, et al. Influence of standardized training on the quality of postpartum visit in community[J]. Maternal and Child Health Care of China, 2020, 35(7): 1186-1188. 10.19829/j.zgfybj.issn.1001-4411.2020.07.005.</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="doi">10.19829/j.zgfybj.issn.1001-4411.2020.07.005</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/4567890.xml
+++ b/tests/fixtures/pmid_xml/4567890.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">4567890</PMID>
+      <DateCompleted>
+        <Year>1973</Year>
+        <Month>03</Month>
+        <Day>23</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>03</Month>
+        <Day>09</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0021-9940</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>82</Volume>
+            <Issue>1</Issue>
+            <PubDate>
+              <Year>1973</Year>
+              <Month>Jan</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Journal of comparative and physiological psychology</Title>
+          <ISOAbbreviation>J Comp Physiol Psychol</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Effects of rostral medial forebrain bundle and olfactory tubercle lesions upon sexual behavior of male rats.</ArticleTitle>
+        <Pagination>
+          <StartPage>30</StartPage>
+          <EndPage>36</EndPage>
+          <MedlinePgn>30-6</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Hitt</LastName>
+            <ForeName>J C</ForeName>
+            <Initials>JC</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Bryon</LastName>
+            <ForeName>D M</ForeName>
+            <Initials>DM</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Modianos</LastName>
+            <ForeName>D T</ForeName>
+            <Initials>DT</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>J Comp Physiol Psychol</MedlineTA>
+        <NlmUniqueID>0414612</NlmUniqueID>
+        <ISSNLinking>0021-9940</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000818" MajorTopicYN="N">Animals</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001835" MajorTopicYN="N">Body Weight</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003307" MajorTopicYN="N">Copulation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004542" MajorTopicYN="N">Ejaculation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005837" MajorTopicYN="N">Genitalia, Male</DescriptorName>
+          <QualifierName UI="Q000033" MajorTopicYN="N">anatomy &amp; histology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007031" MajorTopicYN="N">Hypothalamus</DescriptorName>
+          <QualifierName UI="Q000502" MajorTopicYN="Y">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008032" MajorTopicYN="N">Limbic System</DescriptorName>
+          <QualifierName UI="Q000502" MajorTopicYN="Y">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009830" MajorTopicYN="N">Olfactory Bulb</DescriptorName>
+          <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009929" MajorTopicYN="N">Organ Size</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D051381" MajorTopicYN="N">Rats</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012726" MajorTopicYN="Y">Sexual Behavior, Animal</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013238" MajorTopicYN="N">Stereotaxic Techniques</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1973</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1973</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1973</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">4567890</ArticleId>
+        <ArticleId IdType="doi">10.1037/h0033797</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/500000.xml
+++ b/tests/fixtures/pmid_xml/500000.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">500000</PMID>
+      <DateCompleted>
+        <Year>1980</Year>
+        <Month>01</Month>
+        <Day>24</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2013</Year>
+        <Month>11</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0018-5043</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>11</Volume>
+            <Issue>9</Issue>
+            <PubDate>
+              <Year>1979</Year>
+              <Month>Oct</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Hormone and metabolic research = Hormon- und Stoffwechselforschung = Hormones et metabolisme</Title>
+          <ISOAbbreviation>Horm Metab Res</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Effects of a synthetic hexapeptide (beta-Ala-Arg-Gly-Phe-Phe-Tyr-Nh2) on insulin binding and glucose metabolism of rat adipocytes.</ArticleTitle>
+        <Pagination>
+          <StartPage>498</StartPage>
+          <EndPage>502</EndPage>
+          <MedlinePgn>498-502</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Taketomi</LastName>
+            <ForeName>S</ForeName>
+            <Initials>S</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Iwatsuka</LastName>
+            <ForeName>H</ForeName>
+            <Initials>H</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>Germany</Country>
+        <MedlineTA>Horm Metab Res</MedlineTA>
+        <NlmUniqueID>0177722</NlmUniqueID>
+        <ISSNLinking>0018-5043</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D007328">Insulin</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D010446">Peptide Fragments</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>3CHI920QS7</RegistryNumber>
+          <NameOfSubstance UI="D003571">Cytochalasin B</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 2.7.10.1</RegistryNumber>
+          <NameOfSubstance UI="D011972">Receptor, Insulin</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>IY9XDZ35W2</RegistryNumber>
+          <NameOfSubstance UI="D005947">Glucose</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000273" MajorTopicYN="N">Adipose Tissue</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000818" MajorTopicYN="N">Animals</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003571" MajorTopicYN="N">Cytochalasin B</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005947" MajorTopicYN="N">Glucose</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007328" MajorTopicYN="N">Insulin</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="Y">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000494" MajorTopicYN="N">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010446" MajorTopicYN="N">Peptide Fragments</DescriptorName>
+          <QualifierName UI="Q000494" MajorTopicYN="Y">pharmacology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D051381" MajorTopicYN="N">Rats</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011972" MajorTopicYN="N">Receptor, Insulin</DescriptorName>
+          <QualifierName UI="Q000187" MajorTopicYN="N">drug effects</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013268" MajorTopicYN="N">Stimulation, Chemical</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1979</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1979</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1979</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">500000</ArticleId>
+        <ArticleId IdType="doi">10.1055/s-0028-1092769</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/5678901.xml
+++ b/tests/fixtures/pmid_xml/5678901.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">5678901</PMID>
+      <DateCompleted>
+        <Year>1968</Year>
+        <Month>11</Month>
+        <Day>20</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2004</Year>
+        <Month>11</Month>
+        <Day>17</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0021-7883</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>49</Volume>
+            <Issue>146</Issue>
+            <PubDate>
+              <Year>1968</Year>
+              <Month>Jul</Month>
+              <Day>05</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Journal de medecine de Lyon</Title>
+          <ISOAbbreviation>J Med Lyon</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>[Protected jejunal intubation].</ArticleTitle>
+        <Pagination>
+          <StartPage>1225</StartPage>
+          <EndPage>1235</EndPage>
+          <MedlinePgn>1225-35</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Vachon</LastName>
+            <ForeName>A</ForeName>
+            <Initials>A</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Barthe</LastName>
+            <ForeName>J</ForeName>
+            <Initials>J</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>S&#233;dallian</LastName>
+            <ForeName>J</ForeName>
+            <Initials>J</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Abry</LastName>
+            <ForeName>M</ForeName>
+            <Initials>M</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Brunet</LastName>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Khouzan</LastName>
+            <ForeName>T</ForeName>
+            <Initials>T</Initials>
+          </Author>
+        </AuthorList>
+        <Language>fre</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+        <VernacularTitle>Le tubage j&#233;junal prot&#233;g&#233;.</VernacularTitle>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>France</Country>
+        <MedlineTA>J Med Lyon</MedlineTA>
+        <NlmUniqueID>2985084R</NlmUniqueID>
+        <ISSNLinking>0021-7883</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007441" MajorTopicYN="Y">Intubation, Gastrointestinal</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007583" MajorTopicYN="N">Jejunum</DescriptorName>
+          <QualifierName UI="Q000382" MajorTopicYN="Y">microbiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008103" MajorTopicYN="N">Liver Cirrhosis</DescriptorName>
+          <QualifierName UI="Q000382" MajorTopicYN="Y">microbiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008286" MajorTopicYN="N">Malabsorption Syndromes</DescriptorName>
+          <QualifierName UI="Q000382" MajorTopicYN="Y">microbiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008722" MajorTopicYN="N">Methods</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011178" MajorTopicYN="N">Postgastrectomy Syndromes</DescriptorName>
+          <QualifierName UI="Q000382" MajorTopicYN="Y">microbiology</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1968</Year>
+          <Month>7</Month>
+          <Day>5</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1968</Year>
+          <Month>7</Month>
+          <Day>5</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1968</Year>
+          <Month>7</Month>
+          <Day>5</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">5678901</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/6789012.xml
+++ b/tests/fixtures/pmid_xml/6789012.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">6789012</PMID>
+      <DateCompleted>
+        <Year>1981</Year>
+        <Month>09</Month>
+        <Day>15</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2013</Year>
+        <Month>12</Month>
+        <Day>13</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0025-6196</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>56</Volume>
+            <Issue>7</Issue>
+            <PubDate>
+              <Year>1981</Year>
+              <Month>Jul</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Mayo Clinic proceedings</Title>
+          <ISOAbbreviation>Mayo Clin Proc</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>The diverse picture of gamma heavy-chain disease. Report of seven cases and review of literature.</ArticleTitle>
+        <Pagination>
+          <StartPage>439</StartPage>
+          <EndPage>451</EndPage>
+          <MedlinePgn>439-51</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Kyle</LastName>
+            <ForeName>R A</ForeName>
+            <Initials>RA</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Greipp</LastName>
+            <ForeName>P R</ForeName>
+            <Initials>PR</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Banks</LastName>
+            <ForeName>P M</ForeName>
+            <Initials>PM</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>CA-04646</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>CA-16835</GrantID>
+            <Acronym>CA</Acronym>
+            <Agency>NCI NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>NS-14304K</GrantID>
+            <Acronym>NS</Acronym>
+            <Agency>NINDS NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D002363">Case Reports</PublicationType>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013487">Research Support, U.S. Gov't, P.H.S.</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Mayo Clin Proc</MedlineTA>
+        <NlmUniqueID>0405543</NlmUniqueID>
+        <ISSNLinking>0025-6196</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000906">Antibodies</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000911">Antibodies, Monoclonal</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D007142">Immunoglobulin gamma-Chains</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D007136">Immunoglobulins</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000906" MajorTopicYN="N">Antibodies</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000911" MajorTopicYN="N">Antibodies, Monoclonal</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001853" MajorTopicYN="N">Bone Marrow</DescriptorName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006362" MajorTopicYN="N">Heavy Chain Disease</DescriptorName>
+          <QualifierName UI="Q000150" MajorTopicYN="N">complications</QualifierName>
+          <QualifierName UI="Q000175" MajorTopicYN="Y">diagnosis</QualifierName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+          <QualifierName UI="Q000628" MajorTopicYN="N">therapy</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007142" MajorTopicYN="N">Immunoglobulin gamma-Chains</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007136" MajorTopicYN="N">Immunoglobulins</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008198" MajorTopicYN="N">Lymph Nodes</DescriptorName>
+          <QualifierName UI="Q000473" MajorTopicYN="N">pathology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <NumberOfReferences>70</NumberOfReferences>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1981</Year>
+          <Month>7</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1981</Year>
+          <Month>7</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1981</Year>
+          <Month>7</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">6789012</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/6789123.xml
+++ b/tests/fixtures/pmid_xml/6789123.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">6789123</PMID>
+      <DateCompleted>
+        <Year>1981</Year>
+        <Month>09</Month>
+        <Day>15</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2013</Year>
+        <Month>11</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0149-2195</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>30</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>1981</Year>
+              <Month>Feb</Month>
+              <Day>20</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>MMWR. Morbidity and mortality weekly report</Title>
+          <ISOAbbreviation>MMWR Morb Mortal Wkly Rep</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Community water supply contaminated with caustic soda--Georgia.</ArticleTitle>
+        <Pagination>
+          <StartPage>67</StartPage>
+          <EndPage>73</EndPage>
+          <MedlinePgn>67-8, 73</MedlinePgn>
+        </Pagination>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <CollectiveName>Centers for Disease Control (CDC)</CollectiveName>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>MMWR Morb Mortal Wkly Rep</MedlineTA>
+        <NlmUniqueID>7802429</NlmUniqueID>
+        <ISSNLinking>0149-2195</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>55X04QC32I</RegistryNumber>
+          <NameOfSubstance UI="D012972">Sodium Hydroxide</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D005845" MajorTopicYN="N" Type="Geographic">Georgia</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012972" MajorTopicYN="N">Sodium Hydroxide</DescriptorName>
+          <QualifierName UI="Q000506" MajorTopicYN="Y">poisoning</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014877" MajorTopicYN="Y">Water Pollution, Chemical</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1981</Year>
+          <Month>2</Month>
+          <Day>20</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1981</Year>
+          <Month>2</Month>
+          <Day>20</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1981</Year>
+          <Month>2</Month>
+          <Day>20</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">6789123</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/7518611.xml
+++ b/tests/fixtures/pmid_xml/7518611.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">7518611</PMID>
+      <DateCompleted>
+        <Year>1994</Year>
+        <Month>08</Month>
+        <Day>16</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>08</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0036-5513</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>54</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>1994</Year>
+              <Month>May</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Scandinavian journal of clinical and laboratory investigation</Title>
+          <ISOAbbreviation>Scand J Clin Lab Invest</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Serum alpha-fetoprotein and alcohol consumption.</ArticleTitle>
+        <Pagination>
+          <StartPage>215</StartPage>
+          <EndPage>220</EndPage>
+          <MedlinePgn>215-20</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Fifty-nine persons, 23 chronic alcoholics and 36 normal healthy persons with a well described alcohol consumption, had the serum concentration of alpha-fetoprotein determined by a sensitive monoclonal immunofluorescent assay. A significant elevation in S-AFP was found in alcoholics, median 4.1 kIU/l as compared to 3.0 kIU/l in near-abstainers (&lt; 12 g ethanol per day) (p &lt; 0.02). This difference was not explained by differences in age. S-AFP correlated positively with age (p = 0.01). In non-alcoholics a borderline significant correlation with S-AFP was found with average daily alcohol consumption (self-reported) (p = 0.09) and a significant correlation with the serum concentration of carbohydrate-deficient transferrin (S-CDT) (p = 0.004). In 11 alcoholics 2 months of abstention from alcohol was accompanied by a median reduction of 21% in S-AFP (p &lt; 10(-5)). In alcoholics, but not in social drinkers, S-AFP correlated with S-ASAT (p = 0.004). The increase of S-AFP with alcohol consumption may reflect reversible alcohol-induced liver affection.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Christiansen</LastName>
+            <ForeName>M</ForeName>
+            <Initials>M</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Clinical Biochemistry, Statens Seruminstitut, Copenhagen.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Andersen</LastName>
+            <ForeName>J R</ForeName>
+            <Initials>JR</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>T&#248;rning</LastName>
+            <ForeName>J</ForeName>
+            <Initials>J</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Overg&#229;rd</LastName>
+            <ForeName>O</ForeName>
+            <Initials>O</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Jensen</LastName>
+            <ForeName>S P</ForeName>
+            <Initials>SP</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Magid</LastName>
+            <ForeName>E</ForeName>
+            <Initials>E</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>N&#248;rgaard-Pedersen</LastName>
+            <ForeName>B</ForeName>
+            <Initials>B</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Scand J Clin Lab Invest</MedlineTA>
+        <NlmUniqueID>0404375</NlmUniqueID>
+        <ISSNLinking>0036-5513</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D014168">Transferrin</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D000509">alpha-Fetoproteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="C056759">carbohydrate-deficient transferrin</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000428" MajorTopicYN="N">Alcohol Drinking</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000437" MajorTopicYN="N">Alcoholism</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="N">blood</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D014168" MajorTopicYN="N">Transferrin</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="N">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000032" MajorTopicYN="N">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000509" MajorTopicYN="N">alpha-Fetoproteins</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="Y">analysis</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1994</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1994</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1994</Year>
+          <Month>5</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">7518611</ArticleId>
+        <ArticleId IdType="doi">10.3109/00365519409088427</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/7550356.xml
+++ b/tests/fixtures/pmid_xml/7550356.xml
@@ -1,0 +1,512 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">7550356</PMID>
+      <DateCompleted>
+        <Year>1995</Year>
+        <Month>11</Month>
+        <Day>02</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2026</Year>
+        <Month>05</Month>
+        <Day>18</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">1061-4036</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>11</Volume>
+            <Issue>2</Issue>
+            <PubDate>
+              <Year>1995</Year>
+              <Month>Oct</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Nature genetics</Title>
+          <ISOAbbreviation>Nat Genet</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>The structure of the presenilin 1 (S182) gene and identification of six novel mutations in early onset AD families.</ArticleTitle>
+        <Pagination>
+          <StartPage>219</StartPage>
+          <EndPage>222</EndPage>
+          <MedlinePgn>219-22</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Genetic linkage studies place a gene causing early onset familial Alzheimer's disease (FAD) on chromosome 14q24.3 (refs 1-4). Five mutations within the S182 (Presenilin 1: PS-1) gene, which maps to this region, have recently been reported in several early onset FAD kindreds. We have localized the PS-1 gene to a 75 kb region and present the structure of this gene, evidence for alternative splicing and describe six novel mutations in early onset FAD pedigrees all of which alter residues conserved in the STM2 (Presenilin 2: PS-2) gene.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <CollectiveName>Alzheimer's Disease Collaborative Group</CollectiveName>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>AG00634</GrantID>
+            <Acronym>AG</Acronym>
+            <Agency>NIA NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>AG1187</GrantID>
+            <Acronym>AG</Acronym>
+            <Agency>NIA NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+          <Grant>
+            <GrantID>AG12028</GrantID>
+            <Acronym>AG</Acronym>
+            <Agency>NIA NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016448">Multicenter Study</PublicationType>
+          <PublicationType UI="D052061">Research Support, N.I.H., Extramural</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Nat Genet</MedlineTA>
+        <NlmUniqueID>9216904</NlmUniqueID>
+        <ISSNLinking>1061-4036</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D017931">DNA Primers</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D008565">Membrane Proteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="C508853">PSEN1 protein, human</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D053764">Presenilin-1</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000367" MajorTopicYN="N">Age Factors</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017668" MajorTopicYN="N">Age of Onset</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017398" MajorTopicYN="N">Alternative Splicing</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000544" MajorTopicYN="N">Alzheimer Disease</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000595" MajorTopicYN="N">Amino Acid Sequence</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001483" MajorTopicYN="N">Base Sequence</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002874" MajorTopicYN="N">Chromosome Mapping</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002883" MajorTopicYN="Y">Chromosomes, Human, Pair 14</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017931" MajorTopicYN="N">DNA Primers</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005091" MajorTopicYN="N">Exons</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005190" MajorTopicYN="N">Family</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008040" MajorTopicYN="N">Genetic Linkage</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015698" MajorTopicYN="N">Genomic Library</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D007438" MajorTopicYN="N">Introns</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008565" MajorTopicYN="N">Membrane Proteins</DescriptorName>
+          <QualifierName UI="Q000096" MajorTopicYN="N">biosynthesis</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008969" MajorTopicYN="N">Molecular Sequence Data</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010375" MajorTopicYN="N">Pedigree</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017354" MajorTopicYN="Y">Point Mutation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D016133" MajorTopicYN="N">Polymerase Chain Reaction</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D053764" MajorTopicYN="N">Presenilin-1</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <InvestigatorList>
+        <Investigator ValidYN="Y">
+          <LastName>Clark</LastName>
+          <ForeName>R F</ForeName>
+          <Initials>RF</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Hutton</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Fuldner</LastName>
+          <ForeName>R A</ForeName>
+          <Initials>RA</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Froelich</LastName>
+          <ForeName>S</ForeName>
+          <Initials>S</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Karran</LastName>
+          <ForeName>E</ForeName>
+          <Initials>E</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Talbot</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Crook</LastName>
+          <ForeName>R</ForeName>
+          <Initials>R</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lendon</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Prihar</LastName>
+          <ForeName>G</ForeName>
+          <Initials>G</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>He</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Korenblat</LastName>
+          <ForeName>K</ForeName>
+          <Initials>K</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Martinez</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Wragg</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Busfield</LastName>
+          <ForeName>F</ForeName>
+          <Initials>F</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Behrens</LastName>
+          <ForeName>M I</ForeName>
+          <Initials>MI</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Myers</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Norton</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Morris</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Mehta</LastName>
+          <ForeName>N</ForeName>
+          <Initials>N</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Pearson</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lincoln</LastName>
+          <ForeName>S</ForeName>
+          <Initials>S</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Baker</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Duff</LastName>
+          <ForeName>K</ForeName>
+          <Initials>K</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Zehr</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Perez-Tur</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Houlden</LastName>
+          <ForeName>H</ForeName>
+          <Initials>H</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Ruiz</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Ossa</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lopera</LastName>
+          <ForeName>F</ForeName>
+          <Initials>F</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Arcos</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Madrigal</LastName>
+          <ForeName>L</ForeName>
+          <Initials>L</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Collinge</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Humphreys</LastName>
+          <ForeName>C</ForeName>
+          <Initials>C</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Ashworth</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Sarner</LastName>
+          <ForeName>S</ForeName>
+          <Initials>S</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Fox</LastName>
+          <ForeName>N</ForeName>
+          <Initials>N</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Harvey</LastName>
+          <ForeName>R</ForeName>
+          <Initials>R</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Kennedy</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Roques</LastName>
+          <ForeName>P</ForeName>
+          <Initials>P</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Cline</LastName>
+          <ForeName>R T</ForeName>
+          <Initials>RT</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Phillips</LastName>
+          <ForeName>C A</ForeName>
+          <Initials>CA</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Venter</LastName>
+          <ForeName>J C</ForeName>
+          <Initials>JC</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Forsell</LastName>
+          <ForeName>L</ForeName>
+          <Initials>L</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Axelman</LastName>
+          <ForeName>K</ForeName>
+          <Initials>K</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lilius</LastName>
+          <ForeName>L</ForeName>
+          <Initials>L</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Johnston</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Cowburn</LastName>
+          <ForeName>R</ForeName>
+          <Initials>R</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Vitanen</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Winblad</LastName>
+          <ForeName>B</ForeName>
+          <Initials>B</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Kosik</LastName>
+          <ForeName>K</ForeName>
+          <Initials>K</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Haltia</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Poyhonen</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Dickson</LastName>
+          <ForeName>D</ForeName>
+          <Initials>D</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Mann</LastName>
+          <ForeName>D</ForeName>
+          <Initials>D</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Neary</LastName>
+          <ForeName>D</ForeName>
+          <Initials>D</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Snowden</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lantos</LastName>
+          <ForeName>P</ForeName>
+          <Initials>P</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Lannfelt</LastName>
+          <ForeName>L</ForeName>
+          <Initials>L</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Rossor</LastName>
+          <ForeName>M</ForeName>
+          <Initials>M</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Roberts</LastName>
+          <ForeName>G W</ForeName>
+          <Initials>GW</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Adams</LastName>
+          <ForeName>M D</ForeName>
+          <Initials>MD</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Hardy</LastName>
+          <ForeName>J</ForeName>
+          <Initials>J</Initials>
+        </Investigator>
+        <Investigator ValidYN="Y">
+          <LastName>Goate</LastName>
+          <ForeName>A</ForeName>
+          <Initials>A</Initials>
+        </Investigator>
+      </InvestigatorList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1995</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1995</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1995</Year>
+          <Month>10</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">7550356</ArticleId>
+        <ArticleId IdType="doi">10.1038/ng1095-219</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/7890234.xml
+++ b/tests/fixtures/pmid_xml/7890234.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">7890234</PMID>
+      <DateCompleted>
+        <Year>1995</Year>
+        <Month>04</Month>
+        <Day>18</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>05</Month>
+        <Day>01</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0017-5749</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>36</Volume>
+            <Issue>1</Issue>
+            <PubDate>
+              <Year>1995</Year>
+              <Month>Jan</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Gut</Title>
+          <ISOAbbreviation>Gut</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Soluble interleukin-6 receptors in inflammatory bowel disease: relation to circulating interleukin-6.</ArticleTitle>
+        <Pagination>
+          <StartPage>45</StartPage>
+          <EndPage>49</EndPage>
+          <MedlinePgn>45-9</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>The in vivo appearance of soluble interleukin (IL)-6 receptor (sIL-6R) in serum from patients with inflammatory bowel disease was examined using an enzyme linked immunosorbent assay (ELISA). The serum sIL-6R concentrations in patients with active disease (ulcerative colitis, 148.4 (5.1); Crohn's disease, 142.3 (9.3) ng/ml; mean (SEM)) were significantly raised compared with those in patients with inactive disease (ulcerative colitis, 116.2 (7.2); Crohn's disease, 114.3 (7.1) ng/ml), some other type of colitis (104.8 (11.6) ng/ml), or in normal subjects (107.3 (2.4) ng/ml). These differences were also seen in paired samples examined during both active and inactive phases. Additionally, serum sIL-6R and IL-6 concentrations correlated significantly with C-reactive protein levels in both ulcerative colitis and Crohn's disease patients (r = 0.23 and 0.56, respectively; p &lt; 0.05 for both). Furthermore, gel filtration analysis of serum from these patients showed two major peaks of immunoreactive IL-6-one peak corresponding to free IL-6 and another peak to sIL-6R-bound IL-6-this was further confirmed by a luminescence sandwich ELISA. These results, together with its in vitro effects, indicate that natural sIL-6R may function as a powerful enhancer of the IL-6-dependent immune processes observed in inflammatory bowel disease.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Mitsuyama</LastName>
+            <ForeName>K</ForeName>
+            <Initials>K</Initials>
+            <AffiliationInfo>
+              <Affiliation>Second Department of Medicine, Kurume University School of Medicine, Fukuoka, Japan.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Toyonaga</LastName>
+            <ForeName>A</ForeName>
+            <Initials>A</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Sasaki</LastName>
+            <ForeName>E</ForeName>
+            <Initials>E</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ishida</LastName>
+            <ForeName>O</ForeName>
+            <Initials>O</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Ikeda</LastName>
+            <ForeName>H</ForeName>
+            <Initials>H</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Tsuruta</LastName>
+            <ForeName>O</ForeName>
+            <Initials>O</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Harada</LastName>
+            <ForeName>K</ForeName>
+            <Initials>K</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Tateishi</LastName>
+            <ForeName>H</ForeName>
+            <Initials>H</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Nishiyama</LastName>
+            <ForeName>T</ForeName>
+            <Initials>T</Initials>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Tanikawa</LastName>
+            <ForeName>K</ForeName>
+            <Initials>K</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Gut</MedlineTA>
+        <NlmUniqueID>2985108R</NlmUniqueID>
+        <ISSNLinking>0017-5749</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D015850">Interleukin-6</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D018123">Receptors, Interleukin</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D019947">Receptors, Interleukin-6</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000293" MajorTopicYN="N">Adolescent</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D000368" MajorTopicYN="N">Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002850" MajorTopicYN="N">Chromatography, Gel</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003092" MajorTopicYN="N">Colitis</DescriptorName>
+          <QualifierName UI="Q000276" MajorTopicYN="N">immunology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003093" MajorTopicYN="N">Colitis, Ulcerative</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+          <QualifierName UI="Q000276" MajorTopicYN="N">immunology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003424" MajorTopicYN="N">Crohn Disease</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+          <QualifierName UI="Q000276" MajorTopicYN="N">immunology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004797" MajorTopicYN="N">Enzyme-Linked Immunosorbent Assay</DescriptorName>
+          <QualifierName UI="Q000379" MajorTopicYN="N">methods</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D015850" MajorTopicYN="N">Interleukin-6</DescriptorName>
+          <QualifierName UI="Q000097" MajorTopicYN="Y">blood</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008875" MajorTopicYN="N">Middle Aged</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018123" MajorTopicYN="N">Receptors, Interleukin</DescriptorName>
+          <QualifierName UI="Q000032" MajorTopicYN="Y">analysis</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D019947" MajorTopicYN="N">Receptors, Interleukin-6</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D012995" MajorTopicYN="N">Solubility</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1995</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1995</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1995</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="pmc-release">
+          <Year>1995</Year>
+          <Month>1</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">7890234</ArticleId>
+        <ArticleId IdType="pmc">PMC1382351</ArticleId>
+        <ArticleId IdType="doi">10.1136/gut.36.1.45</ArticleId>
+      </ArticleIdList>
+      <ReferenceList>
+        <Reference>
+          <Citation>Lab Invest. 1989 Dec;61(6):588-602</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2481148</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Immunol. 1989 Nov 1;143(9):2900-6</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2681418</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Ann Intern Med. 1990 Oct 15;113(8):619-27</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2205142</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biochem. 1990 Oct;108(4):673-6</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2292596</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Lab Invest. 1991 Jul;65(1):3-14</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1712874</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>FASEB J. 1991 Aug;5(11):2567-74</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1868981</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gastroenterology. 1992 Feb;102(2):514-9</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1370661</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gut. 1991 Dec;32(12):1531-4</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1773961</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Immunol Lett. 1992 Feb;31(2):123-30</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1740350</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Immunol. 1992 Apr 1;148(7):2175-80</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1545125</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Digestion. 1991;50(2):104-11</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1804734</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Chem Immunol. 1992;51:181-204</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1533128</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Dig Dis Sci. 1992 Jun;37(6):818-26</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1587185</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>FEBS Lett. 1992 Jul 20;306(2-3):257-61</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1321738</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Arthritis Rheum. 1992 Aug;35(8):940-3</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1642659</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Jpn J Cancer Res. 1992 Apr;83(4):373-8</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1506271</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Immunol. 1992 Sep 15;149(6):2021-7</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1381393</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Science. 1992 Oct 23;258(5082):593-7</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1411569</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Clin Exp Immunol. 1992 Nov;90(2):161-9</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1330388</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gastroenterology. 1992 Nov;103(5):1587-95</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">1426879</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Br Med J. 1955 Oct 29;2(4947):1041-8</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">13260656</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Scand J Gastroenterol Suppl. 1984;95:1-27</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">6379849</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Immunol. 1989 Jan 1;142(1):148-52</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2462586</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Immunol. 1989 Jun 15;142(12):4248-55</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2566634</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Biol Chem. 1989 Jul 15;264(20):11966-73</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2545692</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Blood. 1989 Jul;74(1):1-10</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2473791</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Cell. 1989 Aug 11;58(3):573-81</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2788034</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>J Exp Med. 1989 Oct 1;170(4):1409-14</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2529343</ArticleId>
+          </ArticleIdList>
+        </Reference>
+        <Reference>
+          <Citation>Gastroenterology. 1990 Mar;98(3):639-46</Citation>
+          <ArticleIdList>
+            <ArticleId IdType="pubmed">2298368</ArticleId>
+          </ArticleIdList>
+        </Reference>
+      </ReferenceList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/8901345.xml
+++ b/tests/fixtures/pmid_xml/8901345.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">8901345</PMID>
+      <DateCompleted>
+        <Year>1996</Year>
+        <Month>12</Month>
+        <Day>27</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2022</Year>
+        <Month>03</Month>
+        <Day>10</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0278-7393</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>22</Volume>
+            <Issue>2</Issue>
+            <PubDate>
+              <Year>1996</Year>
+              <Month>Mar</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Journal of experimental psychology. Learning, memory, and cognition</Title>
+          <ISOAbbreviation>J Exp Psychol Learn Mem Cogn</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Unsupervised concept learning and value systematicity: a complex whole aids learning the parts.</ArticleTitle>
+        <Pagination>
+          <StartPage>458</StartPage>
+          <EndPage>475</EndPage>
+          <MedlinePgn>458-475</MedlinePgn>
+        </Pagination>
+        <ELocationID EIdType="doi" ValidYN="Y">10.1037/0278-7393.22.2.458</ELocationID>
+        <Abstract>
+          <AbstractText>Ease of learning new concepts may best be understood by simultaneously considering models of learning and theories of how "good" systems of categories are organized. The authors tested the effects on learning of value systematicity, a proposed organizing principle: If 1 attribute is predictive of another, it should predict still more. This principle derives from focused sampling in the internal feedback model (D. Billman &amp; E. Heit, 1988) of unsupervised, or observational, learning. In 3 experiments, the authors tested how the organization of structure in input (value systematicity) affected unsupervised learning of categories about alien animals. Across all experiments, learning a target rule was easier in conditions with high value systematicity, relative to several low systematicity controls. The authors compare results to predictions of several learning models and consider the links between learning and the resulting category structure.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Billman</LastName>
+            <ForeName>Dorrit</ForeName>
+            <Initials>D</Initials>
+            <AffiliationInfo>
+              <Affiliation>Georgia Inst of Technology.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Knutson</LastName>
+            <ForeName>James</ForeName>
+            <Initials>J</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <GrantList CompleteYN="Y">
+          <Grant>
+            <GrantID>R23HD20522</GrantID>
+            <Acronym>HD</Acronym>
+            <Agency>NICHD NIH HHS</Agency>
+            <Country>United States</Country>
+          </Grant>
+        </GrantList>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013487">Research Support, U.S. Gov't, P.H.S.</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>J Exp Psychol Learn Mem Cogn</MedlineTA>
+        <NlmUniqueID>8207540</NlmUniqueID>
+        <ISSNLinking>0278-7393</ISSNLinking>
+      </MedlineJournalInfo>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D000328" MajorTopicYN="N">Adult</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001245" MajorTopicYN="N">Association Learning</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001288" MajorTopicYN="N">Attention</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D003210" MajorTopicYN="Y">Concept Formation</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004193" MajorTopicYN="N">Discrimination Learning</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005260" MajorTopicYN="N">Female</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008297" MajorTopicYN="N">Male</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010364" MajorTopicYN="Y">Pattern Recognition, Visual</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011340" MajorTopicYN="Y">Problem Solving</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1996</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1996</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1996</Year>
+          <Month>3</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">8901345</ArticleId>
+        <ArticleId IdType="doi">10.1037/0278-7393.22.2.458</ArticleId>
+        <ArticleId IdType="pii">1996-02947-014</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/9012456.xml
+++ b/tests/fixtures/pmid_xml/9012456.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">9012456</PMID>
+      <DateCompleted>
+        <Year>1997</Year>
+        <Month>02</Month>
+        <Day>20</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2015</Year>
+        <Month>11</Month>
+        <Day>19</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0008-5472</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>57</Volume>
+            <Issue>3</Issue>
+            <PubDate>
+              <Year>1997</Year>
+              <Month>Feb</Month>
+              <Day>01</Day>
+            </PubDate>
+          </JournalIssue>
+          <Title>Cancer research</Title>
+          <ISOAbbreviation>Cancer Res</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Nitrosated glycine derivatives as a potential source of O6-methylguanine in DNA.</ArticleTitle>
+        <Pagination>
+          <StartPage>366</StartPage>
+          <EndPage>369</EndPage>
+          <MedlinePgn>366-9</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>The nitrosated bile acid conjugate N-nitrosoglycocholic acid reacts with DNA to give, rise to several adducts including O6-carboxymethylguanine and, unexpectedly, O6-methylguanine (O6-MG). O6-MG is well established as a toxic and promutagenic lesion and is a substrate for the DNA repair protein O6-alkylguanine-DNA-alkyltransferase. In contrast, O6-carboxymethylguanine is not repaired by this protein. Similar results have been obtained for other nitrosated glycine derivatives, which suggests that O6-MG, which has been observed in DNA from human gastrointestinal tissues, may be derived from intragastric nitrosation of glycine or related compounds.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Shuker</LastName>
+            <ForeName>D E</ForeName>
+            <Initials>DE</Initials>
+            <AffiliationInfo>
+              <Affiliation>MRC Toxicology Unit, Hodgkin Building, University of Leicester, United Kingdom.</Affiliation>
+            </AffiliationInfo>
+          </Author>
+          <Author ValidYN="Y">
+            <LastName>Margison</LastName>
+            <ForeName>G P</ForeName>
+            <Initials>GP</Initials>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D013485">Research Support, Non-U.S. Gov't</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>United States</Country>
+        <MedlineTA>Cancer Res</MedlineTA>
+        <NlmUniqueID>2984705R</NlmUniqueID>
+        <ISSNLinking>0008-5472</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D009602">Nitrosamines</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>5Z93L87A1R</RegistryNumber>
+          <NameOfSubstance UI="D006147">Guanine</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>76757-85-2</RegistryNumber>
+          <NameOfSubstance UI="C034937">N-nitrosoglycocholic acid</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9007-49-2</RegistryNumber>
+          <NameOfSubstance UI="D004247">DNA</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9B710FV2AE</RegistryNumber>
+          <NameOfSubstance UI="C008449">O-(6)-methylguanine</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>TE7660XO1C</RegistryNumber>
+          <NameOfSubstance UI="D005998">Glycine</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D004247" MajorTopicYN="N">DNA</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005998" MajorTopicYN="N">Glycine</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006147" MajorTopicYN="N">Guanine</DescriptorName>
+          <QualifierName UI="Q000031" MajorTopicYN="Y">analogs &amp; derivatives</QualifierName>
+          <QualifierName UI="Q000378" MajorTopicYN="N">metabolism</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009602" MajorTopicYN="N">Nitrosamines</DescriptorName>
+          <QualifierName UI="Q000378" MajorTopicYN="Y">metabolism</QualifierName>
+        </MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1997</Year>
+          <Month>2</Month>
+          <Day>1</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1997</Year>
+          <Month>2</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1997</Year>
+          <Month>2</Month>
+          <Day>1</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">9012456</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/fixtures/pmid_xml/9562523.xml
+++ b/tests/fixtures/pmid_xml/9562523.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE" Owner="NLM" IndexingMethod="Manual">
+      <PMID Version="1">9562523</PMID>
+      <DateCompleted>
+        <Year>1998</Year>
+        <Month>06</Month>
+        <Day>09</Day>
+      </DateCompleted>
+      <DateRevised>
+        <Year>2019</Year>
+        <Month>09</Month>
+        <Day>21</Day>
+      </DateRevised>
+      <Article PubModel="Print">
+        <Journal>
+          <ISSN IssnType="Print">0785-3890</ISSN>
+          <JournalIssue CitedMedium="Print">
+            <Volume>29</Volume>
+            <Issue>6</Issue>
+            <PubDate>
+              <Year>1997</Year>
+              <Month>Dec</Month>
+            </PubDate>
+          </JournalIssue>
+          <Title>Annals of medicine</Title>
+          <ISOAbbreviation>Ann Med</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Molecular background of the Finnish disease heritage.</ArticleTitle>
+        <Pagination>
+          <StartPage>553</StartPage>
+          <EndPage>556</EndPage>
+          <MedlinePgn>553-6</MedlinePgn>
+        </Pagination>
+        <Abstract>
+          <AbstractText>Finland has a population with a history revealing features of founder effect, genetic drift and isolation. Relatively small founder populations have slowly inhabited a large country and internal isolates have developed within Finland. This is reflected even today in the regional enrichment of some diseases belonging to the Finnish disease heritage. This concept was launched before the DNA era by skillful clinicians and today it comprises some 30 diseases with a wide variety of clinical phenotypes. Special strategies have been adapted in the initial locus assignment and in the restriction of the critical chromosomal DNA region having so far resulted in the successful isolation of 11 disease genes. Detailed analyses of these disease genes and their function have provided new insights into the structure and function of defective proteins as well as into the biology of affected tissues.</AbstractText>
+        </Abstract>
+        <AuthorList CompleteYN="Y">
+          <Author ValidYN="Y">
+            <LastName>Peltonen</LastName>
+            <ForeName>L</ForeName>
+            <Initials>L</Initials>
+            <AffiliationInfo>
+              <Affiliation>Department of Human Molecular Genetics, University of Helsinki, National Public Health Institute, Finland. Leena.Peltonen@ktl.fi</Affiliation>
+            </AffiliationInfo>
+          </Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList>
+          <PublicationType UI="D016428">Journal Article</PublicationType>
+          <PublicationType UI="D016454">Review</PublicationType>
+        </PublicationTypeList>
+      </Article>
+      <MedlineJournalInfo>
+        <Country>England</Country>
+        <MedlineTA>Ann Med</MedlineTA>
+        <NlmUniqueID>8906388</NlmUniqueID>
+        <ISSNLinking>0785-3890</ISSNLinking>
+      </MedlineJournalInfo>
+      <ChemicalList>
+        <Chemical>
+          <RegistryNumber>0</RegistryNumber>
+          <NameOfSubstance UI="D011506">Proteins</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>9007-49-2</RegistryNumber>
+          <NameOfSubstance UI="D004247">DNA</NameOfSubstance>
+        </Chemical>
+        <Chemical>
+          <RegistryNumber>EC 3.5.1.26</RegistryNumber>
+          <NameOfSubstance UI="D001227">Aspartylglucosylaminase</NameOfSubstance>
+        </Chemical>
+      </ChemicalList>
+      <CitationSubset>IM</CitationSubset>
+      <MeshHeadingList>
+        <MeshHeading>
+          <DescriptorName UI="D054880" MajorTopicYN="N">Aspartylglucosaminuria</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001227" MajorTopicYN="N">Aspartylglucosylaminase</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D001695" MajorTopicYN="N">Biology</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D002874" MajorTopicYN="N">Chromosome Mapping</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D004247" MajorTopicYN="N">DNA</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005387" MajorTopicYN="N" Type="Geographic">Finland</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D018703" MajorTopicYN="N">Founder Effect</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005787" MajorTopicYN="N">Gene Frequency</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D005788" MajorTopicYN="N">Gene Pool</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D030342" MajorTopicYN="N">Genetic Diseases, Inborn</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="Y">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D006801" MajorTopicYN="N">Humans</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008661" MajorTopicYN="N">Metabolism, Inborn Errors</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D008967" MajorTopicYN="Y">Molecular Biology</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D009472" MajorTopicYN="N">Neuronal Ceroid-Lipofuscinoses</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D010641" MajorTopicYN="N">Phenotype</DescriptorName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D017354" MajorTopicYN="N">Point Mutation</DescriptorName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D011506" MajorTopicYN="N">Proteins</DescriptorName>
+          <QualifierName UI="Q000737" MajorTopicYN="N">chemistry</QualifierName>
+          <QualifierName UI="Q000235" MajorTopicYN="N">genetics</QualifierName>
+          <QualifierName UI="Q000502" MajorTopicYN="N">physiology</QualifierName>
+        </MeshHeading>
+        <MeshHeading>
+          <DescriptorName UI="D013329" MajorTopicYN="N">Structure-Activity Relationship</DescriptorName>
+        </MeshHeading>
+      </MeshHeadingList>
+      <NumberOfReferences>20</NumberOfReferences>
+    </MedlineCitation>
+    <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="pubmed">
+          <Year>1998</Year>
+          <Month>4</Month>
+          <Day>30</Day>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="medline">
+          <Year>1998</Year>
+          <Month>4</Month>
+          <Day>30</Day>
+          <Hour>0</Hour>
+          <Minute>1</Minute>
+        </PubMedPubDate>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>1998</Year>
+          <Month>4</Month>
+          <Day>30</Day>
+          <Hour>0</Hour>
+          <Minute>0</Minute>
+        </PubMedPubDate>
+      </History>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">9562523</ArticleId>
+        <ArticleId IdType="doi">10.3109/07853899709007481</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>

--- a/tests/test_clinvar_fetcher.py
+++ b/tests/test_clinvar_fetcher.py
@@ -178,8 +178,14 @@ class TestClinVarFetcher(unittest.TestCase):
             if 'submitter_name' in assertion:
                 self.assertIsInstance(assertion['submitter_name'], str)
 
+    @pytest.mark.live_network
     def test_pmids_for_hgvs(self):
-        """Test that pmids_for_hgvs returns a list of PMID strings"""
+        """Test that pmids_for_hgvs returns a list of PMID strings.
+
+        Live NCBI query (ClinVar/eutils): excluded from the offline CI run, like the
+        other live_network tests in this file. Synthetic mocking would only prove the
+        mock works, not the query.
+        """
         pmids = self.fetch.pmids_for_hgvs('NM_000059.4:c.9382C>T')
         self.assertIsInstance(pmids, list)
         for pmid in pmids:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from metapub.convert import pmid2doi, PubMedArticle2doi, bookid2pmid
 from metapub.crossref import TITLE_SIMILARITY_IDEAL_SCORE, TITLE_SIMILARITY_MIN_SCORE
@@ -56,7 +57,10 @@ class TestConversions(unittest.TestCase):
         #doi = pmid2doi(pmid_with_unknown_doi)
         #assert doi is None
 
+    @pytest.mark.live_network
     def test_bookid2pmid(self):
+        # Live NCBI ID conversion (bookID -> PMID via eutils): excluded from the
+        # offline CI run. A synthetic mock would only prove the mock works.
         for item in NCBI_BOOKS:
             assert item['pmid'] == bookid2pmid(item['book_id'])
 

--- a/tests/test_pubmed_article.py
+++ b/tests/test_pubmed_article.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 from datetime import datetime
 from metapub.cache_utils import cleanup_dir
 from metapub.exceptions import *
@@ -7,6 +8,7 @@ from metapub import PubMedArticle, PubMedFetcher
 import random
 
 from tests.common import TEST_CACHEDIR
+from tests.fixtures import load_pmid_xml
 
 xml_str1 = '''<?xml version="1.0"?>
 <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2015//EN" "http://www.ncbi.nlm.nih.gov/corehtml/query/DTD/pubmed_150101.dtd">
@@ -304,7 +306,10 @@ class TestPubMedArticle(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @pytest.mark.live_network
     def test_random_efetch(self):
+        # Inherently a live smoke test: fetches a RANDOM PMID, so it cannot use a
+        # saved fixture. Excluded from the offline CI run via the live_network marker.
         pmid = str(random.randint(22222222, 23333333))
         try:
             article = self.fetch.article_by_pmid(pmid)
@@ -360,7 +365,7 @@ class TestPubMedArticle(unittest.TestCase):
         with a list of qualifiers and their major topic statuses, using PMID 34558640.
         """
         pmid = "34558640"
-        article = self.fetch.article_by_pmid(pmid)
+        article = load_pmid_xml(pmid)
         self.assertIsNotNone(article, f"Failed to fetch article for PMID {pmid}")
 
         mesh_data = article.mesh
@@ -482,7 +487,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], description=case["description"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test that pubdate property exists and returns datetime
                     self.assertIsNotNone(article.pubdate, 
@@ -573,7 +578,7 @@ class TestPubMedArticle(unittest.TestCase):
         for pmid in test_pmids:
             with self.subTest(pmid=pmid):
                 try:
-                    article = self.fetch.article_by_pmid(pmid)
+                    article = load_pmid_xml(pmid)
                     
                     # Test essential attributes
                     for attr_name, expected_type in essential_attrs.items():
@@ -630,7 +635,7 @@ class TestPubMedArticle(unittest.TestCase):
         from xml.etree.ElementTree import Element, SubElement
         
         # Create a test article to access _parse_medlinedate method
-        test_article = self.fetch.article_by_pmid('1000')
+        test_article = load_pmid_xml('1000')
         
         # Test cases for MedlineDate parsing
         medlinedate_cases = [
@@ -687,7 +692,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], description=case["description"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test citation property
                     citation = article.citation
@@ -745,7 +750,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], description=case["description"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test authors attribute
                     self.assertIsInstance(article.authors, list)
@@ -795,7 +800,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in era_test_cases:
             with self.subTest(pmid=case["pmid"], era=case["era"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test year string extraction
                     self.assertEqual(article.year, case["expected_year"],
@@ -814,7 +819,7 @@ class TestPubMedArticle(unittest.TestCase):
         Test that book and article attributes are properly isolated based on pubmed_type.
         """
         # Test article
-        article = self.fetch.article_by_pmid("34889398")  # Known article
+        article = load_pmid_xml("34889398")  # Known article
         self.assertEqual(article.pubmed_type, 'article')
         
         # Article should have article attributes
@@ -827,7 +832,7 @@ class TestPubMedArticle(unittest.TestCase):
         self.assertIsNone(article.book_publisher)
         
         # Test book
-        book = self.fetch.article_by_pmid("20301546")  # Known GeneReviews book
+        book = load_pmid_xml("20301546")  # Known GeneReviews book
         self.assertEqual(book.pubmed_type, 'book')
         
         # Book should have book attributes
@@ -857,7 +862,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], description=case["description"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Should have pubdate
                     self.assertIsNotNone(article.pubdate, f"PMID {case['pmid']} should have pubdate")
@@ -895,7 +900,7 @@ class TestPubMedArticle(unittest.TestCase):
             for pmid in pmids[:2]:  # Test 2 PMIDs per language to balance thoroughness and speed
                 with self.subTest(language=language, pmid=pmid):
                     try:
-                        article = self.fetch.article_by_pmid(pmid)
+                        article = load_pmid_xml(pmid)
                         
                         # Test essential attributes work for non-English content
                         self.assertIsNotNone(article.pmid, f"{language} PMID {pmid}: pmid should not be None")
@@ -960,7 +965,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], language=case["language"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test pubdate property specifically
                     self.assertIsNotNone(article.pubdate,
@@ -996,7 +1001,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], language=case["language"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test standard citation
                     citation = article.citation
@@ -1042,7 +1047,7 @@ class TestPubMedArticle(unittest.TestCase):
         for case in test_cases:
             with self.subTest(pmid=case["pmid"], language=case["language"]):
                 try:
-                    article = self.fetch.article_by_pmid(case["pmid"])
+                    article = load_pmid_xml(case["pmid"])
                     
                     # Test that title can contain non-ASCII characters
                     if article.title:
@@ -1095,7 +1100,7 @@ class TestPubMedArticle(unittest.TestCase):
         for pmid in multilingual_test_pmids:
             with self.subTest(pmid=pmid):
                 try:
-                    article = self.fetch.article_by_pmid(pmid)
+                    article = load_pmid_xml(pmid)
                     
                     for attr_name in essential_attrs:
                         self.assertTrue(hasattr(article, attr_name),
@@ -1123,7 +1128,7 @@ class TestPubMedArticle(unittest.TestCase):
         These should be mapped to appropriate months: Spring=March, Summer=June, Fall/Autumn=September, Winter=December.
         """
         # PMID 28139132 is known to have <Season>Winter</Season> in 2016
-        article = self.fetch.article_by_pmid('28139132')
+        article = load_pmid_xml('28139132')
         
         # Verify the article loads correctly
         self.assertIsNotNone(article, "Article should load successfully")
@@ -1156,7 +1161,7 @@ class TestPubMedArticle(unittest.TestCase):
         Test the seasonal to month mapping used in _construct_datetime.
         """
         # Create a test article to access the method
-        test_article = self.fetch.article_by_pmid('1000')  # Any valid PMID
+        test_article = load_pmid_xml('1000')  # Any valid PMID
         
         # Test data - simulate XML elements with different seasons
         from xml.etree.ElementTree import Element, SubElement


### PR DESCRIPTION
Independent of #160. Fixes the flaky tests that fail in the CI bucket (`pytest -m "not live_network"`) due to NCBI eutils rate-limiting, not code bugs.

## Root cause
Several tests fetched many PMIDs from eutils **in tight loops with no API key**, blowing past the anonymous 3 req/sec limit and failing with `Invalid ID ... (rejected by Eutils)`. `conftest.py` only throttles *between* test functions, not within a loop. These were auto-marked `network` (not `live_network`), so they ran in CI and flaked. (With an API key they all pass — pure throttling.)

## Fix
**`test_pubmed_article.py`** — the comprehensive attribute/parsing loop tests now load saved XML via `load_pmid_xml()` (the existing findit-test fixture pattern) instead of live `article_by_pmid()`. **+52 PMID XML fixtures** added. Verified fully offline with network blocked: 20 passed, 92 subtests.
- `test_random_efetch` fetches a *random* PMID (can't be a fixture) → marked `live_network`.

**`test_convert.py::test_bookid2pmid`** and **`test_clinvar_fetcher.py::test_pmids_for_hgvs`** are live NCBI ID-conversion / ClinVar query loops with no meaningful offline form → marked `live_network` (drift detectors), matching the existing convention in the clinvar file. Per CLAUDE.md, synthetic-mocking these would only prove the mock works, not the query.

## Verification
- Full offline suite: **618 passed, 0 failed**, 62 deselected (was failing 7 before).
- `test_pubmed_article.py` verified with network fully blocked (proves zero network dependence).

## Note
Article *parsing* tests are the right fixture candidates (test real saved XML offline). Genuinely-live *query/conversion* tests are honestly categorized as `live_network` rather than faked. CI is keyless, but the remaining single-call eutils tests are spaced by conftest's coordination and were never the flaky offenders — the in-loop bursts were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)