### PR TITLE
Use VernacularTitle when ArticleTitle is unavailable

### DIFF
--- a/metapub/pubmedarticle.py
+++ b/metapub/pubmedarticle.py
@@ -511,7 +511,12 @@ class PubMedArticle(MetaPubObject):
             return lastnum
 
     def _get_title(self):
-        return self._get(self._root+'/Article/ArticleTitle')
+        title = self._get(self._root+'/Article/ArticleTitle')
+        if title == '[Not Available].':
+            vernacular_title = self._get(self._root+'/Article/VernacularTitle')
+            if vernacular_title:
+                return vernacular_title
+        return title
 
     def _get_volume(self):
         try:

--- a/tests/test_pubmed_article.py
+++ b/tests/test_pubmed_article.py
@@ -359,6 +359,10 @@ class TestPubMedArticle(unittest.TestCase):
         self.assertTrue(abstract.startswith('BACKGROUND: Epstein-Barr virus (EBV) infection and vitamin D insufficiency'))
         self.assertTrue(abstract.endswith('do not implicate a promoted immune response against EBV as the underlying mechanism.'))
 
+    def test_vernacular_title_when_article_title_not_available(self):
+        article = load_pmid_xml("39653886")
+        self.assertEqual(article.title, "Was bei Knieschmerzen wirklich hilft.")
+
     def test_mesh_heading_parsing_detailed(self):
         """
         Tests the parsing of MeSH headings, specifically checking the new structure


### PR DESCRIPTION
Fixes #3

When an ArticleTitle is "[Not Available].", use the
VernacularTitle when available.

Added a test using PMID 39653886.

Tests:
- python -m pytest tests/test_pubmed_article.py
- 22 passed
